### PR TITLE
fix: fix YAML output for opampctl get agent (camelCase fields, timestamps, empty fields)

### DIFF
--- a/api/v1/agent.go
+++ b/api/v1/agent.go
@@ -14,7 +14,7 @@ type Agent struct {
 	Metadata AgentMetadata `json:"metadata"`
 
 	// Spec contains the desired configuration for the agent.
-	Spec AgentSpec `json:"spec"`
+	Spec AgentSpec `json:"spec,omitzero"`
 
 	// Status contains the observed state of the agent.
 	Status AgentStatus `json:"status"`
@@ -29,13 +29,13 @@ type AgentMetadata struct {
 	Namespace string `json:"namespace"`
 
 	// Description is a human-readable description of the agent.
-	Description AgentDescription `json:"description"`
+	Description AgentDescription `json:"description,omitzero"`
 
 	// Capabilities is a bitmask representing the capabilities of the agent.
-	Capabilities AgentCapabilities `json:"capabilities"`
+	Capabilities AgentCapabilities `json:"capabilities,omitempty"`
 
 	// CustomCapabilities is a map of custom capabilities for the agent.
-	CustomCapabilities AgentCustomCapabilities `json:"customCapabilities"`
+	CustomCapabilities AgentCustomCapabilities `json:"customCapabilities,omitzero"`
 } // @name AgentMetadata
 
 // AgentSpec contains the desired configuration for the agent.
@@ -47,7 +47,7 @@ type AgentSpec struct {
 	ConnectionSettings ConnectionSettings `json:"connectionSettings,omitzero"`
 
 	// RemoteConfig is the remote configuration of the agent.
-	RemoteConfig AgentSpecRemoteConfig `json:"remoteConfig"`
+	RemoteConfig AgentSpecRemoteConfig `json:"remoteConfig,omitzero"`
 
 	// PackagesAvailable is the packages available for the agent to download.
 	PackagesAvailable AgentSpecPackages `json:"packagesAvailable,omitzero"`
@@ -66,19 +66,19 @@ type AgentSpecRemoteConfig struct {
 // AgentStatus contains the observed state of the agent.
 type AgentStatus struct {
 	// EffectiveConfig is the effective configuration of the agent.
-	EffectiveConfig AgentEffectiveConfig `json:"effectiveConfig"`
+	EffectiveConfig AgentEffectiveConfig `json:"effectiveConfig,omitzero"`
 
 	// PackageStatuses is a map of package statuses for the agent.
-	PackageStatuses AgentPackageStatuses `json:"packageStatuses"`
+	PackageStatuses AgentPackageStatuses `json:"packageStatuses,omitzero"`
 
 	// ComponentHealth is the health status of the agent's components.
 	ComponentHealth AgentComponentHealth `json:"componentHealth"`
 
 	// AvailableComponents lists components available on the agent.
-	AvailableComponents AgentAvailableComponents `json:"availableComponents"`
+	AvailableComponents AgentAvailableComponents `json:"availableComponents,omitzero"`
 
 	// Conditions is a list of conditions that apply to the agent.
-	Conditions []Condition `json:"conditions"`
+	Conditions []Condition `json:"conditions,omitempty"`
 
 	// Connected indicates if the agent is currently connected.
 	Connected bool `json:"connected"`
@@ -122,7 +122,7 @@ type AgentConfigFile struct {
 
 // AgentPackageStatuses represents the package statuses of the agent.
 type AgentPackageStatuses struct {
-	Packages                      map[string]AgentStatusPackageEntry `json:"packages"`
+	Packages                      map[string]AgentStatusPackageEntry `json:"packages,omitempty"`
 	ServerProvidedAllPackagesHash string                             `json:"serverProvidedAllPackagesHash,omitempty"`
 	ErrorMessage                  string                             `json:"errorMessage,omitempty"`
 } // @name AgentPackageStatuses

--- a/api/v1/time.go
+++ b/api/v1/time.go
@@ -172,7 +172,7 @@ func (t *Time) UnmarshalYAML(value *yaml.Node) error {
 // MarshalYAML implements [yaml.Marshaler].
 func (t Time) MarshalYAML() (any, error) {
 	if t.IsZero() {
-		return nil, nil
+		return (*string)(nil), nil
 	}
 
 	return t.UTC().Format(time.RFC3339), nil

--- a/api/v1/time.go
+++ b/api/v1/time.go
@@ -170,19 +170,10 @@ func (t *Time) UnmarshalYAML(value *yaml.Node) error {
 }
 
 // MarshalYAML implements [yaml.Marshaler].
-//
-//nolint:mnd
 func (t Time) MarshalYAML() (any, error) {
 	if t.IsZero() {
-		// Encode unset/nil objects as JSON's "null".
-		return []byte("null"), nil
+		return nil, nil
 	}
 
-	buf := make([]byte, 0, len(time.RFC3339)+2)
-	buf = append(buf, '"')
-	// time cannot contain non escapable JSON characters
-	buf = t.UTC().AppendFormat(buf, time.RFC3339)
-	buf = append(buf, '"')
-
-	return buf, nil
+	return t.UTC().Format(time.RFC3339), nil
 }

--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -50,8 +50,19 @@ func Format(writer io.Writer, target any, t FormatType) error {
 }
 
 // FormatYAML formats the target as a YAML representation.
+// It routes through JSON so that json struct tags (camelCase field names) are preserved.
 func FormatYAML(writer io.Writer, target any) error {
-	b, err := yaml.Marshal(target)
+	jsonBytes, err := json.Marshal(target)
+	if err != nil {
+		return fmt.Errorf("failed to marshal json: %w", err)
+	}
+
+	var obj any
+	if err = json.Unmarshal(jsonBytes, &obj); err != nil {
+		return fmt.Errorf("failed to unmarshal json: %w", err)
+	}
+
+	b, err := yaml.Marshal(obj)
 	if err != nil {
 		return fmt.Errorf("failed to marshal yaml: %w", err)
 	}

--- a/pkg/formatter/formatter.go
+++ b/pkg/formatter/formatter.go
@@ -58,7 +58,9 @@ func FormatYAML(writer io.Writer, target any) error {
 	}
 
 	var obj any
-	if err = json.Unmarshal(jsonBytes, &obj); err != nil {
+
+	err = json.Unmarshal(jsonBytes, &obj)
+	if err != nil {
 		return fmt.Errorf("failed to unmarshal json: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

- **camelCase field names**: `FormatYAML` was calling `yaml.Marshal` directly, which causes `yaml.v3` to ignore `json:` tags and lowercase all field names (`instanceuid`, `identifyingattributes`, etc.). Changed to route through JSON first so `json:` tag names (camelCase) are preserved in YAML output.
- **Timestamp byte arrays**: `Time.MarshalYAML()` was returning `[]byte`, which `yaml.v3` serialized as a raw byte sequence array instead of a string. Fixed to return `string`.
- **Empty field noise**: Added `omitempty`/`omitzero` to fields that produce noise when empty (`capabilities`, `customCapabilities`, `description`, `spec`, `remoteConfig`, `effectiveConfig`, `packageStatuses`, `availableComponents`, `conditions`).

## Before / After

**Before**
```yaml
- metadata:
    instanceuid: 4d1ff377-...
    description:
        identifyingattributes:
            service.name: otelcol-contrib
    capabilities: 2053
    customcapabilities:
        capabilities: []
  spec:
    newinstanceuid: "\0\0\0\0..."
    connectionsettings: ...
    remoteconfig:
        remoteconfignames: []
  status:
    componenthealth:
        starttime:
            - 34
            - 50
            - 48
            ...
```

**After**
```yaml
- metadata:
    instanceUid: 4d1ff377-...
    namespace: default
    description:
        identifyingAttributes:
            service.name: otelcol-contrib
    capabilities: 2053
  status:
    componentHealth:
        healthy: true
        startTime: "2026-04-28T17:00:26Z"
        status: StatusOK
    conditions:
        - lastTransitionTime: "2026-04-28T17:01:07Z"
          status: "True"
          type: Registered
    connected: true
```

## Test plan

- [ ] Run `opampctl get agent -o yaml` and verify camelCase field names
- [ ] Verify timestamps render as RFC3339 strings
- [ ] Verify empty spec/conditions/effectiveConfig etc. are omitted from output
- [ ] Verify `opampctl get agent -o json` is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)