### PR TITLE
docs & chore: Add opampctl installation to README.md & save artifacts separately

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -63,13 +63,13 @@ release:
   github:
     owner: minuk-dev
     name: opampcommander
-  draft: true
+  draft: false
   replace_existing_draft: true
   skip_upload: false
 
 archives:
   - formats:
-    - tar.gz
+      - tar.gz
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
       {{ .ProjectName }}_
@@ -82,6 +82,28 @@ archives:
     # format_overrides:
     #  - goos: windows
     #    format: zip
+  - formats:
+      - tar.gz
+    ids:
+      - apiserver
+    name_template: >-
+      {{ .ProjectName }}-{{ .Binary }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
+  - formats:
+      - tar.gz
+    ids:
+      - opampctl
+    name_template: >-
+      {{ .ProjectName }}-{{ .Binary }}_
+      {{- title .Os }}_
+      {{- if eq .Arch "amd64" }}x86_64
+      {{- else if eq .Arch "386" }}i386
+      {{- else }}{{ .Arch }}{{ end }}
+      {{- if .Arm }}v{{ .Arm }}{{ end }}
 
 changelog:
   sort: asc

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -68,7 +68,8 @@ release:
   skip_upload: false
 
 archives:
-  - formats:
+  - id: opampcommander
+    formats:
       - tar.gz
     # this name template makes the OS and Arch compatible with the results of `uname`.
     name_template: >-
@@ -82,7 +83,8 @@ archives:
     # format_overrides:
     #  - goos: windows
     #    format: zip
-  - formats:
+  - id: apiserver
+    formats:
       - tar.gz
     ids:
       - apiserver
@@ -93,7 +95,8 @@ archives:
       {{- else if eq .Arch "386" }}i386
       {{- else }}{{ .Arch }}{{ end }}
       {{- if .Arm }}v{{ .Arm }}{{ end }}
-  - formats:
+  - id: opampctl
+    formats:
       - tar.gz
     ids:
       - opampctl

--- a/README.md
+++ b/README.md
@@ -1,5 +1,24 @@
 # OpAMP Commander
 
+## Components
+### opampctl
+- opampctl is a command line tool to control opampcommander.
+
+#### Install
+```sh
+# opampctl
+go install github.com/minuk-dev/opampcommander/cmd/opampctl@latest
+
+# create config file
+opampctl config init
+```
+
+### apiserver
+- apiserver is a server component to support [OpAMP](https://opentelemetry.io/docs/specs/opamp/)
+
+#### How to run
+- TBD
+
 ## Development
 
 ```sh


### PR DESCRIPTION
This pull request introduces several updates to the `.goreleaser.yaml` configuration to enhance the release process and adds documentation for new components in the `README.md`. The key changes include enabling non-draft releases, defining new archives for additional components, and documenting the `opampctl` and `apiserver` components.

### Release configuration updates:
* [`.goreleaser.yaml`](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826L66-R72): Changed the `draft` field under `release` to `false`, enabling non-draft releases.

### Archive definitions:
* [`.goreleaser.yaml`](diffhunk://#diff-7326b55c062b0f46fe9e39aace0a25f4515cf206040fb91a6fd2cae839f5e826R86-R109): Added new archives for `apiserver` and `opampctl` with custom `id`, `formats`, and `name_template` fields to support their packaging.

### Documentation updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R3-R21): Added sections for `opampctl` and `apiserver`, including descriptions and installation instructions for `opampctl`. Placeholder instructions for running `apiserver` were also added.