### PR TITLE
chore: add GitHub Actions workflow for creating and pushing version tags

### DIFF
--- a/.github/workflows/create_tag.yaml
+++ b/.github/workflows/create_tag.yaml
@@ -1,0 +1,66 @@
+name: Create Tag
+
+on:
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: 'Version type to increment (major, minor, patch)'
+        required: true
+        default: 'patch'
+        type: choice
+        options:
+          - major
+          - minor
+          - patch
+
+permissions:
+  contents: write
+
+jobs:
+  create-tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Get latest tag
+        id: get_tag
+        run: |
+          latest_tag=$(git describe --tags $(git rev-list --tags --max-count=1))
+          echo "Latest tag: $latest_tag"
+          echo "tag=$latest_tag" >> $GITHUB_ENV
+
+      - name: Calculate new tag
+        id: calculate_tag
+        run: |
+          IFS='.' read -r major minor patch <<< "${{ env.tag }}"
+          case "${{ github.event.inputs.version_type }}" in
+            major)
+              major=$((major + 1))
+              minor=0
+              patch=0
+              ;;
+            minor)
+              minor=$((minor + 1))
+              patch=0
+              ;;
+            patch)
+              patch=$((patch + 1))
+              ;;
+          esac
+          new_tag="$major.$minor.$patch"
+          echo "New tag: $new_tag"
+          echo "new_tag=$new_tag" >> $GITHUB_ENV
+
+      - name: Create and push new tag
+        run: |
+          git tag ${{ env.new_tag }}
+          git push origin ${{ env.new_tag }}


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate the creation and pushing of tags based on semantic versioning. The workflow allows users to increment the version type (major, minor, or patch) via manual dispatch.

### GitHub Actions Workflow Addition:

* [`.github/workflows/create_tag.yaml`](diffhunk://#diff-7726c917a6c17214b2c505b8881522c81dcc23b9793eb5c7d3e6285224d65413R1-R66): Added a new workflow named "Create Tag" that supports manual dispatch (`workflow_dispatch`) to increment semantic versioning tags (`major`, `minor`, or `patch`). It includes steps to configure Git, retrieve the latest tag, calculate the new tag based on user input, and push the new tag to the repository.