### PR TITLE
fix: update docker image references to use minukdev repository

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -37,16 +37,16 @@ builds:
 
 dockers:
   - image_templates:
-      - "harbor.minuk.dev/opampcommander/apiserver:{{ .Tag }}-amd64"
-      - "harbor.minuk.dev/opampcommander/apiserver:{{ .Major }}-amd64"
+      - "minukdev/opampcommander:{{ .Tag }}-amd64"
+      - "minukdev/opampcommander:{{ .Major }}-amd64"
     use: buildx
     build_flag_templates:
       - "--pull"
       - "--platform=linux/amd64"
     dockerfile: build/docker/apiserver/Dockerfile
   - image_templates:
-      - "harbor.minuk.dev/opampcommander/apiserver:{{ .Tag }}-arm64"
-      - "harbor.minuk.dev/opampcommander/apiserver:{{ .Major }}-arm64"
+      - "minukdev/opampcommander:{{ .Tag }}-arm64"
+      - "minukdev/opampcommander:{{ .Major }}-arm64"
     use: buildx
     build_flag_templates:
       - "--pull"
@@ -54,10 +54,10 @@ dockers:
     goarch: arm64
     dockerfile: build/docker/apiserver/Dockerfile
 docker_manifests:
-  - name_template: "harbor.minuk.dev/opampcommander/apiserver:{{ .Tag }}"
+  - name_template: "minukdev/opampcommander:{{ .Tag }}"
     image_templates:
-      - "harbor.minuk.dev/opampcommander/apiserver:{{ .Tag }}-amd64"
-      - "harbor.minuk.dev/opampcommander/apiserver:{{ .Tag }}-arm64"
+      - "minukdev/opampcommander:{{ .Tag }}-amd64"
+      - "minukdev/opampcommander:{{ .Tag }}-arm64"
 
 release:
   github:


### PR DESCRIPTION
This pull request updates the Docker image templates and manifest configurations in the `.goreleaser.yaml` file to use a new Docker registry. The changes ensure that images are now pushed to the `minukdev` namespace instead of the previous `harbor.minuk.dev` registry.

### Docker image and manifest updates:

* Updated `image_templates` for both `amd64` and `arm64` architectures to use the `minukdev` namespace instead of `harbor.minuk.dev`. This affects the tagging of Docker images for both `{{ .Tag }}` and `{{ .Major }}` versions. (`[.goreleaser.yamlL40-R60](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L40-R60)`)
* Updated `docker_manifests` to reflect the new namespace, changing the `name_template` and associated `image_templates` to point to `minukdev`. (`[.goreleaser.yamlL40-R60](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L40-R60)`)