### PR TITLE
chore(ci): also bump alpha-ha overlay on main push

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,19 +81,24 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.MINUK_CLUSTER_DEPLOY_KEY }}
 
-      - name: Deploy alpha to minuk-cluster
+      - name: Deploy alpha and alpha-ha to minuk-cluster
         if: startsWith(github.ref, 'refs/heads/')
         run: |
           git clone git@github.com:minuk-cluster/minuk-cluster.git /tmp/minuk-cluster
           cd /tmp/minuk-cluster
 
-          yq '(.images[] | select(.name == "ghcr.io/minuk-dev/opampcommander")).newTag = strenv(VERSION)' \
-            -i argocd/apps/opampcommander/overlays/alpha/kustomization.yaml
+          overlays=(alpha alpha-ha)
+          for overlay in "${overlays[@]}"; do
+            yq '(.images[] | select(.name == "ghcr.io/minuk-dev/opampcommander")).newTag = strenv(VERSION)' \
+              -i "argocd/apps/opampcommander/overlays/${overlay}/kustomization.yaml"
+          done
 
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
-          git add argocd/apps/opampcommander/overlays/alpha/kustomization.yaml
-          git commit -m "chore(deploy): update opampcommander alpha to ${VERSION}"
+          for overlay in "${overlays[@]}"; do
+            git add "argocd/apps/opampcommander/overlays/${overlay}/kustomization.yaml"
+          done
+          git commit -m "chore(deploy): update opampcommander alpha and alpha-ha to ${VERSION}"
 
           # retry on push conflict from concurrent CI runs
           for i in 1 2 3; do


### PR DESCRIPTION
## Summary
Extend the `Deploy alpha to minuk-cluster` step in `.github/workflows/release.yaml` so each push to `main` updates the opampcommander image tag in **both** the `alpha` and `alpha-ha` overlays under `argocd/apps/opampcommander/overlays/` in the minuk-cluster repo.

## Why
A new `alpha-ha` overlay was added to minuk-cluster (distributed mode behind Kafka, two apiserver replicas). Today only the `alpha` overlay's `newTag` is updated on each release, so `alpha-ha` lags behind unless manually bumped.

## Test plan
- [ ] Next `main`-branch push produces a single minuk-cluster commit titled `chore(deploy): update opampcommander alpha and alpha-ha to <VERSION>` updating both overlay kustomization.yaml files.
- [ ] ArgoCD picks up the change and rolls both `opampcommander-alpha` and `opampcommander-alpha-ha`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)