### PR TITLE
fix: add /api/v1/opamp to bypass authentication paths

### DIFF
--- a/internal/security/util.go
+++ b/internal/security/util.go
@@ -34,6 +34,7 @@ func NewAuthJWTMiddleware(
 		bypassPrefix = []string{
 			"/api/v1/auth",
 			"/api/v1/ping",
+			"/api/v1/opamp",
 		}
 		authenticatedPrefix = []string{
 			"/api/v1",


### PR DESCRIPTION
This pull request includes a small change to the `NewAuthJWTMiddleware` function in `internal/security/util.go`. The change adds the `/api/v1/opamp` endpoint to the `bypassPrefix` list, allowing it to bypass authentication checks.