### PR TITLE
fix: resolve duplicate error prefix and add ReadBuildInfo fallback for version

### DIFF
--- a/pkg/cmd/opampctl/version/version.go
+++ b/pkg/cmd/opampctl/version/version.go
@@ -88,7 +88,7 @@ func (opt *CommandOptions) fetchVersionInfo(cmd *cobra.Command) (Version, error)
 	v := version.Get()
 
 	//exhaustruct:ignore
-	versionInfo := Version{ClientVersion: &v}
+	versionInfo := Version{ClientVersion: &v, ServerVersion: &v1version.Info{}}
 
 	if opt.clientOnly {
 		return versionInfo, nil
@@ -99,7 +99,7 @@ func (opt *CommandOptions) fetchVersionInfo(cmd *cobra.Command) (Version, error)
 		//exhaustruct:ignore
 		versionInfo.ServerVersion = &v1version.Info{}
 
-		return versionInfo, fmt.Errorf("failed to get server version: %w", err)
+		return versionInfo, err //nolint:wrapcheck
 	}
 
 	versionInfo.ServerVersion = serverVersion

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -3,21 +3,82 @@ package version
 import (
 	"fmt"
 	"runtime"
+	"runtime/debug"
+	"strings"
 
 	v1version "github.com/minuk-dev/opampcommander/api/v1/version"
 )
 
 // Get returns the version information.
+// When the binary is built without goreleaser ldflags (e.g. go install, go build),
+// it falls back to VCS info embedded by the Go toolchain via debug.ReadBuildInfo.
 func Get() v1version.Info {
+	gitVer := gitVersion
+	commit := gitCommit
+	treeState := gitTreeState
+
+	if strings.Contains(gitVer, "$Format:") {
+		if info, ok := debug.ReadBuildInfo(); ok {
+			gitVer, commit, treeState = versionFromBuildInfo(info)
+		}
+	}
+
 	return v1version.Info{
 		Major:        gitMajor,
 		Minor:        gitMinor,
-		GitVersion:   gitVersion,
-		GitCommit:    gitCommit,
-		GitTreeState: gitTreeState,
+		GitVersion:   gitVer,
+		GitCommit:    commit,
+		GitTreeState: treeState,
 		BuildDate:    buildDate,
 		GoVersion:    runtime.Version(),
 		Compiler:     runtime.Compiler,
 		Platform:     fmt.Sprintf("%s/%s", runtime.GOOS, runtime.GOARCH),
+	}
+}
+
+const shortHashLen = 12
+
+func versionFromBuildInfo(info *debug.BuildInfo) (string, string, string) {
+	var revision, modified string
+
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			revision = s.Value
+		case "vcs.modified":
+			modified = s.Value
+		}
+	}
+
+	gitVer := buildGitVersion(info.Main.Version, revision)
+	treeState := buildTreeState(revision, modified)
+
+	return gitVer, revision, treeState
+}
+
+func buildGitVersion(mainVersion, revision string) string {
+	switch {
+	case mainVersion != "" && mainVersion != "(devel)":
+		return mainVersion
+	case revision != "":
+		short := revision
+		if len(short) > shortHashLen {
+			short = short[:shortHashLen]
+		}
+
+		return "v0.0.0-dev+" + short
+	default:
+		return "v0.0.0-dev"
+	}
+}
+
+func buildTreeState(revision, modified string) string {
+	switch {
+	case modified == "true":
+		return "dirty"
+	case revision != "":
+		return "clean"
+	default:
+		return ""
 	}
 }


### PR DESCRIPTION
## Summary

- Fix duplicate `"failed to get server version:"` prefix in `opampctl version` error output — the wrapper in `fetchVersionInfo` and the `PrintErrf` in `Run` were both prepending the same string
- Fix nil pointer dereference panic when `--client-only` flag is used (`ServerVersion` was never initialized in that path)
- Add `debug.ReadBuildInfo()` fallback in `version.Get()` so that binaries built without goreleaser ldflags (e.g. `go build`, `go install`) show a meaningful version instead of the raw `$Format:%H$` template string

## Before / After

**Before** (built with `go build` instead of goreleaser):
```
Failed to get server version: failed to get server version: failed to get version: ...
clientGitVersion                serverGitVersion
--------                        --------
v0.0.0-master+$Format:%H$       unavailable
```

**After**:
```
Failed to get server version: failed to get version: ...
clientGitVersion  serverGitVersion
--------          --------
v0.1.30+dirty     unavailable
```

The Go toolchain (1.18+) embeds VCS info including tag and dirty state into the binary via `debug.ReadBuildInfo()`. `info.Main.Version` returns e.g. `"v0.1.30+dirty"` which we now use as the fallback when ldflags were not set.

## Test plan

- [ ] `go build ./cmd/opampctl && ./opampctl version --client-only` shows tag-based version (e.g. `v0.1.30+dirty`) instead of `$Format:%H$`
- [ ] `opampctl version` with unreachable server shows error without duplicate prefix
- [ ] `opampctl version --client-only` no longer panics
- [ ] Goreleaser builds still use ldflags version as before (the `$Format:` check skips the fallback)
- [ ] `make lint` passes with 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)