### PR TITLE
feat(apiserver): auto-renew instanceUid on conflict

### DIFF
--- a/internal/application/service/opamp/instanceuid_conflict.go
+++ b/internal/application/service/opamp/instanceuid_conflict.go
@@ -1,0 +1,219 @@
+package opamp
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"maps"
+
+	"github.com/google/uuid"
+	"github.com/open-telemetry/opamp-go/protobufs"
+	"github.com/open-telemetry/opamp-go/server/types"
+
+	agentmodel "github.com/minuk-dev/opampcommander/internal/domain/agent/model"
+	domainport "github.com/minuk-dev/opampcommander/internal/domain/port"
+)
+
+const (
+	conflictReasonIdentifyingAttrs   = "stored_agent_has_different_identifying_attributes"
+	conflictReasonLiveAndIdentifying = "live_connection_and_identifying_attributes_mismatch"
+	conflictTriggeredBy              = "system:opamp"
+	serviceInstanceIDAttribute       = "service.instance.id"
+)
+
+// instanceUIDConflict describes a detected conflict on the incoming instanceUID.
+type instanceUIDConflict struct {
+	reason        string
+	existingAgent *agentmodel.Agent
+}
+
+// handleInstanceUIDConflict runs conflict detection and, when a conflict is found, audits
+// the event and returns a renewal ServerToAgent response. Returns nil when no conflict.
+func (s *Service) handleInstanceUIDConflict(
+	ctx context.Context,
+	logger *slog.Logger,
+	conn types.Connection,
+	instanceUID uuid.UUID,
+	message *protobufs.AgentToServer,
+) *protobufs.ServerToAgent {
+	conflict := s.detectInstanceUIDConflict(ctx, conn, instanceUID, message)
+	if conflict == nil {
+		return nil
+	}
+
+	newInstanceUID := s.newInstanceUID(logger)
+	s.recordInstanceUIDConflict(ctx, logger, conflict, instanceUID, newInstanceUID)
+
+	return s.createRenewalServerToAgent(instanceUID, newInstanceUID)
+}
+
+// detectInstanceUIDConflict checks whether the incoming message claims an instanceUID that
+// is already owned by a different agent identity. A conflict requires the stored agent's
+// identifying attributes to differ from the incoming message — a different live connection
+// alone is not enough, since rapid reconnects routinely overlap with the asynchronous
+// cleanup of the previous Connection record. When a live-connection mismatch coincides with
+// an identifying-attribute mismatch, the reason is escalated so operators see the stronger
+// signal.
+func (s *Service) detectInstanceUIDConflict(
+	ctx context.Context,
+	conn types.Connection,
+	instanceUID uuid.UUID,
+	message *protobufs.AgentToServer,
+) *instanceUIDConflict {
+	if instanceUID == uuid.Nil {
+		return nil
+	}
+
+	existingAgent, attrsConflict := s.hasIdentifyingAttrsConflict(ctx, instanceUID, message)
+	if !attrsConflict {
+		return nil
+	}
+
+	if s.hasLiveConnectionConflict(ctx, conn, instanceUID) {
+		return &instanceUIDConflict{
+			reason:        conflictReasonLiveAndIdentifying,
+			existingAgent: existingAgent,
+		}
+	}
+
+	return &instanceUIDConflict{
+		reason:        conflictReasonIdentifyingAttrs,
+		existingAgent: existingAgent,
+	}
+}
+
+// hasLiveConnectionConflict reports whether another connection (distinct from conn) is
+// currently bound to instanceUID.
+func (s *Service) hasLiveConnectionConflict(
+	ctx context.Context,
+	conn types.Connection,
+	instanceUID uuid.UUID,
+) bool {
+	existingConn, err := s.connectionUsecase.GetConnectionByInstanceUID(ctx, instanceUID)
+	if err != nil {
+		return false
+	}
+
+	if existingConn == nil {
+		return false
+	}
+
+	if !existingConn.IsAlive(s.clock.Now()) {
+		return false
+	}
+
+	currentConn, err := s.connectionUsecase.GetConnectionByID(ctx, conn)
+	if err != nil || currentConn == nil {
+		// The current connection has not been registered yet. The existing bound
+		// connection is therefore from a different network connection.
+		return true
+	}
+
+	return existingConn.UID != currentConn.UID
+}
+
+// hasIdentifyingAttrsConflict reports whether a stored agent record for instanceUID exists
+// and whose identifying attributes differ from those reported in the incoming message.
+// Returns the stored agent (or nil) alongside the verdict so callers can attach audit info.
+func (s *Service) hasIdentifyingAttrsConflict(
+	ctx context.Context,
+	instanceUID uuid.UUID,
+	message *protobufs.AgentToServer,
+) (*agentmodel.Agent, bool) {
+	existing, err := s.agentUsecase.GetAgent(ctx, instanceUID)
+	if err != nil {
+		if !errors.Is(err, domainport.ErrResourceNotExist) {
+			s.logger.Warn("failed to load agent for instanceUID conflict check",
+				slog.String("instanceUID", instanceUID.String()),
+				slog.String("error", err.Error()))
+		}
+
+		return nil, false
+	}
+
+	desc := message.GetAgentDescription()
+	if desc == nil {
+		return existing, false
+	}
+
+	incoming := toMap(desc.GetIdentifyingAttributes())
+	stored := existing.Metadata.Description.IdentifyingAttributes
+
+	if len(incoming) == 0 || len(stored) == 0 {
+		return existing, false
+	}
+
+	incomingID, incomingHasID := incoming[serviceInstanceIDAttribute]
+	storedID, storedHasID := stored[serviceInstanceIDAttribute]
+
+	if incomingHasID && storedHasID {
+		return existing, incomingID != storedID
+	}
+
+	return existing, !maps.Equal(incoming, stored)
+}
+
+// recordInstanceUIDConflict appends an audit condition onto the stored agent (if any) and
+// emits a structured log. The audit captures the old/new instanceUID and the reason so
+// operators can trace renewals after the fact.
+func (s *Service) recordInstanceUIDConflict(
+	ctx context.Context,
+	logger *slog.Logger,
+	conflict *instanceUIDConflict,
+	oldInstanceUID, newInstanceUID uuid.UUID,
+) {
+	logger.Warn("instanceUID conflict detected; redirecting new arrival to a fresh instanceUID",
+		slog.String("oldInstanceUID", oldInstanceUID.String()),
+		slog.String("newInstanceUID", newInstanceUID.String()),
+		slog.String("reason", conflict.reason),
+	)
+
+	if conflict.existingAgent == nil {
+		return
+	}
+
+	conflict.existingAgent.RecordInstanceUIDConflict(
+		s.clock.Now(),
+		oldInstanceUID, newInstanceUID,
+		conflict.reason,
+		conflictTriggeredBy,
+	)
+
+	err := s.agentUsecase.SaveAgent(ctx, conflict.existingAgent)
+	if err != nil {
+		logger.Error("failed to persist instanceUID conflict audit on existing agent",
+			slog.String("existingAgentInstanceUID", conflict.existingAgent.Metadata.InstanceUID.String()),
+			slog.String("error", err.Error()),
+		)
+	}
+}
+
+// createRenewalServerToAgent builds a ServerToAgent response that asks the agent to switch
+// to a freshly issued instanceUID. The InstanceUid field echoes the UID the agent currently
+// believes it has, per the OpAMP spec.
+func (s *Service) createRenewalServerToAgent(
+	oldInstanceUID, newInstanceUID uuid.UUID,
+) *protobufs.ServerToAgent {
+	//exhaustruct:ignore
+	return &protobufs.ServerToAgent{
+		InstanceUid: oldInstanceUID[:],
+		AgentIdentification: &protobufs.AgentIdentification{
+			NewInstanceUid: newInstanceUID[:],
+		},
+	}
+}
+
+// newInstanceUID generates a fresh UUID v7 to hand to the conflicting agent. Falls back to
+// a random UUID v4 if v7 generation fails (clock/entropy issue) so the protocol can still
+// progress.
+func (s *Service) newInstanceUID(logger *slog.Logger) uuid.UUID {
+	id, err := uuid.NewV7()
+	if err != nil {
+		logger.Warn("uuid.NewV7 failed; falling back to uuid.New",
+			slog.String("error", err.Error()))
+
+		return uuid.New()
+	}
+
+	return id
+}

