### PR TITLE
fix: decode capabilities bitmask and suppress remaining empty fields in YAML output

### DIFF
--- a/api/v1/agent.go
+++ b/api/v1/agent.go
@@ -1,6 +1,11 @@
 package v1
 
-import "github.com/google/uuid"
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/google/uuid"
+)
 
 const (
 	// AgentKind is the kind of the agent resource.
@@ -96,6 +101,82 @@ type AgentStatus struct {
 // AgentCapabilities is a bitmask representing the capabilities of the agent.
 type AgentCapabilities uint64
 
+type capabilityEntry struct {
+	bit  AgentCapabilities
+	name string
+}
+
+func capabilityTable() []capabilityEntry {
+	return []capabilityEntry{
+		{1, "ReportsStatus"},
+		{2, "AcceptsRemoteConfig"},
+		{4, "ReportsEffectiveConfig"},
+		{8, "AcceptsPackages"},
+		{16, "ReportsPackageStatuses"},
+		{32, "ReportsOwnTraces"},
+		{64, "ReportsOwnMetrics"},
+		{128, "ReportsOwnLogs"},
+		{256, "AcceptsOpAMPConnectionSettings"},
+		{512, "AcceptsOtherConnectionSettings"},
+		{1024, "AcceptsRestartCommand"},
+		{2048, "ReportsHealth"},
+		{4096, "ReportsRemoteConfig"},
+		{8192, "ReportsHeartbeat"},
+		{16384, "ReportsAvailableComponents"},
+	}
+}
+
+// MarshalJSON serializes AgentCapabilities as a list of capability name strings.
+func (c AgentCapabilities) MarshalJSON() ([]byte, error) {
+	var names []string
+
+	for _, entry := range capabilityTable() {
+		if c&entry.bit != 0 {
+			names = append(names, entry.name)
+		}
+	}
+
+	b, err := json.Marshal(names)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal capabilities: %w", err)
+	}
+
+	return b, nil
+}
+
+// UnmarshalJSON deserializes AgentCapabilities from either a list of name strings or a raw integer.
+func (c *AgentCapabilities) UnmarshalJSON(data []byte) error {
+	var names []string
+
+	err := json.Unmarshal(data, &names)
+	if err == nil {
+		*c = 0
+
+		for _, name := range names {
+			for _, entry := range capabilityTable() {
+				if entry.name == name {
+					*c |= entry.bit
+
+					break
+				}
+			}
+		}
+
+		return nil
+	}
+
+	var raw uint64
+
+	err = json.Unmarshal(data, &raw)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal capabilities: %w", err)
+	}
+
+	*c = AgentCapabilities(raw)
+
+	return nil
+}
+
 // AgentDescription represents the description of the agent.
 type AgentDescription struct {
 	// IdentifyingAttributes are attributes that uniquely identify the agent.
@@ -109,9 +190,14 @@ type AgentEffectiveConfig struct {
 	ConfigMap AgentConfigMap `json:"configMap"`
 } // @name AgentEffectiveConfig
 
+// IsZero reports whether the effective config is empty, enabling omitzero on the parent field.
+func (e AgentEffectiveConfig) IsZero() bool {
+	return len(e.ConfigMap.ConfigMap) == 0
+}
+
 // AgentConfigMap represents a map of configuration files for the agent.
 type AgentConfigMap struct {
-	ConfigMap map[string]AgentConfigFile `json:"configMap"`
+	ConfigMap map[string]AgentConfigFile `json:"configMap,omitempty"`
 } // @name AgentConfigMap
 
 // AgentConfigFile represents a configuration file for the agent.
@@ -126,6 +212,11 @@ type AgentPackageStatuses struct {
 	ServerProvidedAllPackagesHash string                             `json:"serverProvidedAllPackagesHash,omitempty"`
 	ErrorMessage                  string                             `json:"errorMessage,omitempty"`
 } // @name AgentPackageStatuses
+
+// IsZero reports whether the package statuses are empty, enabling omitzero on the parent field.
+func (p AgentPackageStatuses) IsZero() bool {
+	return len(p.Packages) == 0 && p.ServerProvidedAllPackagesHash == "" && p.ErrorMessage == ""
+}
 
 // AgentComponentHealth represents the health status of the agent's components.
 type AgentComponentHealth struct {

--- a/api/v1/agent.go
+++ b/api/v1/agent.go
@@ -1,11 +1,6 @@
 package v1
 
-import (
-	"encoding/json"
-	"fmt"
-
-	"github.com/google/uuid"
-)
+import "github.com/google/uuid"
 
 const (
 	// AgentKind is the kind of the agent resource.
@@ -101,13 +96,12 @@ type AgentStatus struct {
 // AgentCapabilities is a bitmask representing the capabilities of the agent.
 type AgentCapabilities uint64
 
-type capabilityEntry struct {
-	bit  AgentCapabilities
-	name string
-}
-
-func capabilityTable() []capabilityEntry {
-	return []capabilityEntry{
+// Names returns the list of capability flag names set in this bitmask.
+func (c AgentCapabilities) Names() []string {
+	table := [...]struct {
+		bit  AgentCapabilities
+		name string
+	}{
 		{1, "ReportsStatus"},
 		{2, "AcceptsRemoteConfig"},
 		{4, "ReportsEffectiveConfig"},
@@ -124,57 +118,16 @@ func capabilityTable() []capabilityEntry {
 		{8192, "ReportsHeartbeat"},
 		{16384, "ReportsAvailableComponents"},
 	}
-}
 
-// MarshalJSON serializes AgentCapabilities as a list of capability name strings.
-func (c AgentCapabilities) MarshalJSON() ([]byte, error) {
 	var names []string
 
-	for _, entry := range capabilityTable() {
+	for _, entry := range table {
 		if c&entry.bit != 0 {
 			names = append(names, entry.name)
 		}
 	}
 
-	b, err := json.Marshal(names)
-	if err != nil {
-		return nil, fmt.Errorf("failed to marshal capabilities: %w", err)
-	}
-
-	return b, nil
-}
-
-// UnmarshalJSON deserializes AgentCapabilities from either a list of name strings or a raw integer.
-func (c *AgentCapabilities) UnmarshalJSON(data []byte) error {
-	var names []string
-
-	err := json.Unmarshal(data, &names)
-	if err == nil {
-		*c = 0
-
-		for _, name := range names {
-			for _, entry := range capabilityTable() {
-				if entry.name == name {
-					*c |= entry.bit
-
-					break
-				}
-			}
-		}
-
-		return nil
-	}
-
-	var raw uint64
-
-	err = json.Unmarshal(data, &raw)
-	if err != nil {
-		return fmt.Errorf("failed to unmarshal capabilities: %w", err)
-	}
-
-	*c = AgentCapabilities(raw)
-
-	return nil
+	return names
 }
 
 // AgentDescription represents the description of the agent.

--- a/internal/application/helper/mapper.go
+++ b/internal/application/helper/mapper.go
@@ -810,11 +810,12 @@ func (mapper *Mapper) mapConditionsToAPI(conditions []model.Condition) []v1.Cond
 }
 
 func (mapper *Mapper) mapNewInstanceUIDToAPI(newInstanceUID []byte) string {
-	if len(newInstanceUID) == 0 {
+	uid, err := uuid.FromBytes(newInstanceUID)
+	if err != nil || uid == uuid.Nil {
 		return ""
 	}
 
-	return string(newInstanceUID)
+	return uid.String()
 }
 
 func (mapper *Mapper) mapOpAMPConnectionFromAPI(

--- a/pkg/cmd/opampctl/get/agent/agent.go
+++ b/pkg/cmd/opampctl/get/agent/agent.go
@@ -3,6 +3,7 @@ package agent
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -34,10 +35,11 @@ type CommandOptions struct {
 	*config.GlobalConfig
 
 	// flags
-	formatType    string
-	byAgentGroup  string
-	namespace     string
-	allNamespaces bool
+	formatType         string
+	byAgentGroup       string
+	namespace          string
+	allNamespaces      bool
+	decodeCapabilities bool
 
 	// internal
 	client *client.Client
@@ -68,6 +70,10 @@ func NewCommand(options CommandOptions) *cobra.Command {
 	cmd.Flags().StringVar(&options.byAgentGroup, "agentgroup", "", "Filter agents by agent group name")
 	cmd.Flags().StringVarP(&options.namespace, "namespace", "n", "default", "Namespace for the agent group filter")
 	cmd.Flags().BoolVarP(&options.allNamespaces, "all-namespaces", "A", false, "List resources across all namespaces")
+	cmd.Flags().BoolVar(
+		&options.decodeCapabilities, "decode-capabilities", false,
+		"Decode the capabilities bitmask into human-readable flag names",
+	)
 
 	return cmd
 }
@@ -267,7 +273,12 @@ func (opt *CommandOptions) formatAgents(cmd *cobra.Command, agents []v1.Agent) e
 			return fmt.Errorf("failed to format agents: %w", err)
 		}
 	case formatter.JSON, formatter.YAML:
-		err := formatter.Format(cmd.OutOrStdout(), agents, formatType)
+		var target any = agents
+		if opt.decodeCapabilities {
+			target = decodeAgentCapabilities(agents)
+		}
+
+		err := formatter.Format(cmd.OutOrStdout(), target, formatType)
 		if err != nil {
 			return fmt.Errorf("failed to format agents: %w", err)
 		}
@@ -276,6 +287,36 @@ func (opt *CommandOptions) formatAgents(cmd *cobra.Command, agents []v1.Agent) e
 	}
 
 	return nil
+}
+
+// decodeAgentCapabilities converts agents to a JSON-serializable form with capabilities
+// expanded into human-readable flag names.
+func decodeAgentCapabilities(agents []v1.Agent) []map[string]any {
+	result := make([]map[string]any, 0, len(agents))
+
+	for _, agent := range agents {
+		jsonBytes, err := json.Marshal(agent)
+		if err != nil {
+			continue
+		}
+
+		var agentMap map[string]any
+
+		err = json.Unmarshal(jsonBytes, &agentMap)
+		if err != nil {
+			continue
+		}
+
+		if metadata, ok := agentMap["metadata"].(map[string]any); ok {
+			if _, ok := metadata["capabilities"].(float64); ok {
+				metadata["capabilities"] = agent.Metadata.Capabilities.Names()
+			}
+		}
+
+		result = append(result, agentMap)
+	}
+
+	return result
 }
 
 func toShortItemForCLI(agent v1.Agent) ItemForCLI {


### PR DESCRIPTION
## Summary

Follow-up to #341 addressing remaining noise in `opampctl get agent -o yaml`:

- **`newInstanceUid` hidden when unset**: `mapNewInstanceUIDToAPI` was returning a 16-null-byte string for `uuid.Nil`, bypassing `omitempty`. Now returns `""` for nil/zero UUIDs.
- **`packageStatuses: {}` and `effectiveConfig` suppressed**: Added `IsZero()` to `AgentPackageStatuses` and `AgentEffectiveConfig` so that `omitzero` on the parent fields works even when internal maps are initialized but empty (not nil).
- **`configMap: {}` inside effectiveConfig**: Added `omitempty` to `AgentConfigMap.ConfigMap`.
- **`--decode-capabilities` flag**: Capabilities remain as a raw integer by default. Pass `--decode-capabilities` with `-o yaml` or `-o json` to expand the bitmask into human-readable flag names.

## Usage

Default (numeric):
```
opampctl get agent -o yaml
```
```yaml
metadata:
    capabilities: 2053
```

With `--decode-capabilities`:
```
opampctl get agent -o yaml --decode-capabilities
```
```yaml
metadata:
    capabilities:
        - ReportsStatus
        - ReportsEffectiveConfig
        - ReportsHealth
```

## Test plan

- [ ] `newInstanceUid` is absent when agent has no new UID assigned
- [ ] `packageStatuses` and `effectiveConfig` are absent when empty
- [ ] `opampctl get agent -o yaml` shows capabilities as a raw integer
- [ ] `opampctl get agent -o yaml --decode-capabilities` shows capabilities as a name list
- [ ] `opampctl get agent -o json --decode-capabilities` also works

🤖 Generated with [Claude Code](https://claude.com/claude-code)