### PR TITLE
feat: seed GET permissions on built-in default role

### DIFF
--- a/pkg/apiserver/module/infrastructure/default_role.go
+++ b/pkg/apiserver/module/infrastructure/default_role.go
@@ -13,16 +13,97 @@ import (
 	userport "github.com/minuk-dev/opampcommander/internal/domain/user/port"
 )
 
-// ensureDefaultRole creates the built-in "default" role if it does not exist.
-// The default role is assigned to all new users automatically on login.
-// It is marked IsBuiltIn=true so it cannot be deleted, but its permissions can be changed.
+// defaultRoleBuiltInPermissions lists the permission names every user should hold
+// in the default namespace via the built-in default role: GET on every
+// namespace-scoped resource. Admins can still customize the default role's
+// permissions via the API; this set is treated as a floor that startup re-applies.
+func defaultRoleBuiltInPermissions() []usermodel.PermissionSpec {
+	specs := make([]usermodel.PermissionSpec, 0, len(usermodel.NamespaceScopedResources()))
+
+	for _, resource := range usermodel.NamespaceScopedResources() {
+		specs = append(specs, usermodel.PermissionSpec{
+			Name:        resource + ":" + usermodel.ActionGet,
+			Description: "Built-in: read access to " + resource + " in the default namespace",
+			Resource:    resource,
+			Action:      usermodel.ActionGet,
+			IsBuiltIn:   true,
+		})
+	}
+
+	return specs
+}
+
+// ensureDefaultPermissions persists the built-in permission docs the default role refers to,
+// so RBACService.SyncPolicies can resolve them via PermissionPersistencePort.GetPermissionByName.
+func ensureDefaultPermissions(
+	ctx context.Context,
+	permissionPersistencePort userport.PermissionPersistencePort,
+	logger *slog.Logger,
+) error {
+	for _, spec := range defaultRoleBuiltInPermissions() {
+		_, err := permissionPersistencePort.GetPermissionByName(ctx, spec.Name)
+		if err == nil {
+			continue
+		}
+
+		if !errors.Is(err, port.ErrResourceNotExist) {
+			return fmt.Errorf("check built-in permission %q: %w", spec.Name, err)
+		}
+
+		logger.Info("creating built-in permission", slog.String("name", spec.Name))
+
+		permission := usermodel.NewPermission(spec.Resource, spec.Action, spec.IsBuiltIn)
+		permission.Spec.Description = spec.Description
+
+		_, err = permissionPersistencePort.PutPermission(ctx, permission)
+		if err != nil {
+			return fmt.Errorf("create built-in permission %q: %w", spec.Name, err)
+		}
+	}
+
+	return nil
+}
+
+// ensureDefaultRole creates the built-in "default" role if it does not exist and ensures it
+// references every built-in permission from defaultRoleBuiltInPermissions. New permissions
+// added to that list in later releases are picked up on next startup; admin-added permissions
+// outside that list are preserved.
+//
+// The role is marked IsBuiltIn=true so it cannot be deleted, but its permissions can be
+// further customized via the API (this hook only enforces the built-in floor).
 func ensureDefaultRole(
 	ctx context.Context,
 	rolePersistencePort userport.RolePersistencePort,
 	logger *slog.Logger,
 ) error {
-	_, err := rolePersistencePort.GetRoleByName(ctx, usermodel.RoleDefault)
+	builtInNames := make([]string, 0, len(defaultRoleBuiltInPermissions()))
+	for _, spec := range defaultRoleBuiltInPermissions() {
+		builtInNames = append(builtInNames, spec.Name)
+	}
+
+	existing, err := rolePersistencePort.GetRoleByName(ctx, usermodel.RoleDefault)
 	if err == nil {
+		added := false
+
+		for _, name := range builtInNames {
+			if !existing.HasPermission(name) {
+				existing.AddPermission(name)
+
+				added = true
+			}
+		}
+
+		if !added {
+			return nil
+		}
+
+		logger.Info("adding missing built-in permissions to default role")
+
+		_, err = rolePersistencePort.PutRole(ctx, existing)
+		if err != nil {
+			return fmt.Errorf("update default role with built-in permissions: %w", err)
+		}
+
 		return nil
 	}
 
@@ -34,6 +115,7 @@ func ensureDefaultRole(
 
 	defaultRole := usermodel.NewRole(usermodel.RoleDefault, true)
 	defaultRole.Spec.Description = "Default role assigned to all new users on first login"
+	defaultRole.Spec.Permissions = builtInNames
 
 	_, err = rolePersistencePort.PutRole(ctx, defaultRole)
 	if err != nil {
@@ -44,14 +126,20 @@ func ensureDefaultRole(
 }
 
 // registerDefaultRoleHook registers a lifecycle hook to ensure
-// the built-in default role exists on startup.
+// the built-in default role and its permissions exist on startup.
 func registerDefaultRoleHook(
 	lifecycle fx.Lifecycle,
 	rolePersistencePort userport.RolePersistencePort,
+	permissionPersistencePort userport.PermissionPersistencePort,
 	logger *slog.Logger,
 ) {
 	lifecycle.Append(fx.Hook{
 		OnStart: func(ctx context.Context) error {
+			err := ensureDefaultPermissions(ctx, permissionPersistencePort, logger)
+			if err != nil {
+				return err
+			}
+
 			return ensureDefaultRole(ctx, rolePersistencePort, logger)
 		},
 		OnStop: nil,

--- a/test/e2e/apiserver/rbac_e2e_test.go
+++ b/test/e2e/apiserver/rbac_e2e_test.go
@@ -3,6 +3,7 @@
 package apiserver_test
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -39,6 +40,66 @@ func TestE2E_APIServer_RBAC(t *testing.T) {
 		assert.Equal(t, "test@test.com", profile.User.Spec.Email)
 		assert.Equal(t, "test-admin", profile.User.Spec.Username)
 		assert.True(t, profile.User.Spec.IsActive)
+	})
+
+	// DefaultRole_HasBuiltInGetPermissions verifies that the built-in "default" role exists
+	// at startup with GET permissions on every namespace-scoped resource. Together with the
+	// SyncPolicies hook that auto-grants the default role to every user in the "default"
+	// namespace, this is what gives every authenticated user read access there.
+	t.Run("DefaultRole_HasBuiltInGetPermissions", func(t *testing.T) {
+		expected := []string{
+			"agent:GET",
+			"agentgroup:GET",
+			"agentpackage:GET",
+			"agentremoteconfig:GET",
+			"certificate:GET",
+			"rolebinding:GET",
+		}
+
+		resp, err := opampClient.RoleService.ListRoles(t.Context())
+		require.NoError(t, err)
+
+		var defaultRole *v1.Role
+
+		for i := range resp.Items {
+			if resp.Items[i].Spec.DisplayName == "default" {
+				defaultRole = &resp.Items[i]
+
+				break
+			}
+		}
+
+		require.NotNil(t, defaultRole, "built-in default role must exist")
+		assert.True(t, defaultRole.Spec.IsBuiltIn, "default role must be marked built-in")
+
+		for _, name := range expected {
+			assert.True(t, slices.Contains(defaultRole.Spec.Permissions, name),
+				"default role missing built-in permission %q (got %v)",
+				name, defaultRole.Spec.Permissions)
+		}
+	})
+
+	// DefaultRole_AppearsOnUserProfile verifies the default role surfaces on /users/me
+	// for every authenticated user, with no RoleBinding (granted implicitly by SyncPolicies).
+	t.Run("DefaultRole_AppearsOnUserProfile", func(t *testing.T) {
+		profile, err := opampClient.UserService.GetMyProfile(t.Context())
+		require.NoError(t, err)
+
+		var defaultEntry *v1.UserRoleEntry
+
+		for i := range profile.Roles {
+			if profile.Roles[i].Role.Spec.DisplayName == "default" {
+				defaultEntry = &profile.Roles[i]
+
+				break
+			}
+		}
+
+		require.NotNil(t, defaultEntry, "profile must include the default role")
+		assert.Nil(t, defaultEntry.RoleBinding,
+			"default role is granted implicitly — no RoleBinding should be reported")
+		assert.NotEmpty(t, defaultEntry.Role.Spec.Permissions,
+			"default role on profile must carry its built-in permissions")
 	})
 
 	// Test 2: List users


### PR DESCRIPTION
## Summary
- Built-in `default` role was created empty, so authenticated users had no read access to namespace-scoped resources out of the box. Every install needed manual role/binding setup before users could even `GET` in their own namespace.
- Seed `<resource>:GET` permission docs on startup for every entry in `NamespaceScopedResources()` (`agent`, `agentgroup`, `agentpackage`, `agentremoteconfig`, `certificate`, `rolebinding`).
- Treat that set as a *floor* the default role re-applies on every boot — existing admin-added permissions are preserved, only missing built-ins are added.

## Test plan
- [x] `go test -short ./...`
- [x] `make lint`
- [x] `go test -tags=e2e ./test/e2e/apiserver/` (all pass)
- [x] New subtests in `TestE2E_APIServer_RBAC`:
  - `DefaultRole_HasBuiltInGetPermissions` — `ListRoles` → default role spec contains every expected `<resource>:GET`
  - `DefaultRole_AppearsOnUserProfile` — `/users/me` surfaces the default role with `RoleBinding == nil` (granted implicitly by `SyncPolicies`) and carries its built-in permission list

## Notes
- HTTP-level RBAC enforcement middleware is not yet wired, so this PR doesn't *block* requests on the new permissions — it just makes the data correct so `/users/me` and the future enforcement path see the right grants.