### PR TITLE
ci(web): split web image release into its own workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -75,22 +75,6 @@ jobs:
           echo "Creating multi-arch manifest: $MANIFEST_TAG"
           docker buildx imagetools create -t "$MANIFEST_TAG" "$AMD64_IMAGE" "$ARM64_IMAGE"
 
-      # Build the web image with the same VERSION goreleaser produced so the
-      # apiserver and the web stay in lockstep and minuk-cluster bumps both
-      # tags atomically.
-      - name: Build and push web image (multi-arch)
-        if: startsWith(github.ref, 'refs/heads/')
-        uses: docker/build-push-action@v6
-        with:
-          context: ./web
-          file: ./web/Dockerfile
-          push: true
-          platforms: linux/amd64,linux/arm64
-          tags: ghcr.io/minuk-dev/opampcommander-web:${{ env.VERSION }}
-          provenance: false
-          cache-from: type=gha,scope=opampcommander-web
-          cache-to: type=gha,mode=max,scope=opampcommander-web
-
       - name: Setup SSH agent for minuk-cluster deploy
         if: startsWith(github.ref, 'refs/heads/')
         uses: webfactory/ssh-agent@v0.9.0
@@ -104,17 +88,10 @@ jobs:
           cd /tmp/minuk-cluster
 
           overlays=(alpha alpha-ha)
-          # Bump apiserver and web tags together. The web entry is only
-          # updated if present, so this workflow can land before the
-          # minuk-cluster side adds the web manifest entry.
           for overlay in "${overlays[@]}"; do
             kustomization="argocd/apps/opampcommander/overlays/${overlay}/kustomization.yaml"
             yq '(.images[] | select(.name == "ghcr.io/minuk-dev/opampcommander")).newTag = strenv(VERSION)' \
               -i "${kustomization}"
-            if yq -e '.images[] | select(.name == "ghcr.io/minuk-dev/opampcommander-web")' "${kustomization}" >/dev/null 2>&1; then
-              yq '(.images[] | select(.name == "ghcr.io/minuk-dev/opampcommander-web")).newTag = strenv(VERSION)' \
-                -i "${kustomization}"
-            fi
           done
 
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -122,9 +99,9 @@ jobs:
           for overlay in "${overlays[@]}"; do
             git add "argocd/apps/opampcommander/overlays/${overlay}/kustomization.yaml"
           done
-          git commit -m "chore(deploy): update opampcommander alpha and alpha-ha to ${VERSION}"
+          git commit -m "chore(deploy): update opampcommander apiserver alpha and alpha-ha to ${VERSION}"
 
-          # retry on push conflict from concurrent CI runs
+          # retry on push conflict from concurrent CI runs (web-release runs in parallel)
           for i in 1 2 3; do
             git push && break
             git pull --rebase && sleep $((i * 3))

--- a/.github/workflows/web-release.yaml
+++ b/.github/workflows/web-release.yaml
@@ -1,0 +1,88 @@
+name: web-release
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - 'v*'
+
+permissions:
+  packages: write
+  contents: write
+
+jobs:
+  web-release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      # scripts/version.sh mirrors .goreleaser.yaml's snapshot.version_template
+      # so this image lands with the same tag as the apiserver image built by
+      # the release workflow on the same commit.
+      - name: Compute version
+        run: |
+          VERSION=$(./scripts/version.sh)
+          echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
+          echo "Computed version: ${VERSION}"
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build and push web image (multi-arch)
+        uses: docker/build-push-action@v6
+        with:
+          context: ./web
+          file: ./web/Dockerfile
+          push: true
+          platforms: linux/amd64,linux/arm64
+          tags: ghcr.io/minuk-dev/opampcommander-web:${{ env.VERSION }}
+          provenance: false
+          cache-from: type=gha,scope=opampcommander-web
+          cache-to: type=gha,mode=max,scope=opampcommander-web
+
+      - name: Setup SSH agent for minuk-cluster deploy
+        if: startsWith(github.ref, 'refs/heads/')
+        uses: webfactory/ssh-agent@v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.MINUK_CLUSTER_DEPLOY_KEY }}
+
+      - name: Deploy alpha and alpha-ha to minuk-cluster
+        if: startsWith(github.ref, 'refs/heads/')
+        run: |
+          git clone git@github.com:minuk-cluster/minuk-cluster.git /tmp/minuk-cluster
+          cd /tmp/minuk-cluster
+
+          overlays=(alpha alpha-ha)
+          # Only touch the web entry if minuk-cluster already declares it,
+          # so this workflow stays a no-op while that side is being wired up.
+          for overlay in "${overlays[@]}"; do
+            kustomization="argocd/apps/opampcommander/overlays/${overlay}/kustomization.yaml"
+            if yq -e '.images[] | select(.name == "ghcr.io/minuk-dev/opampcommander-web")' "${kustomization}" >/dev/null 2>&1; then
+              yq '(.images[] | select(.name == "ghcr.io/minuk-dev/opampcommander-web")).newTag = strenv(VERSION)' \
+                -i "${kustomization}"
+            fi
+          done
+
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          for overlay in "${overlays[@]}"; do
+            git add "argocd/apps/opampcommander/overlays/${overlay}/kustomization.yaml"
+          done
+          if git diff --cached --quiet; then
+            echo "No web image tag updates needed."
+            exit 0
+          fi
+          git commit -m "chore(deploy): update opampcommander-web alpha and alpha-ha to ${VERSION}"
+
+          # retry on push conflict from concurrent CI runs (release runs in parallel)
+          for i in 1 2 3; do
+            git push && break
+            git pull --rebase && sleep $((i * 3))
+          done

