### PR TITLE
feat(web): containerize for production deployment

### DIFF
--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,17 @@
+node_modules
+.next
+.turbo
+out
+build
+coverage
+.env
+.env.local
+.env.*.local
+README.md
+.git
+.gitignore
+.github
+.vscode
+*.log
+npm-debug.log*
+.DS_Store

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1.7
+
+# Multi-stage build for the Next.js standalone output. Final image carries
+# only Node.js + the prebuilt server, no source / no npm install.
+
+ARG NODE_VERSION=20-alpine
+
+# --- deps: install only what the build needs ---------------------------------
+FROM node:${NODE_VERSION} AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+# Build-time toolchains for native deps. None today, but keeps it stable if
+# a transitive dep needs node-gyp later.
+RUN apk add --no-cache libc6-compat && npm ci --no-audit --no-fund
+
+# --- builder: produce .next/standalone ---------------------------------------
+FROM node:${NODE_VERSION} AS builder
+WORKDIR /app
+ENV NEXT_TELEMETRY_DISABLED=1
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+# --- runtime: minimal, non-root ---------------------------------------------
+FROM node:${NODE_VERSION} AS runner
+WORKDIR /app
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    PORT=3000 \
+    HOSTNAME=0.0.0.0
+
+# Non-root user for runtime
+RUN addgroup --system --gid 1001 nodejs \
+ && adduser  --system --uid 1001 --ingroup nodejs nextjs
+
+# Standalone server bundle. The Next.js build emits a self-contained
+# `server.js` plus a trimmed `node_modules`.
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+
+USER nextjs
+EXPOSE 3000
+
+# The server reads OPAMP_API_URL at request time (server-side proxy route),
+# so it can be overridden per environment without rebuilding the image.
+CMD ["node", "server.js"]

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // `standalone` produces a self-contained server bundle in
+  // `.next/standalone/`. The Docker image only needs Node.js + that
+  // directory + the static assets — no npm install at runtime.
+  output: 'standalone',
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

Adds the build artifacts needed to ship the Next.js dashboard as a container image. **Scope is intentionally just "image becomes buildable"** — a follow-up PR wires the release workflow and the minuk-cluster deploy.

## Changes

- `web/next.config.ts` — `output: 'standalone'` so `next build` emits a self-contained `server.js` + trimmed `node_modules` bundle.
- `web/Dockerfile` — three-stage (deps → build → runtime), non-root `nextjs` user, port 3000. Reads `OPAMP_API_URL` at request time, so the same image works in any environment.
- `web/.dockerignore` — trim build context.

## Follow-ups (split out so reviews stay focused)

1. `feat(web): auto-deploy alongside apiserver` — extends `release.yaml` to buildx + push `ghcr.io/minuk-dev/opampcommander-web:${VERSION}` multi-arch and bumps the tag in minuk-cluster overlays.
2. `feat(opampcommander): add web manifests to minuk-cluster` (minuk-cluster#23) — the actual k8s manifests (Deployment / Service / Ingress) for alpha and alpha-ha.

## Test plan

- [x] `cd web && docker build -t local/opampcommander-web:test .` succeeds locally
- [x] `docker run -p 3000:3000 -e OPAMP_API_URL=... local/opampcommander-web:test` serves the dashboard
- [ ] After this PR lands, the follow-up release-workflow PR will start pushing the image to ghcr

🤖 Generated with [Claude Code](https://claude.com/claude-code)