### PR TITLE
deploy: Configures the application with ConfigMap

### DIFF
--- a/deploy/sample/apiserver.yaml
+++ b/deploy/sample/apiserver.yaml
@@ -36,6 +36,37 @@ spec:
         - name: config-volume
           mountPath: /etc/opampcommander
           readOnly: true
+        env:
+        - name: AUTH_ADMIN_USERNAME
+          valueFrom:
+            secretKeyRef:
+              name: apiserver-secrets
+              key: adminUsername
+        - name: AUTH_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: apiserver-secrets
+              key: adminPassword
+        - name: AUTH_JWT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: apiserver-secrets
+              key: jwtSecret
+        - name: AUTH_OAUTH2_CLIENT_ID
+          valueFrom:
+            secretKeyRef:
+              name: apiserver-secrets
+              key: oauth2ClientId
+        - name: AUTH_OAUTH2_CLIENT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: apiserver-secrets
+              key: oauth2ClientSecret
+        - name: AUTH_OAUTH2_STATE_JWT_SECRET
+          valueFrom:
+            secretKeyRef:
+              name: apiserver-secrets
+              key: oauth2StateJwtSecret
       volumes:
       - name: config-volume
         configMap:
@@ -59,28 +90,42 @@ data:
     auth:
       enabled: true
       admin:
-        username: "admin"
-        password: "admin_password"
+        username: # use environment variable. Please see secret
+        password: # use environment variable. Please see secret
       jwt:
         issuer: "opampcommander"
         expire: 5m
-        secret: "your_jwt_secret"
+        secret: # use environment variable. Please see secret
         audience:
         - "opampcommander"
       type: "oauth2"
       oauth2:
         provider: github
-        clientId: "your_client_id"
-        clientSecret: "your_client_secret"
-        redirectUri: "http://localhost:8080/auth/callback"
+        clientId: # use environment variable. Please see secret
+        clientSecret: # use environment variable. Please see secret
+        redirectUri: "https://opampcommander-apiserver.minuk.dev/api/v1/auth/callback"
         state: # to prevent CSRF attacks
           mode: jwt
           jwt:
             issuer: "opampcommander"
             expire: 5m
-            secret: "your_jwt_secret"
+            secret: # use environment variable. Please see secret
             audience:
             - "opampcommander"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: apiserver-secrets
+  namespace: opampcommander
+type: Opaque
+data:
+  adminUsername: admin
+  adminPassword: admin
+  jwtSecret: jwtsecret
+  oauth2ClientId: your_client_id
+  oauth2ClientSecret: your_client_secret
+  oauth2StateJwtSecret: state_jwt_secret
 ---
 apiVersion: v1
 kind: Service

--- a/deploy/sample/apiserver.yaml
+++ b/deploy/sample/apiserver.yaml
@@ -21,7 +21,7 @@ spec:
         image: minukdev/opampcommander:0.1.0
         command:
         - /apiserver
-        - --db-host=etcd.opampcommander.svc.cluster.local.:2379
+        - --config=/etc/opampcommander/config.yaml
         resources:
           requests:
             cpu: 100m
@@ -32,6 +32,55 @@ spec:
         ports:
         - containerPort: 8080
           name: http
+        volumeMounts:
+        - name: config-volume
+          mountPath: /etc/opampcommander
+          readOnly: true
+      volumes:
+      - name: config-volume
+        configMap:
+          name: apiserver-config
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: apiserver-config
+  namespace: opampcommander
+data:
+  config.yaml: |
+    address: localhost:8080
+    database:
+      type: "etcd"
+      endpoints:
+      - "etcd.opampcommander.svc.cluster.local.:2379"
+    log:
+      level: "info"
+      format: "json"
+    auth:
+      enabled: true
+      admin:
+        username: "admin"
+        password: "admin_password"
+      jwt:
+        issuer: "opampcommander"
+        expire: 5m
+        secret: "your_jwt_secret"
+        audience:
+        - "opampcommander"
+      type: "oauth2"
+      oauth2:
+        provider: github
+        clientId: "your_client_id"
+        clientSecret: "your_client_secret"
+        redirectUri: "http://localhost:8080/auth/callback"
+        state: # to prevent CSRF attacks
+          mode: jwt
+          jwt:
+            issuer: "opampcommander"
+            expire: 5m
+            secret: "your_jwt_secret"
+            audience:
+            - "opampcommander"
 ---
 apiVersion: v1
 kind: Service
@@ -48,3 +97,14 @@ spec:
   selector:
     app: apiserver
   type: ClusterIP
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: apiserver-ingress
+  namespace: opampcommander
+spec:
+  rules:
+  - host: apiserver.opampcommander.local
+    http:
+      paths:


### PR DESCRIPTION
This pull request updates the deployment configuration for the `apiserver` in the `deploy/sample/apiserver.yaml` file. The changes include switching to a configuration file-based setup, adding a ConfigMap for managing configuration, and introducing an Ingress resource for external access.

### Configuration Management Updates:
* Replaced the `--db-host` command-line argument with a `--config` argument pointing to a configuration file (`/etc/opampcommander/config.yaml`).
* Added a `ConfigMap` named `apiserver-config` to store the configuration, including database settings, logging, authentication, and OAuth2 details.
* Mounted the `ConfigMap` as a read-only volume (`config-volume`) in the container at `/etc/opampcommander`.

### Networking Enhancements:
* Introduced an `Ingress` resource (`apiserver-ingress`) to expose the `apiserver` externally under the hostname `apiserver.opampcommander.local`.