### PR TITLE
ci(web): build + push web image, auto-deploy to minuk-cluster

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,6 +75,22 @@ jobs:
           echo "Creating multi-arch manifest: $MANIFEST_TAG"
           docker buildx imagetools create -t "$MANIFEST_TAG" "$AMD64_IMAGE" "$ARM64_IMAGE"
 
+      # Build the web image with the same VERSION goreleaser produced so the
+      # apiserver and the web stay in lockstep and minuk-cluster bumps both
+      # tags atomically.
+      - name: Build and push web image (multi-arch)
+        if: startsWith(github.ref, 'refs/heads/')
+        uses: docker/build-push-action@v6
+        with:
+          context: ./web
+          file: ./web/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ghcr.io/minuk-dev/opampcommander-web:${{ env.VERSION }}
+          provenance: false
+          cache-from: type=gha,scope=opampcommander-web
+          cache-to: type=gha,mode=max,scope=opampcommander-web
+
       - name: Setup SSH agent for minuk-cluster deploy
         if: startsWith(github.ref, 'refs/heads/')
         uses: webfactory/ssh-agent@v0.9.0
@@ -88,9 +104,17 @@ jobs:
           cd /tmp/minuk-cluster
 
           overlays=(alpha alpha-ha)
+          # Bump apiserver and web tags together. The web entry is only
+          # updated if present, so this workflow can land before the
+          # minuk-cluster side adds the web manifest entry.
           for overlay in "${overlays[@]}"; do
+            kustomization="argocd/apps/opampcommander/overlays/${overlay}/kustomization.yaml"
             yq '(.images[] | select(.name == "ghcr.io/minuk-dev/opampcommander")).newTag = strenv(VERSION)' \
-              -i "argocd/apps/opampcommander/overlays/${overlay}/kustomization.yaml"
+              -i "${kustomization}"
+            if yq -e '.images[] | select(.name == "ghcr.io/minuk-dev/opampcommander-web")' "${kustomization}" >/dev/null 2>&1; then
+              yq '(.images[] | select(.name == "ghcr.io/minuk-dev/opampcommander-web")).newTag = strenv(VERSION)' \
+                -i "${kustomization}"
+            fi
           done
 
           git config user.email "github-actions[bot]@users.noreply.github.com"

--- a/web/.dockerignore
+++ b/web/.dockerignore
@@ -1,0 +1,17 @@
+node_modules
+.next
+.turbo
+out
+build
+coverage
+.env
+.env.local
+.env.*.local
+README.md
+.git
+.gitignore
+.github
+.vscode
+*.log
+npm-debug.log*
+.DS_Store

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -1,0 +1,47 @@
+# syntax=docker/dockerfile:1.7
+
+# Multi-stage build for the Next.js standalone output. Final image carries
+# only Node.js + the prebuilt server, no source / no npm install.
+
+ARG NODE_VERSION=20-alpine
+
+# --- deps: install only what the build needs ---------------------------------
+FROM node:${NODE_VERSION} AS deps
+WORKDIR /app
+COPY package.json package-lock.json ./
+# Build-time toolchains for native deps. None today, but keeps it stable if
+# a transitive dep needs node-gyp later.
+RUN apk add --no-cache libc6-compat && npm ci --no-audit --no-fund
+
+# --- builder: produce .next/standalone ---------------------------------------
+FROM node:${NODE_VERSION} AS builder
+WORKDIR /app
+ENV NEXT_TELEMETRY_DISABLED=1
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+RUN npm run build
+
+# --- runtime: minimal, non-root ---------------------------------------------
+FROM node:${NODE_VERSION} AS runner
+WORKDIR /app
+ENV NODE_ENV=production \
+    NEXT_TELEMETRY_DISABLED=1 \
+    PORT=3000 \
+    HOSTNAME=0.0.0.0
+
+# Non-root user for runtime
+RUN addgroup --system --gid 1001 nodejs \
+ && adduser  --system --uid 1001 --ingroup nodejs nextjs
+
+# Standalone server bundle. The Next.js build emits a self-contained
+# `server.js` plus a trimmed `node_modules`.
+COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
+COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
+
+USER nextjs
+EXPOSE 3000
+
+# The server reads OPAMP_API_URL at request time (server-side proxy route),
+# so it can be overridden per environment without rebuilding the image.
+CMD ["node", "server.js"]

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -1,7 +1,10 @@
 import type { NextConfig } from 'next';
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  // `standalone` produces a self-contained server bundle in
+  // `.next/standalone/`. The Docker image only needs Node.js + that
+  // directory + the static assets — no npm install at runtime.
+  output: 'standalone',
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary

Wires the auto-deploy half of the web rollout. **Stacked on top of #367** (web Dockerfile) — base is `feat/web-deploy` so the diff stays focused. GitHub will re-target this PR to `main` once #367 merges.

After this lands, every push to main:

1. **goreleaser** keeps building and pushing the apiserver image + producing `VERSION`.
2. A new **buildx step** builds the web image multi-arch (linux/amd64 + linux/arm64) and pushes `ghcr.io/minuk-dev/opampcommander-web:\${VERSION}`. GHA layer cache is scoped to the web image so reruns are quick.
3. The existing **minuk-cluster deploy step** now bumps the apiserver *and* web tags in `overlays/{alpha,alpha-ha}/kustomization.yaml` in one commit, so ArgoCD rolls both at once.

The web tag bump is conditional on the entry already existing in the kustomization, so this workflow is harmless until the minuk-cluster companion PR (minuk-cluster#23) adds the entry.

## Changes

- `.github/workflows/release.yaml`
  - new `docker/build-push-action@v6` step for the web image, multi-arch
  - existing deploy step extended to also bump `opampcommander-web` newTag, gated on existence

## Companion

- minuk-cluster#23 — adds `base/web.yaml` + overlay wiring so the bumped image has somewhere to deploy.

## Merge order

1. opampcommander#367 (Dockerfile)
2. This PR (auto-deploy)
3. minuk-cluster#23 (manifests)

## Test plan

- [ ] After merge, the first push to main builds and pushes `ghcr.io/minuk-dev/opampcommander-web:0.1.x-SNAPSHOT-<sha>` (multi-arch)
- [ ] minuk-cluster main receives a single commit bumping both apiserver and web tags
- [ ] ArgoCD reconciles `opampcommander-alpha` (after minuk-cluster#23) and the web Pod starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)