### PR TITLE
test(etcd): add config consistency test for agent adapter and update testcontainers dependency

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -92,6 +92,7 @@ linters:
             - go.etcd.io/etcd/client/v3
             - github.com/testcontainers/testcontainers-go
             - github.com/testcontainers/testcontainers-go/modules/etcd
+            - github.com/testcontainers/testcontainers-go/wait
 formatters:
   enable:
     - gci


### PR DESCRIPTION
This pull request makes a minor update to the linter configuration by adding a new import path to the exclusion list in `.golangci.yaml`. This helps ensure that code from the `github.com/testcontainers/testcontainers-go/wait` package is properly handled during linting. 

- Added `github.com/testcontainers/testcontainers-go/wait` to the list of excluded import paths in the `linters` section of `.golangci.yaml`.