### PR TITLE
feat(opampctl): add context management commands for switching and lis…

### DIFF
--- a/pkg/cmd/opampctl/context/context.go
+++ b/pkg/cmd/opampctl/context/context.go
@@ -1,0 +1,33 @@
+// Package context provides the context command for opampctl.
+package context
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/context/ls"
+	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/context/use"
+	"github.com/minuk-dev/opampcommander/pkg/opampctl/config"
+)
+
+// CommandOptions contains the options for the context command.
+type CommandOptions struct {
+	*config.GlobalConfig
+}
+
+// NewCommand creates a new context command.
+func NewCommand(options CommandOptions) *cobra.Command {
+	//exhaustruct:ignore
+	cmd := &cobra.Command{
+		Use:   "context",
+		Short: "Manage contexts",
+	}
+
+	cmd.AddCommand(use.NewCommand(use.CommandOptions{
+		GlobalConfig: options.GlobalConfig,
+	}))
+	cmd.AddCommand(ls.NewCommand(ls.CommandOptions{
+		GlobalConfig: options.GlobalConfig,
+	}))
+
+	return cmd
+}

--- a/pkg/cmd/opampctl/context/ls/ls.go
+++ b/pkg/cmd/opampctl/context/ls/ls.go
@@ -1,0 +1,61 @@
+// Package ls provides the ls command for opampctl context.
+package ls
+
+import (
+	"github.com/spf13/cobra"
+
+	"github.com/minuk-dev/opampcommander/pkg/opampctl/config"
+)
+
+// CommandOptions contains the options for the ls command.
+type CommandOptions struct {
+	*config.GlobalConfig
+}
+
+// NewCommand creates a new ls command.
+func NewCommand(options CommandOptions) *cobra.Command {
+	//exhaustruct:ignore
+	return &cobra.Command{
+		Use:   "ls",
+		Short: "List all contexts",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := options.Prepare(cmd, args)
+			if err != nil {
+				return err
+			}
+
+			err = options.Run(cmd, args)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+}
+
+// Prepare prepares the command to run.
+func (opt *CommandOptions) Prepare(_ *cobra.Command, _ []string) error {
+	// No preparation needed for ls command
+	return nil
+}
+
+// Run runs the command.
+func (opt *CommandOptions) Run(cmd *cobra.Command, _ []string) error {
+	if len(opt.Contexts) == 0 {
+		cmd.Println("No contexts found")
+
+		return nil
+	}
+
+	// Print contexts with current context marked
+	for _, ctx := range opt.Contexts {
+		if ctx.Name == opt.CurrentContext {
+			cmd.Printf("* %s (current)\n", ctx.Name)
+		} else {
+			cmd.Printf("  %s\n", ctx.Name)
+		}
+	}
+
+	return nil
+}

--- a/pkg/cmd/opampctl/context/use/use.go
+++ b/pkg/cmd/opampctl/context/use/use.go
@@ -1,0 +1,125 @@
+// Package use provides the use command for opampctl context.
+package use
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	"github.com/minuk-dev/opampcommander/pkg/opampctl/config"
+)
+
+const (
+	// configFilePermissions defines the file permissions for the config file.
+	configFilePermissions = 0o600
+)
+
+var (
+	// ErrContextNotFound is returned when the context is not found.
+	ErrContextNotFound = errors.New("context does not exist")
+)
+
+// CommandOptions contains the options for the use command.
+type CommandOptions struct {
+	*config.GlobalConfig
+}
+
+// NewCommand creates a new use command.
+func NewCommand(options CommandOptions) *cobra.Command {
+	//exhaustruct:ignore
+	return &cobra.Command{
+		Use:   "use [context-name]",
+		Short: "Switch to a different context",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := options.Prepare(cmd, args)
+			if err != nil {
+				return err
+			}
+
+			err = options.Run(cmd, args)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+}
+
+// Prepare prepares the command to run.
+func (opt *CommandOptions) Prepare(_ *cobra.Command, _ []string) error {
+	// No preparation needed for use command
+	return nil
+}
+
+// Run runs the command.
+func (opt *CommandOptions) Run(cmd *cobra.Command, args []string) error {
+	contextName := args[0]
+
+	// Check if context exists
+	contextExists := false
+
+	for _, ctx := range opt.Contexts {
+		if ctx.Name == contextName {
+			contextExists = true
+
+			break
+		}
+	}
+
+	if !contextExists {
+		return fmt.Errorf("%w: %q", ErrContextNotFound, contextName)
+	}
+
+	// Update current context
+	opt.CurrentContext = contextName
+
+	// Save to config file
+	configPath := opt.ConfigFilename
+	if configPath == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("failed to get user home directory: %w", err)
+		}
+
+		configPath = filepath.Join(home, ".config", "opampcommander", "opampctl", "config.yaml")
+	}
+
+	// Read existing config file
+	data, err := os.ReadFile(filepath.Clean(configPath))
+	if err != nil {
+		return fmt.Errorf("failed to read config file: %w", err)
+	}
+
+	// Unmarshal to map to preserve order and comments
+	var configMap map[string]any
+
+	err = yaml.Unmarshal(data, &configMap)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal config: %w", err)
+	}
+
+	// Update currentContext
+	configMap["currentContext"] = contextName
+
+	// Marshal back to YAML
+	updatedData, err := yaml.Marshal(configMap)
+	if err != nil {
+		return fmt.Errorf("failed to marshal config: %w", err)
+	}
+
+	// Write back to file
+	err = os.WriteFile(filepath.Clean(configPath), updatedData, configFilePermissions)
+	if err != nil {
+		return fmt.Errorf("failed to write config file: %w", err)
+	}
+
+	cmd.Printf("Switched to context %q\n", contextName)
+
+	return nil
+}

