### PR TITLE
fix: extend GitHub OAuth device auth timeout to device code expiry

### DIFF
--- a/pkg/client/auth.go
+++ b/pkg/client/auth.go
@@ -117,8 +117,10 @@ func (s *AuthService) ExchangeDeviceAuthToken(deviceCode string, expiry time.Tim
 
 	if !expiry.IsZero() {
 		req = req.SetQueryParam("expiry", expiry.Format(time.RFC3339))
+
 		ctx, cancel := context.WithDeadline(context.Background(), expiry)
 		defer cancel()
+
 		req = req.SetContext(ctx)
 	}
 

--- a/pkg/client/auth.go
+++ b/pkg/client/auth.go
@@ -1,6 +1,7 @@
 package client
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -116,6 +117,9 @@ func (s *AuthService) ExchangeDeviceAuthToken(deviceCode string, expiry time.Tim
 
 	if !expiry.IsZero() {
 		req = req.SetQueryParam("expiry", expiry.Format(time.RFC3339))
+		ctx, cancel := context.WithDeadline(context.Background(), expiry)
+		defer cancel()
+		req = req.SetContext(ctx)
 	}
 
 	res, err := req.Get(GithubAuthExchangeDeviceAuthAPIURL)


### PR DESCRIPTION
## Summary

- Fixes a timeout issue where `opampctl` GitHub OAuth device auth login fails before the user can authenticate in the browser.
- The global Resty HTTP client timeout of 15s caused `ExchangeDeviceAuthToken` to time out while the server was still polling GitHub for the token.
- Now uses the device code expiry time (typically 15 minutes, as issued by GitHub) as the HTTP request context deadline.

## Root Cause

`pkg/client/client.go` sets a 15-second global timeout on the Resty HTTP client. The GitHub device auth flow keeps the HTTP connection open while the server polls GitHub's token endpoint. The client times out after 15 seconds — well before the user has a chance to open the browser and enter the code.

## Test plan

- [ ] Run `opampctl` GitHub OAuth login
- [ ] Verify authentication succeeds even when the user takes more than 15 seconds in the browser
- [ ] Verify an appropriate error is returned after the device code expires (15 minutes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)