### PR TITLE
fix: return clear error when endpoint is not configured in current context

### DIFF
--- a/pkg/clientutil/clientutil.go
+++ b/pkg/clientutil/clientutil.go
@@ -28,12 +28,18 @@ const (
 var (
 	// ErrUnauthorized is returned when the client is unauthorized.
 	ErrUnauthorized = errors.New("unauthorized")
+	// ErrNoEndpoint is returned when no endpoint is configured for the current context.
+	ErrNoEndpoint = errors.New("no endpoint configured for current context: run 'opampctl context use <name>' or set a cluster endpoint in your config")
 )
 
 // NewClient creates a new authenticated Client.
 func NewClient(
 	config *config.GlobalConfig,
 ) (*client.Client, error) {
+	if configutil.GetCurrentOpAMPCommanderEndpoint(config) == "" {
+		return nil, ErrNoEndpoint
+	}
+
 	cli, err := NewAuthedClient(config)
 	if err != nil {
 		if errors.Is(err, filecache.ErrNoCachedKey) ||
@@ -53,10 +59,15 @@ func NewClient(
 }
 
 // NewUnauthenticatedClient creates a new unauthenticated Client.
+// Returns nil if no endpoint is configured for the current context.
 func NewUnauthenticatedClient(
 	config *config.GlobalConfig,
 ) *client.Client {
 	endpoint := configutil.GetCurrentOpAMPCommanderEndpoint(config)
+	if endpoint == "" {
+		return nil
+	}
+
 	cli := client.New(
 		endpoint,
 		client.WithLogger(config.Log.Logger),

--- a/pkg/clientutil/clientutil.go
+++ b/pkg/clientutil/clientutil.go
@@ -29,7 +29,8 @@ var (
 	// ErrUnauthorized is returned when the client is unauthorized.
 	ErrUnauthorized = errors.New("unauthorized")
 	// ErrNoEndpoint is returned when no endpoint is configured for the current context.
-	ErrNoEndpoint = errors.New("no endpoint configured for current context: run 'opampctl context use <name>' or set a cluster endpoint in your config")
+	ErrNoEndpoint = errors.New("no endpoint configured for current context: " +
+		"run 'opampctl context use <name>' or set a cluster endpoint in your config")
 )
 
 // NewClient creates a new authenticated Client.


### PR DESCRIPTION
## Summary

- `NewClient` now checks for an empty endpoint before proceeding and returns `ErrNoEndpoint` with an actionable message (`"no endpoint configured for current context: run 'opampctl context use <name>' or set a cluster endpoint in your config"`)
- `NewUnauthenticatedClient` returns `nil` when no endpoint is configured, instead of creating a broken client

## Motivation

Previously a misconfigured context (e.g. a typo in the config key like `clsuter:` instead of `cluster:`) caused the endpoint to be resolved as `""`, resulting in a cryptic Go HTTP error: `unsupported protocol scheme ""`. The new error message tells the user exactly what to fix.

## Test plan

- [ ] Run `opampctl get agent` with a context that has no cluster endpoint configured — confirm the new error message appears
- [ ] Run `opampctl get agent` with a valid context — confirm normal behaviour is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)