### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,6 @@
 name: test
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/minuk-dev/opampcommander/security/code-scanning/3](https://github.com/minuk-dev/opampcommander/security/code-scanning/3)

To fix the problem, you should add a `permissions` key to the workflow file to limit the permissions granted to the GITHUB_TOKEN. For this workflow, setting `permissions: contents: read` at the workflow or job level is sufficient, as none of the jobs perform actions that require write access. The best location is near the top level, so that all jobs inherit these least-privilege permissions, unless otherwise needed. In `.github/workflows/test.yaml`, add:

```yaml
permissions:
  contents: read
```

directly after the workflow name (line 1), before the `on:` block (line 2).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
