### PR TITLE
fix: enhance logging setup and environment variable handling in apiserver

### DIFF
--- a/pkg/apiserver/app.go
+++ b/pkg/apiserver/app.go
@@ -3,10 +3,12 @@ package apiserver
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"time"
 
 	"go.uber.org/fx"
+	"go.uber.org/fx/fxevent"
 
 	"github.com/minuk-dev/opampcommander/internal/security"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/config"
@@ -50,6 +52,11 @@ func New(settings config.ServerSettings) *Server {
 		// init
 		fx.Invoke(func(*http.Server) {}),
 		fx.Invoke(func(*Executor) {}),
+		fx.WithLogger(func(logger *slog.Logger) fxevent.Logger {
+			return &fxevent.SlogLogger{
+				Logger: logger,
+			}
+		}),
 	)
 
 	server := &Server{

--- a/pkg/cmd/apiserver/apiserver.go
+++ b/pkg/cmd/apiserver/apiserver.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -146,9 +147,12 @@ func (opt *CommandOption) Init(cmd *cobra.Command, _ []string) error {
 		opt.viper.SetConfigType("yaml")
 	}
 
-	opt.viper.AutomaticEnv() // read in environment variables that match
-
 	_ = opt.viper.ReadInConfig()
+
+	// Use environment variables
+	// e.g. LOG_LEVEL=debug will set log.level to debug
+	opt.viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_")) // replace '.' with '_' for environment variables
+	opt.viper.AutomaticEnv()                                   // read in environment variables that match
 
 	err = opt.viper.Unmarshal(opt)
 	if err != nil {


### PR DESCRIPTION
This pull request introduces enhancements to logging and configuration handling in the `apiserver` package. The changes include adding a structured logger for the `fx` application lifecycle and improving environment variable handling for configuration.

### Logging Enhancements:
* [`pkg/apiserver/app.go`](diffhunk://#diff-c932f0ce166c3a54f49e16829eac094419dff5285848bf799ca99172418274bbR55-R59): Introduced `fx.WithLogger` to integrate `slog` with the `fx` application lifecycle using `fxevent.SlogLogger`. This provides structured logging for `fx` events.

### Configuration Improvements:
* [`pkg/cmd/apiserver/apiserver.go`](diffhunk://#diff-42f75be16f3708fbfc8da6eafa390eeff8fe722dc5b067e47b4b2da15e9320a9L149-R156): Updated `viper` configuration to support environment variables with dot-to-underscore replacements (e.g., `LOG_LEVEL=debug` maps to `log.level=debug`). This ensures better compatibility with environment-based configurations.