### PR TITLE
fix(apiserver): fix wrong format

### DIFF
--- a/.github/workflows/golangci-lint.yaml
+++ b/.github/workflows/golangci-lint.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-      - master
   pull_request:
 
 permissions:

--- a/internal/adapter/in/http/v1/agent/mapper.go
+++ b/internal/adapter/in/http/v1/agent/mapper.go
@@ -1,1 +1,0 @@
-package agent

--- a/internal/application/service/agent/mapper.go
+++ b/internal/application/service/agent/mapper.go
@@ -51,21 +51,21 @@ func (mapper *Mapper) MapAgentToAPI(agent *model.Agent) *v1agent.Agent {
 }
 
 const (
-	// ContentTypeJSON is the content type for JSON.
-	ContentTypeJSON = "application/json"
-	// ContentTypeYAML is the content type for YAML.
-	ContentTypeYAML = "application/yaml"
-	// EmptyContentType is the content type for empty.
+	// TextJSON is the content type for JSON.
+	TextJSON = "text/json"
+	// TextYAML is the content type for YAML.
+	TextYAML = "text/yaml"
+	// Empty is the content type for empty.
 	// Empty content type is treated as YAML by default.
 	// Due to spec miss, old otel-collector sends empty content type even though it should be YAML.
-	EmptyContentType = ""
+	Empty = ""
 )
 
 func (mapper *Mapper) mapConfigFileToAPI(configFile model.AgentConfigFile) v1agent.ConfigFile {
 	switch configFile.ContentType {
-	case ContentTypeJSON,
-		ContentTypeYAML,
-		EmptyContentType:
+	case TextJSON,
+		TextYAML,
+		Empty:
 		return v1agent.ConfigFile{
 			Body:        string(configFile.Body),
 			ContentType: configFile.ContentType,


### PR DESCRIPTION
This pull request introduces several changes focused on content type naming conventions and minor cleanups in the codebase. The most significant update is the renaming of content type constants to improve clarity and consistency. Additionally, there are minor maintenance changes to workflow configuration and package declarations.

**Content type constant renaming and usage:**

* Renamed content type constants in `internal/application/service/agent/mapper.go` from `ContentTypeJSON`, `ContentTypeYAML`, and `EmptyContentType` to `TextJSON`, `TextYAML`, and `Empty`, respectively, and updated their values and usage throughout the file. This improves clarity and aligns naming with their actual string values.

**Workflow configuration:**

* Removed the `master` branch from the list of branches triggering the `golangci-lint` GitHub Actions workflow in `.github/workflows/golangci-lint.yaml`, so now only `main` triggers the workflow.

**Codebase cleanup:**

* Removed an unnecessary package declaration line from `internal/adapter/in/http/v1/agent/mapper.go`.