### PR TITLE
fix(apiserver): fix wrong config filer viper option

### DIFF
--- a/pkg/apiserver/config/config.go
+++ b/pkg/apiserver/config/config.go
@@ -9,7 +9,7 @@ import (
 // ServerSettings is a struct that holds the server settings.
 type ServerSettings struct {
 	Address           string
-	DatabaesEndpoints []string
+	DatabaseEndpoints []string
 	LogLevel          slog.Level
 	LogFormat         LogFormat
 	AuthSettings      *AuthSettings

--- a/pkg/apiserver/database.go
+++ b/pkg/apiserver/database.go
@@ -20,7 +20,7 @@ type Controller interface {
 func NewEtcdClient(settings *config.ServerSettings, lifecycle fx.Lifecycle) (*clientv3.Client, error) {
 	//exhaustruct:ignore
 	etcdConfig := clientv3.Config{
-		Endpoints: settings.DatabaesEndpoints,
+		Endpoints: settings.DatabaseEndpoints,
 	}
 
 	etcdClient, err := clientv3.New(etcdConfig)

--- a/pkg/cmd/apiserver/apiserver.go
+++ b/pkg/cmd/apiserver/apiserver.go
@@ -163,7 +163,7 @@ func (opt *CommandOption) Prepare(_ *cobra.Command, _ []string) error {
 	logLevel := toSlogLevel(opt.Log.Level)
 	opt.app = apiserver.New(appconfig.ServerSettings{
 		Address:           opt.Address,
-		DatabaesEndpoints: opt.Database.Endpoints,
+		DatabaseEndpoints: opt.Database.Endpoints,
 		LogLevel:          logLevel,
 		LogFormat:         appconfig.LogFormat(opt.Log.Format),
 		AuthSettings: &appconfig.AuthSettings{

--- a/pkg/cmd/apiserver/apiserver.go
+++ b/pkg/cmd/apiserver/apiserver.go
@@ -134,7 +134,7 @@ func (opt *CommandOption) Init(cmd *cobra.Command, _ []string) error {
 	}
 
 	if opt.configFilename != "" {
-		viper.SetConfigFile(opt.configFilename)
+		opt.viper.SetConfigFile(opt.configFilename)
 	} else {
 		home, err := os.UserHomeDir()
 		if err != nil {


### PR DESCRIPTION
This pull request addresses a typo in the `ServerSettings` struct and its usage across the codebase, along with a minor improvement to the `CommandOption` initialization logic. The most important changes include fixing the misspelled `DatabaesEndpoints` field and replacing it with the correct `DatabaseEndpoints` name, and updating the `viper` configuration setup to use the instance variable `opt.viper`.

### Typo Fixes in `ServerSettings` and Related Code:

* [`pkg/apiserver/config/config.go`](diffhunk://#diff-b2f61ee41ff97f90468a9bce911cbe5efb1c5a9c774acb89e301fb81408f18f3L12-R12): Corrected the field name in the `ServerSettings` struct from `DatabaesEndpoints` to `DatabaseEndpoints`.
* [`pkg/apiserver/database.go`](diffhunk://#diff-6d9ceffb1244b18ee609b4a88faffa13d38734dc8779d23d5ec259dd6fae7c6fL23-R23): Updated the `NewEtcdClient` function to reference the corrected `DatabaseEndpoints` field in the `ServerSettings` struct.
* [`pkg/cmd/apiserver/apiserver.go`](diffhunk://#diff-42f75be16f3708fbfc8da6eafa390eeff8fe722dc5b067e47b4b2da15e9320a9L166-R166): Updated the `Prepare` method in `CommandOption` to use the corrected `DatabaseEndpoints` field.

### Improvement to `CommandOption` Initialization:

* [`pkg/cmd/apiserver/apiserver.go`](diffhunk://#diff-42f75be16f3708fbfc8da6eafa390eeff8fe722dc5b067e47b4b2da15e9320a9L137-R137): Modified the `Init` method in `CommandOption` to use the `opt.viper` instance for setting the configuration file, ensuring better encapsulation and consistency.