### PR TITLE
feat(cd): auto-deploy alpha to minuk-cluster on main merge

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -52,6 +52,9 @@ jobs:
           name: goreleaser-assets
           path: |
             dist/*
+      - name: Extract version
+        run: echo "VERSION=$(jq -r '.version' dist/metadata.json)" >> $GITHUB_ENV
+
       - name: Set up Docker Buildx
         if: startsWith(github.ref, 'refs/heads/')
         uses: docker/setup-buildx-action@v3
@@ -64,11 +67,36 @@ jobs:
             echo "Pushing $image"
             docker push "$image"
           done < image_list.txt
-          
-          VERSION=$(jq -r '.version' dist/metadata.json)
+
           AMD64_IMAGE="ghcr.io/minuk-dev/opampcommander:${VERSION}-amd64"
           ARM64_IMAGE="ghcr.io/minuk-dev/opampcommander:${VERSION}-arm64"
           MANIFEST_TAG="ghcr.io/minuk-dev/opampcommander:${VERSION}"
-          
+
           echo "Creating multi-arch manifest: $MANIFEST_TAG"
           docker buildx imagetools create -t "$MANIFEST_TAG" "$AMD64_IMAGE" "$ARM64_IMAGE"
+
+      - name: Setup SSH agent for minuk-cluster deploy
+        if: startsWith(github.ref, 'refs/heads/')
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.MINUK_CLUSTER_DEPLOY_KEY }}
+
+      - name: Deploy alpha to minuk-cluster
+        if: startsWith(github.ref, 'refs/heads/')
+        run: |
+          git clone git@github.com:minuk-cluster/minuk-cluster.git /tmp/minuk-cluster
+          cd /tmp/minuk-cluster
+
+          yq '(.images[] | select(.name == "ghcr.io/minuk-dev/opampcommander")).newTag = strenv(VERSION)' \
+            -i argocd/apps/opampcommander/overlays/alpha/kustomization.yaml
+
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git add argocd/apps/opampcommander/overlays/alpha/kustomization.yaml
+          git commit -m "chore(deploy): update opampcommander alpha to ${VERSION}"
+
+          # retry on push conflict from concurrent CI runs
+          for i in 1 2 3; do
+            git push && break
+            git pull --rebase && sleep $((i * 3))
+          done


### PR DESCRIPTION
## Summary

- After a Docker image is built and pushed to ghcr.io on every push to `main`, automatically update the image tag in the minuk-cluster repo's alpha overlay and push the commit
- ArgoCD detects the change and syncs the `opampcommander-alpha` namespace automatically

## Changes

- Add `Extract version` step — separates VERSION extraction from the image push step for clarity
- Add `Setup SSH agent` step — uses `webfactory/ssh-agent@v0.9.0` to load the deploy key into memory without writing it to disk
- Add `Deploy alpha to minuk-cluster` step — updates `newTag` in `overlays/alpha/kustomization.yaml` via `yq`, commits, and pushes with up to 3 retries on push conflict

## Required setup (one-time)

1. Generate an SSH key pair:
   ```bash
   ssh-keygen -t ed25519 -C "opampcommander-cd" -f ~/.ssh/opampcommander_cd -N ""
   ```
2. **minuk-cluster/minuk-cluster** → Settings → Deploy keys → Add deploy key
   - Paste the public key (`~/.ssh/opampcommander_cd.pub`), check **Allow write access**
3. **minuk-dev/opampcommander** → Settings → Secrets → Actions → New repository secret
   - Name: `MINUK_CLUSTER_DEPLOY_KEY`, Value: full content of `~/.ssh/opampcommander_cd`

## Test plan

- [ ] SSH deploy key registered on both repos
- [ ] Push a commit to `main` and confirm the "Deploy alpha to minuk-cluster" step passes in Actions
- [ ] Confirm a `chore(deploy): update opampcommander alpha to ...` commit appears in minuk-cluster
- [ ] Confirm the `opampcommander-alpha` ArgoCD app reaches Synced status

🤖 Generated with [Claude Code](https://claude.com/claude-code)