--- a/internal/application/service/opamp/instanceuid_conflict_test.go
+++ b/internal/application/service/opamp/instanceuid_conflict_test.go
@@ -1,0 +1,398 @@
+//nolint:testpackage // white-box test of unexported instanceUID conflict helpers
+package opamp
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/open-telemetry/opamp-go/protobufs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	agentmodel "github.com/minuk-dev/opampcommander/internal/domain/agent/model"
+	"github.com/minuk-dev/opampcommander/internal/domain/agent/model/agent"
+	agentport "github.com/minuk-dev/opampcommander/internal/domain/agent/port"
+	domainport "github.com/minuk-dev/opampcommander/internal/domain/port"
+	"github.com/minuk-dev/opampcommander/pkg/utils/clock"
+)
+
+// stubAgentUsecase satisfies agentport.AgentUsecase by embedding the interface; only the
+// methods used by detectInstanceUIDConflict / recordInstanceUIDConflict are overridden.
+type stubAgentUsecase struct {
+	agentport.AgentUsecase
+
+	getResult *agentmodel.Agent
+	getErr    error
+	saved     *agentmodel.Agent
+}
+
+func (s *stubAgentUsecase) GetAgent(_ context.Context, _ uuid.UUID) (*agentmodel.Agent, error) {
+	return s.getResult, s.getErr
+}
+
+func (s *stubAgentUsecase) SaveAgent(_ context.Context, a *agentmodel.Agent) error {
+	s.saved = a
+
+	return nil
+}
+
+// stubConnectionUsecase satisfies agentport.ConnectionUsecase the same way.
+type stubConnectionUsecase struct {
+	agentport.ConnectionUsecase
+
+	byInstanceUID    *agentmodel.Connection
+	byInstanceUIDErr error
+	byID             *agentmodel.Connection
+	byIDErr          error
+}
+
+func (s *stubConnectionUsecase) GetConnectionByInstanceUID(
+	_ context.Context,
+	_ uuid.UUID,
+) (*agentmodel.Connection, error) {
+	return s.byInstanceUID, s.byInstanceUIDErr
+}
+
+func (s *stubConnectionUsecase) GetConnectionByID(_ context.Context, _ any) (*agentmodel.Connection, error) {
+	return s.byID, s.byIDErr
+}
+
+func newTestService(t *testing.T, agentUC agentport.AgentUsecase, connUC agentport.ConnectionUsecase) *Service {
+	t.Helper()
+
+	return &Service{
+		clock:             clock.NewRealClock(),
+		logger:            slog.New(slog.DiscardHandler),
+		agentUsecase:      agentUC,
+		connectionUsecase: connUC,
+	}
+}
+
+func aliveConn(t *testing.T, uid uuid.UUID, instanceUID uuid.UUID) *agentmodel.Connection {
+	t.Helper()
+
+	return &agentmodel.Connection{
+		ID:                 struct{}{},
+		Type:               agentmodel.ConnectionTypeWebSocket,
+		UID:                uid,
+		InstanceUID:        instanceUID,
+		LastCommunicatedAt: time.Now(),
+	}
+}
+
+func TestCreateRenewalServerToAgent(t *testing.T) {
+	t.Parallel()
+
+	svc := &Service{}
+	oldUID := uuid.New()
+	newUID := uuid.New()
+	got := svc.createRenewalServerToAgent(oldUID, newUID)
+
+	require.NotNil(t, got)
+	assert.Equal(t, oldUID[:], got.GetInstanceUid())
+	require.NotNil(t, got.GetAgentIdentification())
+	assert.Equal(t, newUID[:], got.GetAgentIdentification().GetNewInstanceUid())
+}
+
+func TestNewInstanceUIDGeneratesV7(t *testing.T) {
+	t.Parallel()
+
+	svc := newTestService(t, nil, nil)
+	id := svc.newInstanceUID(svc.logger)
+
+	assert.NotEqual(t, uuid.Nil, id)
+	assert.Equal(t, uuid.Version(7), id.Version())
+}
+
+func TestDetectInstanceUIDConflict_NoConflictForBrandNewAgent(t *testing.T) {
+	t.Parallel()
+
+	agentUC := &stubAgentUsecase{getErr: domainport.ErrResourceNotExist}
+	connUC := &stubConnectionUsecase{byInstanceUIDErr: agentport.ErrConnectionNotFound}
+
+	svc := newTestService(t, agentUC, connUC)
+
+	conflict := svc.detectInstanceUIDConflict(t.Context(), nil, uuid.New(), &protobufs.AgentToServer{})
+
+	assert.Nil(t, conflict)
+}
+
+func TestDetectInstanceUIDConflict_NilInstanceUID(t *testing.T) {
+	t.Parallel()
+
+	svc := newTestService(t, &stubAgentUsecase{}, &stubConnectionUsecase{})
+
+	conflict := svc.detectInstanceUIDConflict(t.Context(), nil, uuid.Nil, &protobufs.AgentToServer{})
+
+	assert.Nil(t, conflict)
+}
+
+func TestDetectInstanceUIDConflict_LiveConnectionAloneIsNotConflict(t *testing.T) {
+	t.Parallel()
+
+	// A different live connection on the same instanceUID by itself is not a conflict —
+	// it happens on every WebSocket reconnect before OnConnectionClose cleanup runs.
+	// We must only flag a conflict when the identifying attributes also differ.
+	instanceUID := uuid.New()
+	other := aliveConn(t, uuid.New(), instanceUID)
+	current := aliveConn(t, uuid.New(), instanceUID)
+
+	agentUC := &stubAgentUsecase{getErr: domainport.ErrResourceNotExist}
+	connUC := &stubConnectionUsecase{byInstanceUID: other, byID: current}
+
+	svc := newTestService(t, agentUC, connUC)
+
+	conflict := svc.detectInstanceUIDConflict(t.Context(), nil, instanceUID, &protobufs.AgentToServer{})
+
+	assert.Nil(t, conflict)
+}
+
+func TestDetectInstanceUIDConflict_IdentifyingAttrsMismatch(t *testing.T) {
+	t.Parallel()
+
+	instanceUID := uuid.New()
+
+	stored := agentmodel.NewAgent(instanceUID, agentmodel.WithDescription(&agent.Description{
+		IdentifyingAttributes: map[string]string{
+			"service.instance.id": "stored-instance",
+			"service.name":        "collector",
+		},
+	}))
+
+	agentUC := &stubAgentUsecase{getResult: stored}
+	connUC := &stubConnectionUsecase{byInstanceUIDErr: agentport.ErrConnectionNotFound}
+
+	svc := newTestService(t, agentUC, connUC)
+
+	msg := &protobufs.AgentToServer{
+		AgentDescription: &protobufs.AgentDescription{
+			IdentifyingAttributes: []*protobufs.KeyValue{
+				{Key: "service.instance.id", Value: &protobufs.AnyValue{
+					Value: &protobufs.AnyValue_StringValue{StringValue: "different-instance"},
+				}},
+				{Key: "service.name", Value: &protobufs.AnyValue{
+					Value: &protobufs.AnyValue_StringValue{StringValue: "collector"},
+				}},
+			},
+		},
+	}
+
+	conflict := svc.detectInstanceUIDConflict(t.Context(), nil, instanceUID, msg)
+
+	require.NotNil(t, conflict)
+	assert.Equal(t, conflictReasonIdentifyingAttrs, conflict.reason)
+	assert.Same(t, stored, conflict.existingAgent)
+}
+
+func TestDetectInstanceUIDConflict_IdentifyingAttrsMatchNoConflict(t *testing.T) {
+	t.Parallel()
+
+	instanceUID := uuid.New()
+	stored := agentmodel.NewAgent(instanceUID, agentmodel.WithDescription(&agent.Description{
+		IdentifyingAttributes: map[string]string{"service.instance.id": "same"},
+	}))
+
+	agentUC := &stubAgentUsecase{getResult: stored}
+	connUC := &stubConnectionUsecase{byInstanceUIDErr: agentport.ErrConnectionNotFound}
+
+	svc := newTestService(t, agentUC, connUC)
+
+	msg := &protobufs.AgentToServer{
+		AgentDescription: &protobufs.AgentDescription{
+			IdentifyingAttributes: []*protobufs.KeyValue{
+				{Key: "service.instance.id", Value: &protobufs.AnyValue{
+					Value: &protobufs.AnyValue_StringValue{StringValue: "same"},
+				}},
+			},
+		},
+	}
+
+	conflict := svc.detectInstanceUIDConflict(t.Context(), nil, instanceUID, msg)
+
+	assert.Nil(t, conflict)
+}
+
+func TestDetectInstanceUIDConflict_LiveAndIdentifyingCombined(t *testing.T) {
+	t.Parallel()
+
+	instanceUID := uuid.New()
+	stored := agentmodel.NewAgent(instanceUID, agentmodel.WithDescription(&agent.Description{
+		IdentifyingAttributes: map[string]string{"service.instance.id": "stored"},
+	}))
+
+	other := aliveConn(t, uuid.New(), instanceUID)
+	current := aliveConn(t, uuid.New(), instanceUID)
+
+	agentUC := &stubAgentUsecase{getResult: stored}
+	connUC := &stubConnectionUsecase{byInstanceUID: other, byID: current}
+
+	svc := newTestService(t, agentUC, connUC)
+
+	msg := &protobufs.AgentToServer{
+		AgentDescription: &protobufs.AgentDescription{
+			IdentifyingAttributes: []*protobufs.KeyValue{
+				{Key: "service.instance.id", Value: &protobufs.AnyValue{
+					Value: &protobufs.AnyValue_StringValue{StringValue: "different"},
+				}},
+			},
+		},
+	}
+
+	conflict := svc.detectInstanceUIDConflict(t.Context(), nil, instanceUID, msg)
+
+	require.NotNil(t, conflict)
+	assert.Equal(t, conflictReasonLiveAndIdentifying, conflict.reason)
+}
+
+func TestRecordInstanceUIDConflict_AddsConditionAndSaves(t *testing.T) {
+	t.Parallel()
+
+	stored := agentmodel.NewAgent(uuid.New())
+	agentUC := &stubAgentUsecase{}
+	svc := newTestService(t, agentUC, &stubConnectionUsecase{})
+
+	oldUID := uuid.New()
+	newUID := uuid.New()
+
+	svc.recordInstanceUIDConflict(t.Context(), svc.logger,
+		&instanceUIDConflict{reason: conflictReasonIdentifyingAttrs, existingAgent: stored},
+		oldUID, newUID)
+
+	assert.Same(t, stored, agentUC.saved)
+	condition := stored.GetCondition(agentmodel.AgentConditionTypeInstanceUIDConflict)
+	require.NotNil(t, condition)
+	assert.Equal(t, agentmodel.AgentConditionStatusTrue, condition.Status)
+	assert.Contains(t, condition.Message, oldUID.String())
+	assert.Contains(t, condition.Message, newUID.String())
+	assert.Contains(t, condition.Message, conflictReasonIdentifyingAttrs)
+}
+
+func TestRecordInstanceUIDConflict_NoExistingAgentSkipsSave(t *testing.T) {
+	t.Parallel()
+
+	agentUC := &stubAgentUsecase{}
+	svc := newTestService(t, agentUC, &stubConnectionUsecase{})
+
+	svc.recordInstanceUIDConflict(t.Context(), svc.logger,
+		&instanceUIDConflict{reason: conflictReasonIdentifyingAttrs, existingAgent: nil},
+		uuid.New(), uuid.New())
+
+	assert.Nil(t, agentUC.saved)
+}
+
+func TestRecordInstanceUIDConflict_ReplacesPreviousAudit(t *testing.T) {
+	t.Parallel()
+
+	stored := agentmodel.NewAgent(uuid.New())
+	svc := newTestService(t, &stubAgentUsecase{}, &stubConnectionUsecase{})
+
+	firstNew := uuid.New()
+	secondNew := uuid.New()
+	oldUID := uuid.New()
+
+	svc.recordInstanceUIDConflict(t.Context(), svc.logger,
+		&instanceUIDConflict{reason: conflictReasonLiveAndIdentifying, existingAgent: stored},
+		oldUID, firstNew)
+	svc.recordInstanceUIDConflict(t.Context(), svc.logger,
+		&instanceUIDConflict{reason: conflictReasonIdentifyingAttrs, existingAgent: stored},
+		oldUID, secondNew)
+
+	condition := stored.GetCondition(agentmodel.AgentConditionTypeInstanceUIDConflict)
+	require.NotNil(t, condition)
+	assert.Contains(t, condition.Message, secondNew.String())
+	assert.Contains(t, condition.Message, conflictReasonIdentifyingAttrs)
+	assert.NotContains(t, condition.Message, firstNew.String())
+
+	count := 0
+
+	for _, c := range stored.Status.Conditions {
+		if c.Type == agentmodel.AgentConditionTypeInstanceUIDConflict {
+			count++
+		}
+	}
+
+	assert.Equal(t, 1, count, "should not duplicate the conflict condition")
+}
+
+var errTestTransient = errors.New("transient persistence failure")
+
+func TestDetectInstanceUIDConflict_AgentFetchTransientErrorIsNotConflict(t *testing.T) {
+	t.Parallel()
+
+	agentUC := &stubAgentUsecase{getErr: errTestTransient}
+	connUC := &stubConnectionUsecase{byInstanceUIDErr: agentport.ErrConnectionNotFound}
+
+	svc := newTestService(t, agentUC, connUC)
+
+	msg := &protobufs.AgentToServer{
+		AgentDescription: &protobufs.AgentDescription{
+			IdentifyingAttributes: []*protobufs.KeyValue{
+				{Key: "service.instance.id", Value: &protobufs.AnyValue{
+					Value: &protobufs.AnyValue_StringValue{StringValue: "x"},
+				}},
+			},
+		},
+	}
+
+	conflict := svc.detectInstanceUIDConflict(t.Context(), nil, uuid.New(), msg)
+
+	assert.Nil(t, conflict)
+}
+
+func TestHandleInstanceUIDConflict_ReturnsRenewalAndAudits(t *testing.T) {
+	t.Parallel()
+
+	instanceUID := uuid.New()
+
+	stored := agentmodel.NewAgent(instanceUID, agentmodel.WithDescription(&agent.Description{
+		IdentifyingAttributes: map[string]string{serviceInstanceIDAttribute: "stored"},
+	}))
+
+	agentUC := &stubAgentUsecase{getResult: stored}
+	connUC := &stubConnectionUsecase{byInstanceUIDErr: agentport.ErrConnectionNotFound}
+
+	svc := newTestService(t, agentUC, connUC)
+
+	msg := &protobufs.AgentToServer{
+		AgentDescription: &protobufs.AgentDescription{
+			IdentifyingAttributes: []*protobufs.KeyValue{
+				{Key: serviceInstanceIDAttribute, Value: &protobufs.AnyValue{
+					Value: &protobufs.AnyValue_StringValue{StringValue: "different"},
+				}},
+			},
+		},
+	}
+
+	response := svc.handleInstanceUIDConflict(t.Context(), svc.logger, nil, instanceUID, msg)
+
+	require.NotNil(t, response)
+	assert.Equal(t, instanceUID[:], response.GetInstanceUid())
+	require.NotNil(t, response.GetAgentIdentification())
+	newUIDBytes := response.GetAgentIdentification().GetNewInstanceUid()
+	require.Len(t, newUIDBytes, 16)
+	newUID, err := uuid.FromBytes(newUIDBytes)
+	require.NoError(t, err)
+	assert.NotEqual(t, instanceUID, newUID)
+
+	assert.Same(t, stored, agentUC.saved)
+	cond := stored.GetCondition(agentmodel.AgentConditionTypeInstanceUIDConflict)
+	require.NotNil(t, cond)
+	assert.Contains(t, cond.Message, newUID.String())
+}
+
+func TestHandleInstanceUIDConflict_NoConflictReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	agentUC := &stubAgentUsecase{getErr: domainport.ErrResourceNotExist}
+	connUC := &stubConnectionUsecase{byInstanceUIDErr: agentport.ErrConnectionNotFound}
+
+	svc := newTestService(t, agentUC, connUC)
+
+	response := svc.handleInstanceUIDConflict(t.Context(), svc.logger, nil, uuid.New(), &protobufs.AgentToServer{})
+
+	assert.Nil(t, response)
+}

