### PR TITLE
fix(apiserver): allow configured non-loopback OAuth redirect hosts

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -66,6 +66,7 @@ linters:
             - github.com/spf13/cobra
             - github.com/spf13/viper
             - github.com/spf13/afero
+            - github.com/go-viper/mapstructure/v2
             - go.uber.org/fx
             - github.com/gin-gonic/gin
             # Basic Libraries

--- a/configs/apiserver/config.sample.yaml
+++ b/configs/apiserver/config.sample.yaml
@@ -39,6 +39,12 @@ auth:
     clientId: "your_client_id"
     clientSecret: "your_client_secret"
     redirectUri: "http://localhost:8080/auth/callback"
+    # Additional hosts the /api/v1/auth/github/authcode endpoint will accept
+    # as redirect_uri targets, on top of the always-allowed loopback hosts
+    # (127.0.0.1, ::1, localhost). Set this to the deployed web UI host(s)
+    # so browser logins from the dashboard work end-to-end.
+    allowedRedirectHosts:
+      - opampcommander.minuk.dev
     state: # to prevent CSRF attacks
       mode: jwt
       jwt:

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/cloudevents/sdk-go/v2 v2.16.2
 	github.com/gin-gonic/gin v1.12.0
 	github.com/go-resty/resty/v2 v2.17.2
+	github.com/go-viper/mapstructure/v2 v2.4.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/google/go-github/v72 v72.0.0
 	github.com/google/uuid v1.6.0