--- a/.github/workflows/web-release.yaml
+++ b/.github/workflows/web-release.yaml
@@ -21,10 +21,17 @@ jobs:
           fetch-depth: 0
       # scripts/version.sh mirrors .goreleaser.yaml's snapshot.version_template
       # so this image lands with the same tag as the apiserver image built by
-      # the release workflow on the same commit.
+      # the release workflow on the same commit. Snapshot-ness MUST be decided
+      # off github.ref (the same signal release.yaml uses to pass --snapshot
+      # to goreleaser); a git-state check would mis-tag commits that happen to
+      # sit at a released tag on main.
       - name: Compute version
         run: |
-          VERSION=$(./scripts/version.sh)
+          if [[ "${{ github.ref }}" == refs/tags/v* ]]; then
+            VERSION=$(./scripts/version.sh)
+          else
+            VERSION=$(./scripts/version.sh --snapshot)
+          fi
           echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
           echo "Computed version: ${VERSION}"
       - name: Login to GHCR

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -8,6 +8,11 @@
 
 version: 2
 
+# Keep in lockstep with scripts/version.sh — the web workflow computes the
+# snapshot tag without goreleaser, so the format must be reproducible.
+snapshot:
+  version_template: "{{ incpatch .Version }}-SNAPSHOT-{{ .ShortCommit }}"
+
 before:
   hooks:
     # You may remove this if you don't use go modules.

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -3,14 +3,29 @@
 # lockstep with .goreleaser.yaml's snapshot.version_template so the apiserver
 # and web images, built in separate workflows, end up with identical tags.
 #
-# Tagged build (HEAD == v*): "<tag without leading v>"  e.g. "0.1.39"
-# Untagged build (snapshot): "<incpatch last_tag>-SNAPSHOT-<7-char commit>"
-#                                                 e.g. "0.1.40-SNAPSHOT-7452c0d"
+# Release build (no flag, HEAD == v*): "<tag without leading v>"
+#                                         e.g. "0.1.39"
+# Snapshot build (--snapshot, OR no flag and HEAD is not a tag):
+#                "<incpatch last_tag>-SNAPSHOT-<7-char commit>"
+#                                         e.g. "0.1.40-SNAPSHOT-7452c0d"
+#
+# CI MUST pass --snapshot whenever it would also pass --snapshot to goreleaser
+# (i.e. for non-tag refs). Auto-detecting from HEAD alone breaks when main
+# happens to land on a tagged commit.
 set -euo pipefail
 
-if tag=$(git describe --tags --exact-match HEAD 2>/dev/null); then
-    echo "${tag#v}"
-    exit 0
+snapshot=0
+case "${1:-}" in
+    --snapshot) snapshot=1 ;;
+    "") ;;
+    *) echo "usage: $0 [--snapshot]" >&2; exit 2 ;;
+esac
+
+if [[ "${snapshot}" -eq 0 ]]; then
+    if tag=$(git describe --tags --exact-match HEAD 2>/dev/null); then
+        echo "${tag#v}"
+        exit 0
+    fi
 fi
 
 last_tag=$(git describe --tags --abbrev=0 --match='v*' 2>/dev/null || echo "v0.0.0")

--- a/scripts/version.sh
+++ b/scripts/version.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Prints the project version for the current commit. Output must stay in
+# lockstep with .goreleaser.yaml's snapshot.version_template so the apiserver
+# and web images, built in separate workflows, end up with identical tags.
+#
+# Tagged build (HEAD == v*): "<tag without leading v>"  e.g. "0.1.39"
+# Untagged build (snapshot): "<incpatch last_tag>-SNAPSHOT-<7-char commit>"
+#                                                 e.g. "0.1.40-SNAPSHOT-7452c0d"
+set -euo pipefail
+
+if tag=$(git describe --tags --exact-match HEAD 2>/dev/null); then
+    echo "${tag#v}"
+    exit 0
+fi
+
+last_tag=$(git describe --tags --abbrev=0 --match='v*' 2>/dev/null || echo "v0.0.0")
+last_tag=${last_tag#v}
+IFS='.' read -r major minor patch <<<"${last_tag}"
+next_patch=$((patch + 1))
+short_commit=$(git rev-parse --short=7 HEAD)
+echo "${major}.${minor}.${next_patch}-SNAPSHOT-${short_commit}"


### PR DESCRIPTION
## Summary
- Move the web image build/push/deploy out of `release.yaml`'s `goreleaser` job into a dedicated `web-release.yaml` workflow — the goreleaser job no longer carries non-goreleaser steps, and the web pipeline shows up as its own GitHub check.
- Add `scripts/version.sh` as the single source of truth for the snapshot version, and pin `.goreleaser.yaml`'s `snapshot.version_template` to `"{{ incpatch .Version }}-SNAPSHOT-{{ .ShortCommit }}"` so both workflows independently produce identical tags on the same commit.
- `web-release.yaml` decides snapshot mode off `github.ref` (the same signal `release.yaml` uses to gate `--snapshot` on goreleaser), so a commit that happens to land on a released tag on `main` still gets the snapshot tag everywhere instead of one side reverting to the release tag.
- Both workflows trigger on the same `main`/tag events so apiserver and web images always land at the same version; retry-on-push handles the concurrent deploy commit race against `minuk-cluster`.

## Test plan
- [ ] After merge, confirm both `Release` and `web-release` workflows trigger on the same `main` push.
- [ ] Verify the two images land at the same tag (e.g. `0.1.40-SNAPSHOT-<shortsha>`) in GHCR.
- [ ] Verify `minuk-cluster` receives two separate commits (one per image) updating both `alpha` and `alpha-ha` overlays to the same version.
- [ ] On the next `v*` tag push, verify both images publish at `<tag>` (no `-SNAPSHOT` suffix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)