--- a/internal/application/service/opamp/opamp.go
+++ b/internal/application/service/opamp/opamp.go
@@ -163,18 +163,11 @@ func (s *Service) OnMessage(
 	)
 	logger.Info("start")
 
-	connection, err := s.injectInstanceUIDToConnection(ctx, conn, instanceUID)
-	if err != nil {
-		logger.Error("failed to inject instanceUID to connection", slog.String("error", err.Error()))
-		// even if injecting instanceUID fails, proceed to process the message
+	if response := s.handleInstanceUIDConflict(ctx, logger, conn, instanceUID, message); response != nil {
+		return response
 	}
 
-	if connection != nil {
-		logger = logger.With(
-			slog.String("connectionUID", connection.UID.String()),
-			slog.String("connectionType", connection.Type.String()),
-		)
-	}
+	connection, logger := s.prepareConnection(ctx, logger, conn, instanceUID)
 
 	currentServer, err := s.serverIdentityProvider.CurrentServer(ctx)
 	if err != nil {
@@ -367,6 +360,30 @@ func (s *Service) cleanUpConnection(ctx context.Context, conn types.Connection) 
 	}
 
 	return nil
+}
+
+// prepareConnection resolves the agentmodel.Connection for the incoming network connection,
+// injects the instanceUID, and decorates the logger with connection-scoped fields. Errors
+// are logged and the caller is expected to continue without the connection if it is nil.
+func (s *Service) prepareConnection(
+	ctx context.Context,
+	logger *slog.Logger,
+	conn types.Connection,
+	instanceUID uuid.UUID,
+) (*agentmodel.Connection, *slog.Logger) {
+	connection, err := s.injectInstanceUIDToConnection(ctx, conn, instanceUID)
+	if err != nil {
+		logger.Error("failed to inject instanceUID to connection", slog.String("error", err.Error()))
+	}
+
+	if connection != nil {
+		logger = logger.With(
+			slog.String("connectionUID", connection.UID.String()),
+			slog.String("connectionType", connection.Type.String()),
+		)
+	}
+
+	return connection, logger
 }
 
 func (s *Service) injectInstanceUIDToConnection(

--- a/internal/domain/agent/model/agent.go
+++ b/internal/domain/agent/model/agent.go
@@ -350,6 +350,9 @@ const (
 	AgentConditionTypeConfigured AgentConditionType = "Configured"
 	// AgentConditionTypeRegistered represents the condition when the agent has been registered.
 	AgentConditionTypeRegistered AgentConditionType = "Registered"
+	// AgentConditionTypeInstanceUIDConflict records that another agent attempted to use this
+	// agent's instanceUID and was redirected to a freshly issued one.
+	AgentConditionTypeInstanceUIDConflict AgentConditionType = "InstanceUIDConflict"
 )
 
 // AgentConditionStatus represents the status of an agent condition.
@@ -1139,6 +1142,36 @@ func (a *Agent) MarkConnected(triggeredBy string) {
 func (a *Agent) MarkDisconnected(triggeredBy string) {
 	a.Status.Connected = false
 	a.SetCondition(AgentConditionTypeConnected, AgentConditionStatusFalse, triggeredBy, "Agent disconnected")
+}
+
+// RecordInstanceUIDConflict audits an InstanceUIDConflict event on the agent, always
+// replacing any prior conflict condition so the recorded message reflects the most recent
+// occurrence (SetCondition would skip refreshes when the status is unchanged).
+func (a *Agent) RecordInstanceUIDConflict(
+	now time.Time,
+	oldInstanceUID, newInstanceUID uuid.UUID,
+	conflictReason, triggeredBy string,
+) {
+	cond := AgentCondition{
+		Type:               AgentConditionTypeInstanceUIDConflict,
+		LastTransitionTime: now,
+		Status:             AgentConditionStatusTrue,
+		Reason:             triggeredBy,
+		Message: fmt.Sprintf(
+			"another agent attempted to use instanceUID %s; redirected to %s (reason: %s)",
+			oldInstanceUID, newInstanceUID, conflictReason,
+		),
+	}
+
+	for i, existing := range a.Status.Conditions {
+		if existing.Type == cond.Type {
+			a.Status.Conditions[i] = cond
+
+			return
+		}
+	}
+
+	a.Status.Conditions = append(a.Status.Conditions, cond)
 }
 
 // NewInstanceUID returns the new instance UID to inform the agent.


### PR DESCRIPTION
## Summary
- Detect instanceUid conflicts on OpAMP `OnMessage` and respond with `ServerToAgent.AgentIdentification.NewInstanceUid` so the new arrival switches to a freshly issued UUIDv7.
- A conflict requires the stored agent's identifying attributes (`service.instance.id` when present) to differ from the incoming message — a live-connection mismatch alone is **not** a conflict, since it routinely happens during WebSocket reconnects before async `OnConnectionClose` cleanup. Live mismatch combined with attrs mismatch escalates the audit reason.
- Audit on the rightful owner via a new `AgentConditionTypeInstanceUIDConflict` condition that always replaces the prior occurrence (so repeat conflicts surface the latest renewal), plus a structured warn log.

Closes #246

## Test plan
- [x] `go test -short ./internal/application/service/opamp/ ./internal/domain/agent/...` — 14 new tests cover: nil/match/mismatch attrs, live-connection-alone is not a conflict, live + attrs combined, transient agent-fetch error, audit replacement semantics, no-existing-agent skip, renewal response shape, UUIDv7 generation, and the `handleInstanceUIDConflict` orchestration happy/no-conflict paths.
- [x] `make lint` — clean (only the pre-existing `pkg/formatter/formatter.go:107` warning, untouched).
- [ ] Manual: run two OpAMP agents with the same hard-coded instanceUid but different `service.instance.id` and confirm the second agent receives `new_instance_uid` and reconnects with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)