### PR TITLE
fix: sanitize HTML error responses and show unavailable for unreachable server version

### DIFF
--- a/pkg/client/error.go
+++ b/pkg/client/error.go
@@ -3,6 +3,7 @@ package client
 import (
 	"errors"
 	"fmt"
+	"strings"
 )
 
 var (
@@ -21,5 +22,16 @@ type ResponseError struct {
 
 // Error implements the error interface for ResponseError.
 func (e *ResponseError) Error() string {
-	return fmt.Sprintf("response error: status code %d, message: %s", e.StatusCode, e.ErrorMessage)
+	msg := e.ErrorMessage
+	if isHTMLBody(msg) {
+		msg = "unexpected HTML response (server may not be an OpAMP Commander instance)"
+	}
+
+	return fmt.Sprintf("response error: status code %d, message: %s", e.StatusCode, msg)
+}
+
+func isHTMLBody(s string) bool {
+	trimmed := strings.ToLower(strings.TrimSpace(s))
+
+	return strings.HasPrefix(trimmed, "<html") || strings.HasPrefix(trimmed, "<!doctype html")
 }

--- a/pkg/cmd/opampctl/version/version.go
+++ b/pkg/cmd/opampctl/version/version.go
@@ -67,29 +67,55 @@ func (opt *CommandOptions) Prepare(*cobra.Command, []string) error {
 	return nil
 }
 
+const unavailable = "unavailable"
+
 // Run executes the command.
 func (opt *CommandOptions) Run(cmd *cobra.Command, _ []string) error {
-	var (
-		serverErr   error
-		versionInfo Version
-	)
-
-	versionInfo.ClientVersion = func() *v1version.Info {
-		v := version.Get()
-
-		return &v
-	}()
-	if !opt.clientOnly {
-		versionInfo.ServerVersion, serverErr = opt.client.GetServerVersion(cmd.Context())
-		if serverErr != nil {
-			cmd.PrintErrf("Failed to get server version: %v\n", serverErr)
-			//exhaustruct:ignore
-			versionInfo.ServerVersion = &v1version.Info{} // to prevent nil pointer dereference
-		}
+	versionInfo, serverErr := opt.fetchVersionInfo(cmd)
+	if serverErr != nil {
+		cmd.PrintErrf("Failed to get server version: %v\n", serverErr)
 	}
 
-	var formatErr error
+	err := opt.printVersion(cmd, versionInfo, serverErr)
+	if err != nil {
+		return fmt.Errorf("failed to format version information: %w", err)
+	}
 
+	return nil
+}
+
+func (opt *CommandOptions) fetchVersionInfo(cmd *cobra.Command) (Version, error) {
+	v := version.Get()
+
+	//exhaustruct:ignore
+	versionInfo := Version{ClientVersion: &v}
+
+	if opt.clientOnly {
+		return versionInfo, nil
+	}
+
+	serverVersion, err := opt.client.GetServerVersion(cmd.Context())
+	if err != nil {
+		//exhaustruct:ignore
+		versionInfo.ServerVersion = &v1version.Info{}
+
+		return versionInfo, fmt.Errorf("failed to get server version: %w", err)
+	}
+
+	versionInfo.ServerVersion = serverVersion
+
+	return versionInfo, nil
+}
+
+func serverVersionOrUnavailable(v string, serverErr error) string {
+	if v == "" && serverErr != nil {
+		return unavailable
+	}
+
+	return v
+}
+
+func (opt *CommandOptions) printVersion(cmd *cobra.Command, versionInfo Version, serverErr error) error {
 	switch opt.formatType {
 	case "short":
 		type shortItem struct {
@@ -97,10 +123,15 @@ func (opt *CommandOptions) Run(cmd *cobra.Command, _ []string) error {
 			ServerGitVersion string `short:"serverGitVersion"`
 		}
 
-		formatErr = formatter.FormatShort(cmd.OutOrStdout(), shortItem{
+		err := formatter.FormatShort(cmd.OutOrStdout(), shortItem{
 			ClientGitVersion: versionInfo.ClientVersion.GitVersion,
-			ServerGitVersion: versionInfo.ServerVersion.GitVersion,
+			ServerGitVersion: serverVersionOrUnavailable(versionInfo.ServerVersion.GitVersion, serverErr),
 		})
+		if err != nil {
+			return fmt.Errorf("failed to format short: %w", err)
+		}
+
+		return nil
 	case "text":
 		type textItem struct {
 			ClientGitVersion string `text:"clientGitVersion"`
@@ -111,21 +142,25 @@ func (opt *CommandOptions) Run(cmd *cobra.Command, _ []string) error {
 			ServerCommitHash string `text:"serverCommitHash"`
 		}
 
-		formatErr = formatter.FormatText(cmd.OutOrStdout(), textItem{
+		err := formatter.FormatText(cmd.OutOrStdout(), textItem{
 			ClientGitVersion: versionInfo.ClientVersion.GitVersion,
 			ClientBuildDate:  versionInfo.ClientVersion.BuildDate,
 			ClientCommitHash: versionInfo.ClientVersion.GitCommit,
-			ServerGitVersion: versionInfo.ServerVersion.GitVersion,
+			ServerGitVersion: serverVersionOrUnavailable(versionInfo.ServerVersion.GitVersion, serverErr),
 			ServerBuildDate:  versionInfo.ServerVersion.BuildDate,
 			ServerCommitHash: versionInfo.ServerVersion.GitCommit,
 		})
+		if err != nil {
+			return fmt.Errorf("failed to format text: %w", err)
+		}
+
+		return nil
 	default:
-		formatErr = formatter.Format(cmd.OutOrStdout(), versionInfo, formatter.FormatType(opt.formatType))
-	}
+		err := formatter.Format(cmd.OutOrStdout(), versionInfo, formatter.FormatType(opt.formatType))
+		if err != nil {
+			return fmt.Errorf("failed to format: %w", err)
+		}
 
-	if formatErr != nil {
-		return fmt.Errorf("failed to format version information: %w", formatErr)
+		return nil
 	}
-
-	return nil
 }


### PR DESCRIPTION
## Summary

- Detect HTML response bodies in `ResponseError.Error()` and replace with a human-readable message instead of dumping raw HTML markup (e.g. nginx 404 pages)
- Show `"unavailable"` for server git version when the server is unreachable, rather than an empty string
- Refactor `opampctl version Run()` into `fetchVersionInfo` / `printVersion` helpers to reduce function length and improve readability

## Before / After

**Before** (server returns nginx 404):
```
Failed to get server version: failed to get version: response error: status code 404, message: <html>
<head><title>404 Not Found</title></head>
<body>
<center><h1>404 Not Found</h1></center>
<hr><center>nginx</center>
</body>
</html>
```

**After**:
```
Failed to get server version: failed to get version: response error: status code 404, message: unexpected HTML response (server may not be an OpAMP Commander instance)
```

And the version table now shows `unavailable` instead of blank:
```
clientGitVersion  serverGitVersion
--------          --------
v0.1.0            unavailable
```

## Test plan

- [ ] Run `opampctl version` against an endpoint that returns an nginx 404 — error message should show the sanitized string, not raw HTML
- [ ] Run `opampctl version` with no server configured — `serverGitVersion` column shows `unavailable`
- [ ] Run `opampctl version --client-only` — only client version is printed, no server call made
- [ ] Run `opampctl version -o text` — same sanitization and `unavailable` fallback apply
- [ ] `make lint` passes with 0 issues
- [ ] `make unittest` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)