@@ -82,7 +83,6 @@ require (
 	github.com/go-openapi/jsonreference v0.20.2 // indirect
 	github.com/go-openapi/spec v0.20.9 // indirect
 	github.com/go-openapi/swag v0.23.0 // indirect
-	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/goccy/go-yaml v1.19.2 // indirect
 	github.com/google/go-querystring v1.1.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.28.0 // indirect

--- a/internal/adapter/in/http/auth/github/controller.go
+++ b/internal/adapter/in/http/auth/github/controller.go
@@ -8,7 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
-	"slices"
+	"strings"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -196,10 +196,15 @@ var errDisallowedHost = errors.New(
 		"or a configured allowed host",
 )
 
+// errEmptyHost indicates the redirect_uri parses to no host (e.g. "http:///x").
+var errEmptyHost = errors.New("redirect_uri must include a host")
+
 // ValidateRedirect ensures the redirect URI is safe to redirect tokens to.
 // Loopback hosts (127.0.0.1, ::1, localhost) are always accepted so the CLI
 // loopback flow keeps working; additional hosts can be allowlisted via the
 // auth.oauth2.allowedRedirectHosts config (e.g. a deployed web UI host).
+// Comparison is case-insensitive because DNS hostnames are case-insensitive
+// and operators should not get tripped up by browser-vs-config casing.
 // Exported so the validation can be reused (and tested in black-box).
 func ValidateRedirect(rawURL string, allowedHosts []string) error {
 	parsed, err := url.Parse(rawURL)
@@ -211,14 +216,24 @@ func ValidateRedirect(rawURL string, allowedHosts []string) error {
 		return fmt.Errorf("%w: got %q", errInvalidScheme, parsed.Scheme)
 	}
 
-	host := parsed.Hostname()
+	host := strings.ToLower(parsed.Hostname())
+	if host == "" {
+		return errEmptyHost
+	}
+
 	switch host {
 	case "127.0.0.1", "::1", "localhost":
 		return nil
 	}
 
-	if slices.Contains(allowedHosts, host) {
-		return nil
+	for _, allowed := range allowedHosts {
+		// Normalize on both sides and skip blank entries so a config like
+		// `allowedRedirectHosts: ["", "foo.dev"]` doesn't accidentally
+		// accept the empty-host edge case after lower-casing.
+		allowed = strings.TrimSpace(strings.ToLower(allowed))
+		if allowed != "" && allowed == host {
+			return nil
+		}
 	}
 
 	return fmt.Errorf("%w: got %q", errDisallowedHost, host)

--- a/internal/adapter/in/http/auth/github/controller.go
+++ b/internal/adapter/in/http/auth/github/controller.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/url"
+	"slices"
 	"time"
 
 	"github.com/gin-gonic/gin"
@@ -160,7 +161,7 @@ func (c *Controller) AuthCodeURL(ctx *gin.Context) {
 		return
 	}
 
-	err := validateLoopbackRedirect(redirectURI)
+	err := ValidateRedirect(redirectURI, c.service.AllowedRedirectHosts())
 	if err != nil {
 		ctx.JSON(http.StatusBadRequest, gin.H{
 			"error":   "invalid redirect_uri",
@@ -188,12 +189,19 @@ func (c *Controller) AuthCodeURL(ctx *gin.Context) {
 // errInvalidScheme indicates the redirect_uri scheme is not http/https.
 var errInvalidScheme = errors.New("redirect_uri scheme must be http or https")
 
-// errNonLoopbackHost indicates the redirect_uri host is not a loopback address.
-var errNonLoopbackHost = errors.New("redirect_uri host must be a loopback address (127.0.0.1, ::1, localhost)")
+// errDisallowedHost indicates the redirect_uri host is neither a loopback
+// address nor a configured allowlist entry.
+var errDisallowedHost = errors.New(
+	"redirect_uri host must be a loopback address (127.0.0.1, ::1, localhost) " +
+		"or a configured allowed host",
+)
 
-// validateLoopbackRedirect ensures the redirect URI points to a loopback host.
-// Only loopback hosts are accepted to avoid serving as an open redirect for token leakage.
-func validateLoopbackRedirect(rawURL string) error {
+// ValidateRedirect ensures the redirect URI is safe to redirect tokens to.
+// Loopback hosts (127.0.0.1, ::1, localhost) are always accepted so the CLI
+// loopback flow keeps working; additional hosts can be allowlisted via the
+// auth.oauth2.allowedRedirectHosts config (e.g. a deployed web UI host).
+// Exported so the validation can be reused (and tested in black-box).
+func ValidateRedirect(rawURL string, allowedHosts []string) error {
 	parsed, err := url.Parse(rawURL)
 	if err != nil {
 		return fmt.Errorf("parse: %w", err)
@@ -207,9 +215,13 @@ func validateLoopbackRedirect(rawURL string) error {
 	switch host {
 	case "127.0.0.1", "::1", "localhost":
 		return nil
-	default:
-		return fmt.Errorf("%w: got %q", errNonLoopbackHost, host)
 	}
+
+	if slices.Contains(allowedHosts, host) {
+		return nil
+	}
+
+	return fmt.Errorf("%w: got %q", errDisallowedHost, host)
 }
 
 // Callback handles the callback from GitHub after the user has authenticated.

--- a/internal/adapter/in/http/auth/github/controller_test.go
+++ b/internal/adapter/in/http/auth/github/controller_test.go
@@ -47,6 +47,32 @@ func TestValidateRedirect(t *testing.T) {
 			[]string{"opampcommander-alpha.minuk.dev"},
 			false,
 		},
+
+		// Hostnames are case-insensitive: uppercase URL host should still
+		// match a lower-case allowlist entry (and vice versa).
+		{
+			"uppercase URL host matches lower allowlist",
+			"https://OPAMPCOMMANDER-ALPHA.MINUK.DEV/cb",
+			[]string{"opampcommander-alpha.minuk.dev"},
+			false,
+		},
+		{
+			"mixed-case allowlist still matches",
+			"https://opampcommander-alpha.minuk.dev/cb",
+			[]string{"OpAmPcOmMaNdEr-AlPhA.minuk.dev"},
+			false,
+		},
+
+		// Empty hostname (e.g. `http:///path`) must never sneak through,
+		// even if the allowlist happens to contain an empty entry.
+		{"empty host bare", "http:///path", nil, true},
+		{"empty host bare with blank allowlist", "http:///path", []string{""}, true},
+		{
+			"blank allowlist entries are ignored",
+			"https://opampcommander-alpha.minuk.dev/cb",
+			[]string{"", "   ", "opampcommander-alpha.minuk.dev"},
+			false,
+		},
 	}
 
 	for _, tc := range cases {

--- a/internal/adapter/in/http/auth/github/controller_test.go
+++ b/internal/adapter/in/http/auth/github/controller_test.go
@@ -1,0 +1,65 @@
+package github_test
+
+import (
+	"testing"
+
+	github "github.com/minuk-dev/opampcommander/internal/adapter/in/http/auth/github"
+)
+
+func TestValidateRedirect(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		rawURL  string
+		allowed []string
+		wantErr bool
+	}{
+		// Loopback hosts are always accepted, regardless of allowlist.
+		{"loopback IPv4", "http://127.0.0.1:3000/cb", nil, false},
+		{"loopback IPv6", "http://[::1]:3000/cb", nil, false},
+		{"localhost", "http://localhost:3000/cb", nil, false},
+		{"https loopback", "https://127.0.0.1/cb", nil, false},
+
+		// Scheme must be http/https.
+		{"bad scheme", "javascript:alert(1)", nil, true},
+		{"file scheme", "file:///etc/passwd", nil, true},
+
+		// Non-loopback host without allowlist → rejected.
+		{"non-loopback without allowlist", "https://evil.com/cb", nil, true},
+		{
+			"non-loopback with mismatching allowlist",
+			"https://evil.com/cb",
+			[]string{"opampcommander-alpha.minuk.dev"},
+			true,
+		},
+
+		// Non-loopback host that is on the allowlist → accepted.
+		{
+			"non-loopback in allowlist",
+			"https://opampcommander-alpha.minuk.dev/login/github/callback",
+			[]string{"opampcommander-alpha.minuk.dev"},
+			false,
+		},
+		{
+			"non-loopback in allowlist with port",
+			"https://opampcommander-alpha.minuk.dev:8443/cb",
+			[]string{"opampcommander-alpha.minuk.dev"},
+			false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := github.ValidateRedirect(tc.rawURL, tc.allowed)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf(
+					"ValidateRedirect(%q, %v) = %v; wantErr=%v",
+					tc.rawURL, tc.allowed, err, tc.wantErr,
+				)
+			}
+		})
+	}
+}

--- a/internal/security/security.go
+++ b/internal/security/security.go
@@ -70,12 +70,20 @@ var _ Usecase = (*Service)(nil)
 
 // Service provides security-related functionality for the opampcommander application.
 type Service struct {
-	logger             *slog.Logger
-	oauth2Config       *oauth2.Config
-	oauthStateSettings config.JWTSettings
-	adminSettings      config.AdminSettings
-	tokenSettings      config.JWTSettings
-	httpClient         *http.Client
+	logger               *slog.Logger
+	oauth2Config         *oauth2.Config
+	oauthStateSettings   config.JWTSettings
+	adminSettings        config.AdminSettings
+	tokenSettings        config.JWTSettings
+	httpClient           *http.Client
+	allowedRedirectHosts []string
+}
+
+// AllowedRedirectHosts returns the configured extra hosts that the
+// authcode endpoint will accept as redirect targets (in addition to
+// loopback hosts).
+func (s *Service) AllowedRedirectHosts() []string {
+	return s.allowedRedirectHosts
 }
 
 // OPAMPClaims defines the custom claims for the JWT token used for opampcommander's authentication.
@@ -95,6 +103,9 @@ func New(
 	httpClient *http.Client,
 ) *Service {
 	var oauth2Cfg *oauth2.Config
+
+	var allowedRedirectHosts []string
+
 	if settings.OAuthSettings != nil {
 		oauth2Cfg = &oauth2.Config{
 			ClientID:     settings.OAuthSettings.ClientID,
@@ -103,15 +114,17 @@ func New(
 			Scopes:       []string{"user:email", "read:org"},
 			Endpoint:     oauth2github.Endpoint,
 		}
+		allowedRedirectHosts = settings.OAuthSettings.AllowedRedirectHosts
 	}
 
 	return &Service{
-		logger:             logger,
-		oauth2Config:       oauth2Cfg,
-		oauthStateSettings: settings.JWTSettings,
-		adminSettings:      settings.AdminSettings,
-		tokenSettings:      settings.JWTSettings,
-		httpClient:         httpClient,
+		logger:               logger,
+		oauth2Config:         oauth2Cfg,
+		oauthStateSettings:   settings.JWTSettings,
+		adminSettings:        settings.AdminSettings,
+		tokenSettings:        settings.JWTSettings,
+		httpClient:           httpClient,
+		allowedRedirectHosts: allowedRedirectHosts,
 	}
 }
 

--- a/pkg/apiserver/config/auth.go
+++ b/pkg/apiserver/config/auth.go
@@ -32,6 +32,12 @@ type OAuthSettings struct {
 	Secret string
 	// CallbackURL is the URL to which GitHub will redirect after authentication.
 	CallbackURL string
+	// AllowedRedirectHosts is the list of additional hostnames that the
+	// /api/v1/auth/github/authcode endpoint will accept as redirect targets,
+	// in addition to the always-allowed loopback hosts (127.0.0.1, ::1,
+	// localhost). Use this to allowlist the web UI deployment (e.g.
+	// "opampcommander-alpha.minuk.dev"). Empty by default.
+	AllowedRedirectHosts []string
 	// JWTSettings holds the JWT configuration settings.
 	// This is used for the state parameter in OAuth2 authentication.
 	JWTSettings JWTSettings

--- a/pkg/cmd/apiserver/apiserver.go
+++ b/pkg/cmd/apiserver/apiserver.go
@@ -84,11 +84,12 @@ type CommandOption struct {
 		}
 		Type   string `mapstructure:"type"`
 		OAuth2 struct {
-			Provider     string `mapstructure:"provider"`
-			ClientID     string `mapstructure:"clientId"`
-			ClientSecret string `mapstructure:"clientSecret"`
-			RedirectURI  string `mapstructure:"redirectUri"`
-			State        struct {
+			Provider             string   `mapstructure:"provider"`
+			ClientID             string   `mapstructure:"clientId"`
+			ClientSecret         string   `mapstructure:"clientSecret"`
+			RedirectURI          string   `mapstructure:"redirectUri"`
+			AllowedRedirectHosts []string `mapstructure:"allowedRedirectHosts"`
+			State                struct {
 				Mode string `mapstructure:"mode"`
 				JWT  struct {
 					Issuer   string        `mapstructure:"issuer"`
@@ -197,6 +198,12 @@ func NewCommand(opt CommandOption) *cobra.Command {
 	cmd.Flags().String("auth.oauth2.clientId", "", "OAuth2 client ID")
 	cmd.Flags().String("auth.oauth2.clientSecret", "", "OAuth2 client secret")
 	cmd.Flags().String("auth.oauth2.redirectUri", "", "OAuth2 redirect URL")
+	cmd.Flags().StringSlice(
+		"auth.oauth2.allowedRedirectHosts",
+		nil,
+		"additional hosts the OAuth2 authcode endpoint accepts as redirect "+
+			"targets (loopback hosts are always allowed)",
+	)
 	cmd.Flags().String("auth.oauth2.state.mode", "jwt", "OAuth2 state mode (jwt)")
 	cmd.Flags().String("auth.oauth2.state.jwt.secret", "", "OAuth2 state JWT secret")
 
@@ -277,9 +284,10 @@ func (opt *CommandOption) Prepare(_ *cobra.Command, _ []string) error {
 				Audience:          opt.Auth.JWT.Audience,
 			},
 			OAuthSettings: &appconfig.OAuthSettings{
-				ClientID:    opt.Auth.OAuth2.ClientID,
-				Secret:      opt.Auth.OAuth2.ClientSecret,
-				CallbackURL: opt.Auth.OAuth2.RedirectURI,
+				ClientID:             opt.Auth.OAuth2.ClientID,
+				Secret:               opt.Auth.OAuth2.ClientSecret,
+				CallbackURL:          opt.Auth.OAuth2.RedirectURI,
+				AllowedRedirectHosts: opt.Auth.OAuth2.AllowedRedirectHosts,
 				JWTSettings: appconfig.JWTSettings{
 					Issuer:            opt.Auth.OAuth2.State.JWT.Issuer,
 					Expiration:        opt.Auth.OAuth2.State.JWT.Expire,

--- a/pkg/cmd/apiserver/apiserver.go
+++ b/pkg/cmd/apiserver/apiserver.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/go-viper/mapstructure/v2"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"go.uber.org/fx"
@@ -238,7 +239,18 @@ func (opt *CommandOption) Init(cmd *cobra.Command, _ []string) error {
 	opt.viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_")) // replace '.' with '_' for environment variables
 	opt.viper.AutomaticEnv()                                   // read in environment variables that match
 
-	err = opt.viper.Unmarshal(opt)
+	// viper's StringSlice env-var support is famously fragile — without a
+	// decode hook, `AUTH_OAUTH2_ALLOWEDREDIRECTHOSTS=a,b,c` lands as a
+	// single-element slice. Adding StringToSliceHookFunc(",") makes every
+	// `[]string` mapstructure field accept comma-separated env values,
+	// while preserving native YAML list semantics. The Duration hook is
+	// preserved for the existing time.Duration fields.
+	err = opt.viper.Unmarshal(opt, viper.DecodeHook(
+		mapstructure.ComposeDecodeHookFunc(
+			mapstructure.StringToTimeDurationHookFunc(),
+			mapstructure.StringToSliceHookFunc(","),
+		),
+	))
 	if err != nil {
 		return fmt.Errorf("failed to unmarshal config: %w", err)
 	}


### PR DESCRIPTION
## Summary

The deployed web dashboard's GitHub login fails today with **`400 invalid redirect_uri`**. The apiserver's `validateLoopbackRedirect` only accepts `127.0.0.1`, `::1`, and `localhost`, but the alpha web is served from `https://opampcommander-alpha.minuk.dev`.

This PR adds an explicit allowlist so deployed hostnames can be opted in via config, while loopback hosts stay always-on. **Both local dev and deployed UI can therefore share a single apiserver** (e.g. point a local `npm run dev` at the alpha apiserver — `localhost:3000` is loopback, the alpha web's host is in the allowlist, both pass).

## What lands

- `pkg/apiserver/config/auth.go` — new `AllowedRedirectHosts []string` field on `OAuthSettings`.
- `internal/security/security.go` — `Service` carries the allowlist and exposes it via `AllowedRedirectHosts()`.
- `internal/adapter/in/http/auth/github/controller.go`
  - rename internal validator to **exported** `ValidateRedirect(rawURL, allowedHosts)`
  - loopback hosts still always pass; configured hosts are accepted; everything else still 400s with a clear error
- `pkg/cmd/apiserver/apiserver.go`
  - viper struct field + cobra flag (`--auth.oauth2.allowedRedirectHosts`)
  - **decode hook**: `mapstructure.StringToSliceHookFunc(",")` so every `[]string` config field (including this one, plus pre-existing `audience`, `database.endpoints`, `event.kafka.brokers`) splits comma-separated env var values correctly. Without this, viper StringSlice + AutomaticEnv puts the whole env var into a single-element slice — a well-known viper gotcha.
- `.golangci.yaml` — allowlist `github.com/go-viper/mapstructure/v2` in depguard.
- `configs/apiserver/config.sample.yaml` — documented example.
- `internal/adapter/in/http/auth/github/controller_test.go` — new black-box tests covering scheme rejection, loopback always-accept, allowlist-miss, allowlist-hit (with port).

## Three ways to configure

YAML:
```yaml
auth:
  oauth2:
    allowedRedirectHosts:
      - opampcommander-alpha.minuk.dev
      - opampcommander-alpha-ha.minuk.dev
```

Flag (repeat or comma-separated):
```
--auth.oauth2.allowedRedirectHosts=opampcommander-alpha.minuk.dev,opampcommander-alpha-ha.minuk.dev
```

Env var (comma-separated, picked up via `AutomaticEnv` and the new slice decode hook):
```
AUTH_OAUTH2_ALLOWEDREDIRECTHOSTS=opampcommander-alpha.minuk.dev,opampcommander-alpha-ha.minuk.dev
```

## Use case — alpha apiserver serving both deployed and local dashboards

Set on the apiserver pod:
```
AUTH_OAUTH2_ALLOWEDREDIRECTHOSTS=opampcommander-alpha.minuk.dev
```

Then:
- The deployed dashboard at `https://opampcommander-alpha.minuk.dev` can complete login (host in allowlist).
- A developer running `npm run dev` locally with `OPAMP_API_URL=https://opampcommander-apiserver-alpha.minuk.dev` can also complete login — `http://localhost:3000` is loopback and always allowed.

Companion change in minuk-cluster sets this for alpha + alpha-ha overlays (minuk-cluster#24).

## Test plan

- [x] `go build ./...`
- [x] `go test -short ./internal/adapter/in/http/auth/github/... ./internal/security/...`
- [x] `make lint`
- [ ] After merge + alpha deploy, verify GitHub login from `https://opampcommander-alpha.minuk.dev` succeeds end-to-end
- [ ] Verify a local `npm run dev` against the alpha apiserver also completes login
- [ ] Verify the CLI loopback login still works (`opampctl login`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)