### PR TITLE
fix(apiserver): set HTTP IdleTimeout to avoid OpAMP HTTP EOF race

### DIFF
--- a/pkg/apiserver/module/infrastructure/http.go
+++ b/pkg/apiserver/module/infrastructure/http.go
@@ -28,6 +28,14 @@ const (
 	// DefaultHTTPReadTimeout is the default timeout for reading HTTP requests.
 	// It should be set to a reasonable value to avoid security issues.
 	DefaultHTTPReadTimeout = 30 * time.Second
+
+	// DefaultHTTPIdleTimeout is how long a keep-alive connection stays open
+	// between requests. It must be longer than the OpAMP HTTP client's poll
+	// interval (default 30s) — otherwise the server can close an idle
+	// keep-alive connection exactly as the client tries to reuse it, which
+	// surfaces as `Post ... : EOF` on the agent. When unset, net/http falls
+	// back to ReadTimeout, which produces that exact race.
+	DefaultHTTPIdleTimeout = 120 * time.Second
 )
 
 var (
@@ -46,6 +54,7 @@ func NewHTTPServer(
 	//exhaustruct:ignore
 	srv := &http.Server{
 		ReadTimeout: DefaultHTTPReadTimeout,
+		IdleTimeout: DefaultHTTPIdleTimeout,
 		Addr:        settings.Address,
 		Handler:     engine,
 		ConnContext: connContext,


### PR DESCRIPTION
## Symptom
OpAMP HTTP agents see periodic errors of the form:

```
error opampextension Failed to do HTTP request (Post "http://apiserver:8080/api/v1/opamp": EOF), will retry
```

Reproduced on the `opampcommander-alpha-ha` deployment where two apiserver replicas sit behind a ClusterIP Service and an otel-collector with the `opamp` extension polls over HTTP.

## Root cause
`pkg/apiserver/module/infrastructure/http.go` constructs `http.Server` with `ReadTimeout: 30s` and no `IdleTimeout`. Per net/http, when `IdleTimeout` is unset it falls back to `ReadTimeout` — so keep-alive connections are reaped after 30 seconds of idleness.

The OpAMP HTTP client polls roughly every 30 seconds. When the client tries to reuse a keep-alive connection at the same moment the server closes it, the request fails mid-flight and the client sees `EOF`. The retry succeeds because a fresh TCP connection is opened. This matches the cadence and the "transient EOF every few polls" pattern we observed in the apiserver logs (handler logs nothing for the failing attempt, because the connection died before the request was framed).

## Fix
Set `IdleTimeout` explicitly to 120s so keep-alive connections comfortably outlive typical OpAMP poll intervals.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./pkg/apiserver/module/infrastructure/...`
- [ ] Deploy the new image to `opampcommander-alpha-ha` and confirm the otel-collector-http no longer logs the EOF error every poll cycle.

🤖 Generated with [Claude Code](https://claude.com/claude-code)