### PR TITLE
feat: add tab completion for opampctl context use command

### DIFF
--- a/pkg/cmd/opampctl/context/use/use.go
+++ b/pkg/cmd/opampctl/context/use/use.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -32,9 +33,10 @@ type CommandOptions struct {
 func NewCommand(options CommandOptions) *cobra.Command {
 	//exhaustruct:ignore
 	return &cobra.Command{
-		Use:   "use [context-name]",
-		Short: "Switch to a different context",
-		Args:  cobra.ExactArgs(1),
+		Use:               "use [context-name]",
+		Short:             "Switch to a different context",
+		Args:              cobra.ExactArgs(1),
+		ValidArgsFunction: options.ValidArgsFunction,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			err := options.Prepare(cmd, args)
 			if err != nil {
@@ -122,4 +124,19 @@ func (opt *CommandOptions) Run(cmd *cobra.Command, args []string) error {
 	cmd.Printf("Switched to context %q\n", contextName)
 
 	return nil
+}
+
+// ValidArgsFunction provides dynamic completion for context names.
+func (opt *CommandOptions) ValidArgsFunction(
+	_ *cobra.Command, _ []string, toComplete string,
+) ([]string, cobra.ShellCompDirective) {
+	names := make([]string, 0, len(opt.Contexts))
+
+	for _, ctx := range opt.Contexts {
+		if strings.HasPrefix(ctx.Name, toComplete) {
+			names = append(names, ctx.Name)
+		}
+	}
+
+	return names, cobra.ShellCompDirectiveNoFileComp
 }


### PR DESCRIPTION
## Summary

- Add `ValidArgsFunction` to `opampctl context use` so pressing Tab completes context names
- Completions are resolved from `GlobalConfig.Contexts` (local config file) — no API call needed, works offline

## How to use

Register shell completions once:

```sh
# zsh
opampctl completion zsh > ~/.zsh/completions/_opampctl

# bash
opampctl completion bash > /etc/bash_completion.d/opampctl
```

Then `opampctl context use <Tab>` will suggest context names defined in your config.

## Test plan

- [ ] Register shell completions for your shell
- [ ] Type `opampctl context use <Tab>` and verify existing context names appear
- [ ] Verify partial prefix matching works (e.g. `opampctl context use dev<Tab>`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)