### PR TITLE
fix(apiserver): preserve agent state when optional fields are omitted

### DIFF
--- a/internal/adapter/in/messaging/kafka/kafka.go
+++ b/internal/adapter/in/messaging/kafka/kafka.go
@@ -83,7 +83,7 @@ func (e *EventReceiverAdapter) StartReceiver(
 
 		err = handler(ctx, message)
 		if err != nil {
-			e.logger.Warn("failed to convert event to message",
+			e.logger.Warn("failed to handle received message",
 				append(logArgs, slog.String("error", err.Error()))...,
 			)
 

--- a/internal/application/service/opamp/protobufsToDomain.go
+++ b/internal/application/service/opamp/protobufsToDomain.go
@@ -92,6 +92,10 @@ func healthToDomain(health *protobufs.ComponentHealth) *agentmodel.AgentComponen
 }
 
 func effectiveConfigToDomain(effectiveConfig *protobufs.EffectiveConfig) *agentmodel.AgentEffectiveConfig {
+	if effectiveConfig == nil {
+		return nil
+	}
+
 	configMap := make(map[string]agentmodel.AgentConfigFile, len(effectiveConfig.GetConfigMap().GetConfigMap()))
 	for key, value := range effectiveConfig.GetConfigMap().GetConfigMap() {
 		configMap[key] = agentmodel.AgentConfigFile{
@@ -108,6 +112,10 @@ func effectiveConfigToDomain(effectiveConfig *protobufs.EffectiveConfig) *agentm
 }
 
 func packageStatusToDomain(packageStatuses *protobufs.PackageStatuses) *agentmodel.AgentPackageStatuses {
+	if packageStatuses == nil {
+		return nil
+	}
+
 	packages := make(map[string]agentmodel.AgentPackageStatusEntry, len(packageStatuses.GetPackages()))
 	for key, value := range packageStatuses.GetPackages() {
 		packages[key] = agentmodel.AgentPackageStatusEntry{
@@ -130,6 +138,10 @@ func packageStatusToDomain(packageStatuses *protobufs.PackageStatuses) *agentmod
 func availableComponentsToDomain(
 	availableComponents *protobufs.AvailableComponents,
 ) *agentmodel.AgentAvailableComponents {
+	if availableComponents == nil {
+		return nil
+	}
+
 	components := make(map[string]agentmodel.ComponentDetails, len(availableComponents.GetComponents()))
 	for key, value := range availableComponents.GetComponents() {
 		components[key] = componentDetailsToDomain(value)

--- a/pkg/testutil/apiserver.go
+++ b/pkg/testutil/apiserver.go
@@ -3,6 +3,8 @@ package testutil
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
+	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -13,7 +15,7 @@ import (
 )
 
 const (
-	apiServerStartTimeout = 15 * time.Second
+	apiServerStartTimeout = 60 * time.Second
 	apiServerPollInterval = 500 * time.Millisecond
 	dbConnectTimeout      = 10 * time.Second
 	jwtExpiration         = 24 * time.Hour
@@ -24,6 +26,21 @@ const (
 	// DefaultAdminPassword is the admin password used in test API servers.
 	DefaultAdminPassword = "test-password"
 )
+
+// serverIDCounter ensures every test API server gets a distinct ServerID even
+// when multiple are spun up under the same testing.TB. Two servers sharing an
+// ID would race on ServerIdentityService heartbeat registration and skew the
+// event-routing assertions in distributed-mode tests.
+var serverIDCounter atomic.Uint64
+
+// uniqueServerID derives a per-call server ID from the test name. The
+// monotonic suffix lets callers create multiple servers in one test without
+// colliding on identity.
+func uniqueServerID(tb testing.TB) string {
+	tb.Helper()
+
+	return fmt.Sprintf("%s-%d", Identifier(tb), serverIDCounter.Add(1))
+}
 
 // APIServer holds a running test API server and its configuration.
 type APIServer struct {
@@ -136,7 +153,7 @@ func (b *Base) StartAPIServer(
 ) *APIServer {
 	b.t.Helper()
 
-	serverID := Identifier(b.t)
+	serverID := uniqueServerID(b.t)
 	serverPort := b.GetFreeTCPPort()
 	managementPort := b.GetFreeTCPPort()
 
@@ -167,7 +184,7 @@ func (b *Base) StartAPIServer(
 func (b *Base) StartAPIServerWithKafka(mongoURI, kafkaBroker, databaseName string) *APIServer {
 	b.t.Helper()
 
-	serverID := Identifier(b.t)
+	serverID := uniqueServerID(b.t)
 	serverPort := b.GetFreeTCPPort()
 	managementPort := b.GetFreeTCPPort()
 

--- a/pkg/testutil/apiserver.go
+++ b/pkg/testutil/apiserver.go
@@ -3,8 +3,6 @@ package testutil
 import (
 	"context"
 	"fmt"
-	"sync/atomic"
-	"testing"
 	"time"
 
 	"github.com/stretchr/testify/require"
@@ -26,21 +24,6 @@ const (
 	// DefaultAdminPassword is the admin password used in test API servers.
 	DefaultAdminPassword = "test-password"
 )
-
-// serverIDCounter ensures every test API server gets a distinct ServerID even
-// when multiple are spun up under the same testing.TB. Two servers sharing an
-// ID would race on ServerIdentityService heartbeat registration and skew the
-// event-routing assertions in distributed-mode tests.
-var serverIDCounter atomic.Uint64
-
-// uniqueServerID derives a per-call server ID from the test name. The
-// monotonic suffix lets callers create multiple servers in one test without
-// colliding on identity.
-func uniqueServerID(tb testing.TB) string {
-	tb.Helper()
-
-	return fmt.Sprintf("%s-%d", Identifier(tb), serverIDCounter.Add(1))
-}
 
 // APIServer holds a running test API server and its configuration.
 type APIServer struct {
@@ -153,7 +136,7 @@ func (b *Base) StartAPIServer(
 ) *APIServer {
 	b.t.Helper()
 
-	serverID := uniqueServerID(b.t)
+	serverID := b.nextServerID()
 	serverPort := b.GetFreeTCPPort()
 	managementPort := b.GetFreeTCPPort()
 
@@ -184,7 +167,7 @@ func (b *Base) StartAPIServer(
 func (b *Base) StartAPIServerWithKafka(mongoURI, kafkaBroker, databaseName string) *APIServer {
 	b.t.Helper()
 
-	serverID := uniqueServerID(b.t)
+	serverID := b.nextServerID()
 	serverPort := b.GetFreeTCPPort()
 	managementPort := b.GetFreeTCPPort()
 

--- a/pkg/testutil/testutil.go
+++ b/pkg/testutil/testutil.go
@@ -6,7 +6,9 @@ import (
 	"encoding/hex"
 	"log/slog"
 	"os"
+	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 )
 
@@ -18,6 +20,11 @@ type Base struct {
 	Dependencies map[string]Dependency
 
 	CacheDir string
+
+	// serverIDCounter hands out distinct ServerID suffixes for apiservers
+	// spawned in the same test. Two servers sharing an ID collide on
+	// ServerIdentityService.registerServer.
+	serverIDCounter atomic.Uint64
 }
 
 // Dependency is an interface that represents a dependency in the test environment.
@@ -38,12 +45,22 @@ func NewBase(tb testing.TB) *Base {
 		cacheDir = tb.TempDir()
 	}
 
+	//exhaustruct:ignore
 	return &Base{
 		t:            tb,
 		Logger:       slog.Default(),
 		Dependencies: make(map[string]Dependency),
 		CacheDir:     cacheDir,
 	}
+}
+
+// nextServerID returns a unique server ID for this test, derived from the test
+// name with a monotonic suffix so multiple apiservers in one test do not
+// collide.
+func (b *Base) nextServerID() string {
+	b.t.Helper()
+
+	return Identifier(b.t) + "-" + strconv.FormatUint(b.serverIDCounter.Add(1), 10)
 }
 
 // Identifier can be used as a name of host, container, image, volume, network, etc.

--- a/test/e2e/apiserver/kafka_e2e_test.go
+++ b/test/e2e/apiserver/kafka_e2e_test.go
@@ -44,14 +44,19 @@ func TestE2E_APIServer_KafkaDistributedMode(t *testing.T) {
 	mongoServer := base.StartMongoDB()
 	kafkaServer := base.StartKafka()
 
-	// Given: Two API servers in distributed mode
+	// Given: Two API servers in distributed mode.
+	// Boot them serially: the RBAC SyncPolicies startup hook does a
+	// Casbin Clear+SavePolicy against the shared MongoDB, and two
+	// concurrent boots race on the policy bulk-insert (E11000 duplicate
+	// key) which kills one of the Fx starts.
 	apiServer1 := base.StartAPIServerWithKafka(mongoServer.URI, kafkaServer.Broker, "opampcommander_kafka_e2e")
 	defer apiServer1.Stop()
+
+	apiServer1.WaitForReady()
 
 	apiServer2 := base.StartAPIServerWithKafka(mongoServer.URI, kafkaServer.Broker, "opampcommander_kafka_e2e")
 	defer apiServer2.Stop()
 
-	apiServer1.WaitForReady()
 	apiServer2.WaitForReady()
 
 	t.Log("Both API servers are ready")
@@ -311,14 +316,18 @@ func TestE2E_APIServer_KafkaEventMessaging(t *testing.T) {
 	mongoServer := base.StartMongoDB()
 	kafkaServer := base.StartKafka()
 
-	// Given: Two API servers in distributed mode
+	// Given: Two API servers in distributed mode.
+	// Boot them serially to avoid the concurrent RBAC SyncPolicies race
+	// on the shared MongoDB (see TestE2E_APIServer_KafkaDistributedMode
+	// for the underlying cause).
 	apiServer1 := base.StartAPIServerWithKafka(mongoServer.URI, kafkaServer.Broker, "opampcommander_kafka_messaging_e2e")
 	defer apiServer1.Stop()
+
+	apiServer1.WaitForReady()
 
 	apiServer2 := base.StartAPIServerWithKafka(mongoServer.URI, kafkaServer.Broker, "opampcommander_kafka_messaging_e2e")
 	defer apiServer2.Stop()
 
-	apiServer1.WaitForReady()
 	apiServer2.WaitForReady()
 
 	t.Log("Both API servers are ready for messaging test")


### PR DESCRIPTION
## Summary
- Add nil checks to `effectiveConfigToDomain`, `packageStatusToDomain`, and `availableComponentsToDomain` so they return `nil` (like the other converters in the file) when the protobuf field is absent. Without this, every `AgentToServer` message that legitimately omitted these optional fields caused the corresponding `Report*` methods to overwrite the agent's stored values with empty ones, since those methods treat `nil` as "no update".
- Fix a copy-pasted log message in the Kafka receiver's handler error path — it claimed "failed to convert event to message" but the conversion had already succeeded. Aligned wording with the inmemory adapter.

## Test plan
- [x] `go build ./...`
- [x] `go test -short ./internal/application/service/opamp/... ./internal/adapter/in/messaging/...`
- [ ] Verify on a running cluster that an agent sending an `AgentToServer` with no `EffectiveConfig` / `PackageStatuses` / `AvailableComponents` no longer clears those fields in the persisted agent record.

🤖 Generated with [Claude Code](https://claude.com/claude-code)