--- a/pkg/cmd/opampctl/opampctl.go
+++ b/pkg/cmd/opampctl/opampctl.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/viper"
 
 	configCmd "github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/config"
+	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/context"
 	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/create"
 	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/deletecmd"
 	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/get"
@@ -45,6 +46,7 @@ func NewCommand(options CommandOption) *cobra.Command {
 	cmd.AddCommand(deletecmd.NewCommand(deletecmd.CommandOptions{GlobalConfig: options.globalConfig}))
 	cmd.AddCommand(create.NewCommand(create.CommandOptions{GlobalConfig: options.globalConfig}))
 	cmd.AddCommand(configCmd.NewCommand(configCmd.CommandOptions{GlobalConfig: options.globalConfig}))
+	cmd.AddCommand(context.NewCommand(context.CommandOptions{GlobalConfig: options.globalConfig}))
 	cmd.AddCommand(whoami.NewCommand(whoami.CommandOptions{GlobalConfig: options.globalConfig}))
 	cmd.AddCommand(version.NewCommand(version.CommandOptions{GlobalConfig: options.globalConfig}))
 


### PR DESCRIPTION
…ting contexts

close #100 
This pull request introduces a new `context` command group to the `opampctl` CLI tool, allowing users to manage CLI contexts. The main additions are the implementation of the `context` command with two subcommands: `ls` for listing available contexts and `use` for switching between them. Integration of these commands into the main CLI is also included.

**New context command group:**

* Added `pkg/cmd/opampctl/context/context.go`, implementing the `context` command group with support for managing contexts and delegating to subcommands.

**Subcommands for context management:**

* Added `pkg/cmd/opampctl/context/ls/ls.go`, providing the `ls` subcommand to list all contexts and highlight the current context.
* Added `pkg/cmd/opampctl/context/use/use.go`, implementing the `use` subcommand to switch the current context, update the config file, and handle errors if the context does not exist.

**Integration with main CLI:**

* Registered the new `context` command group in the main CLI by updating imports in `pkg/cmd/opampctl/opampctl.go`.
* Added the `context` command to the main CLI command tree in `pkg/cmd/opampctl/opampctl.go`.