### PR TITLE
fix: use dedicated no-timeout Resty client for GitHub device auth exchange

### DIFF
--- a/pkg/client/auth.go
+++ b/pkg/client/auth.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/go-resty/resty/v2"
+
 	v1auth "github.com/minuk-dev/opampcommander/api/v1/auth"
 )
 
@@ -111,7 +113,12 @@ func (s *AuthService) GetDeviceAuthToken() (*v1auth.DeviceAuthnTokenResponse, er
 func (s *AuthService) ExchangeDeviceAuthToken(deviceCode string, expiry time.Time) (*v1auth.AuthnTokenResponse, error) {
 	var authToken v1auth.AuthnTokenResponse
 
-	req := s.service.Resty.R().
+	// This request blocks on the server while it polls GitHub for authorization.
+	// The shared Resty client has a 15s hard timeout which is too short for interactive login.
+	// Use a dedicated client with no timeout; the context deadline is the only limit.
+	exchangeClient := resty.New().SetBaseURL(s.service.Resty.HostURL)
+
+	req := exchangeClient.R().
 		SetResult(&authToken).
 		SetQueryParam("device_code", deviceCode)
 

--- a/pkg/client/auth.go
+++ b/pkg/client/auth.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/go-resty/resty/v2"
-
 	v1auth "github.com/minuk-dev/opampcommander/api/v1/auth"
 )
 
@@ -115,8 +113,8 @@ func (s *AuthService) ExchangeDeviceAuthToken(deviceCode string, expiry time.Tim
 
 	// This request blocks on the server while it polls GitHub for authorization.
 	// The shared Resty client has a 15s hard timeout which is too short for interactive login.
-	// Use a dedicated client with no timeout; the context deadline is the only limit.
-	exchangeClient := resty.New().SetBaseURL(s.service.Resty.HostURL)
+	// Clone the client and clear the timeout; the context deadline is the only limit.
+	exchangeClient := s.service.Resty.Clone().SetTimeout(0)
 
 	req := exchangeClient.R().
 		SetResult(&authToken).


### PR DESCRIPTION
## Summary

- Fixes the GitHub OAuth device auth login timeout in `opampctl`.
- The previous fix (#339) attempted to use `SetContext` with the device code expiry as deadline, but `context.WithDeadline` does not override `Client.Timeout` — the shorter of the two always wins. The 15s Resty client timeout was still cutting the connection short.
- The real fix: use a dedicated Resty client with `Timeout = 0` (no hard timeout) for `ExchangeDeviceAuthToken`, so only the context deadline (device code expiry, ~15 min) limits the wait.

## Root Cause

`pkg/client/client.go` sets `defaultHTTPTimeout = 15s` on the shared Resty client. In Go's `net/http`, when both `Client.Timeout` and a context deadline are present, whichever expires first cancels the request. Since 15s < 15min, the client timeout always won — regardless of the context deadline set in the previous fix.

## Test plan

- [ ] Run `opampctl get agent` (or any other command) to trigger GitHub OAuth device login
- [ ] Verify authentication succeeds even when the user takes more than 15 seconds to authenticate in the browser
- [ ] Verify an appropriate error is returned after the device code expires (~15 minutes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)