### PR TITLE
feat(web): YAML sample loader for editors + /profile page

### DIFF
--- a/web/app/agentgroups/AgentGroupEditDialog.tsx
+++ b/web/app/agentgroups/AgentGroupEditDialog.tsx
@@ -7,15 +7,20 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  ListItemText,
+  Menu,
+  MenuItem,
   Stack,
   TextField,
   ToggleButton,
   ToggleButtonGroup,
   Typography,
 } from '@mui/material';
+import { ArrowDropDown as ArrowDropDownIcon } from '@mui/icons-material';
 import { useEffect, useState } from 'react';
 import { useNamespace } from '@/components/NamespaceProvider';
 import { api } from '@/lib/api-client';
+import { loadAgentGroupSamples, type AgentGroupSample } from '@/lib/samples';
 import { fromYAML, toYAML } from '@/lib/yaml';
 import type { AgentGroup, AgentGroupSpec } from '@/lib/types';
 
@@ -58,6 +63,38 @@ export default function AgentGroupEditDialog({ open, mode, initial, onClose, onS
   const [attributesText, setAttributesText] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [sampleAnchor, setSampleAnchor] = useState<HTMLElement | null>(null);
+  const [samples, setSamples] = useState<AgentGroupSample[] | null>(null);
+  const [samplesError, setSamplesError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    setSamplesError(null);
+    loadAgentGroupSamples()
+      .then((list) => {
+        if (!cancelled) setSamples(list);
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setSamplesError(err instanceof Error ? err.message : String(err));
+          setSamples([]);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  const applySample = (s: AgentGroupSample) => {
+    if (mode === 'create') {
+      setName(s.name);
+    }
+    setAttributesText(serialize(s.attributes, format));
+    setSpecText(serialize(s.spec, format));
+    setError(null);
+    setSampleAnchor(null);
+  };
 
   useEffect(() => {
     if (open) {
@@ -131,22 +168,49 @@ export default function AgentGroupEditDialog({ open, mode, initial, onClose, onS
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
       <DialogTitle>
-        <Stack direction="row" alignItems="center" justifyContent="space-between">
+        <Stack direction="row" alignItems="center" justifyContent="space-between" gap={1}>
           {mode === 'create' ? 'Create agent group' : 'Edit agent group'}
-          <ToggleButtonGroup
-            size="small"
-            exclusive
-            value={format}
-            onChange={(_, v: Format | null) => v && switchFormat(v)}
-            aria-label="format"
-          >
-            <ToggleButton value="yaml">YAML</ToggleButton>
-            <ToggleButton value="json">JSON</ToggleButton>
-          </ToggleButtonGroup>
+          <Stack direction="row" alignItems="center" gap={1}>
+            <Button
+              size="small"
+              variant="outlined"
+              endIcon={<ArrowDropDownIcon />}
+              onClick={(e) => setSampleAnchor(e.currentTarget)}
+              aria-label="load sample"
+              disabled={!samples}
+            >
+              {samples ? 'Load sample' : 'Loading…'}
+            </Button>
+            <Menu
+              anchorEl={sampleAnchor}
+              open={Boolean(sampleAnchor)}
+              onClose={() => setSampleAnchor(null)}
+            >
+              {(samples ?? []).length === 0 && <MenuItem disabled>No samples available</MenuItem>}
+              {(samples ?? []).map((s) => (
+                <MenuItem key={s.label} onClick={() => applySample(s)}>
+                  <ListItemText primary={s.label} secondary={s.description} />
+                </MenuItem>
+              ))}
+            </Menu>
+            <ToggleButtonGroup
+              size="small"
+              exclusive
+              value={format}
+              onChange={(_, v: Format | null) => v && switchFormat(v)}
+              aria-label="format"
+            >
+              <ToggleButton value="yaml">YAML</ToggleButton>
+              <ToggleButton value="json">JSON</ToggleButton>
+            </ToggleButtonGroup>
+          </Stack>
         </Stack>
       </DialogTitle>
       <DialogContent>
         <Stack spacing={2} mt={1}>
+          {samplesError && (
+            <Alert severity="warning">Failed to load samples: {samplesError}</Alert>
+          )}
           {error && <Alert severity="error">{error}</Alert>}
           <TextField
             label="Name"

--- a/web/app/agentgroups/AgentGroupEditDialog.tsx
+++ b/web/app/agentgroups/AgentGroupEditDialog.tsx
@@ -17,7 +17,7 @@ import {
   Typography,
 } from '@mui/material';
 import { ArrowDropDown as ArrowDropDownIcon } from '@mui/icons-material';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useNamespace } from '@/components/NamespaceProvider';
 import { api } from '@/lib/api-client';
 import { loadAgentGroupSamples, type AgentGroupSample } from '@/lib/samples';
@@ -68,9 +68,12 @@ export default function AgentGroupEditDialog({ open, mode, initial, onClose, onS
   const [samplesError, setSamplesError] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!open) return;
+    if (!open) {
+      setSamples(null);
+      setSamplesError(null);
+      return;
+    }
     let cancelled = false;
-    setSamplesError(null);
     loadAgentGroupSamples()
       .then((list) => {
         if (!cancelled) setSamples(list);
@@ -96,15 +99,23 @@ export default function AgentGroupEditDialog({ open, mode, initial, onClose, onS
     setSampleAnchor(null);
   };
 
+  // Reset on the closed→open transition only. Parents may pass a freshly
+  // fetched `initial` reference for the same logical row mid-edit (e.g. list
+  // refresh), which must not stomp the user's in-progress buffers.
+  const wasOpen = useRef(false);
+  const initialRef = useRef(initial);
+  initialRef.current = initial;
   useEffect(() => {
-    if (open) {
+    if (open && !wasOpen.current) {
+      const i = initialRef.current;
       setError(null);
       setFormat('yaml');
-      setName(initial?.metadata.name ?? '');
-      setSpecText(serialize(initial?.spec ?? defaultSpec(), 'yaml'));
-      setAttributesText(serialize(initial?.metadata.attributes ?? {}, 'yaml'));
+      setName(i?.metadata.name ?? '');
+      setSpecText(serialize(i?.spec ?? defaultSpec(), 'yaml'));
+      setAttributesText(serialize(i?.metadata.attributes ?? {}, 'yaml'));
     }
-  }, [open, initial]);
+    wasOpen.current = open;
+  }, [open]);
 
   const switchFormat = (next: Format) => {
     if (next === format) return;
@@ -187,8 +198,8 @@ export default function AgentGroupEditDialog({ open, mode, initial, onClose, onS
               onClose={() => setSampleAnchor(null)}
             >
               {(samples ?? []).length === 0 && <MenuItem disabled>No samples available</MenuItem>}
-              {(samples ?? []).map((s) => (
-                <MenuItem key={s.label} onClick={() => applySample(s)}>
+              {(samples ?? []).map((s, i) => (
+                <MenuItem key={`${i}-${s.label}`} onClick={() => applySample(s)}>
                   <ListItemText primary={s.label} secondary={s.description} />
                 </MenuItem>
               ))}
@@ -208,9 +219,7 @@ export default function AgentGroupEditDialog({ open, mode, initial, onClose, onS
       </DialogTitle>
       <DialogContent>
         <Stack spacing={2} mt={1}>
-          {samplesError && (
-            <Alert severity="warning">Failed to load samples: {samplesError}</Alert>
-          )}
+          {samplesError && <Alert severity="warning">Failed to load samples: {samplesError}</Alert>}
           {error && <Alert severity="error">{error}</Alert>}
           <TextField
             label="Name"

--- a/web/app/agentpackages/page.tsx
+++ b/web/app/agentpackages/page.tsx
@@ -63,6 +63,8 @@ export default function AgentPackagesPage() {
               </>
             }
             initialValue={emptyPackage(namespace, '')}
+            samplesUrl="/samples/agentpackages.yaml"
+            samplesVars={{ namespace }}
             onClose={onClose}
             onSave={async (parsed) => {
               const body = parsed as AgentPackage;
@@ -77,6 +79,8 @@ export default function AgentPackagesPage() {
             title={`Edit ${row.metadata.name}`}
             description="Edit the package as JSON."
             initialValue={row}
+            samplesUrl="/samples/agentpackages.yaml"
+            samplesVars={{ namespace }}
             onClose={onClose}
             onSave={async (parsed) => {
               const body = parsed as AgentPackage;

--- a/web/app/agentremoteconfigs/page.tsx
+++ b/web/app/agentremoteconfigs/page.tsx
@@ -52,6 +52,8 @@ export default function AgentRemoteConfigsPage() {
             title="Create remote config"
             description="metadata.name + spec.value (config body) + spec.contentType (e.g. text/yaml)."
             initialValue={emptyConfig(namespace)}
+            samplesUrl="/samples/agentremoteconfigs.yaml"
+            samplesVars={{ namespace }}
             onClose={onClose}
             onSave={async (parsed) => {
               await api.post(
@@ -67,6 +69,8 @@ export default function AgentRemoteConfigsPage() {
             open={open}
             title={`Edit ${row.metadata.name}`}
             initialValue={row}
+            samplesUrl="/samples/agentremoteconfigs.yaml"
+            samplesVars={{ namespace }}
             onClose={onClose}
             onSave={async (parsed) => {
               await api.put(

--- a/web/app/agents/[id]/AgentEditDialog.tsx
+++ b/web/app/agents/[id]/AgentEditDialog.tsx
@@ -26,6 +26,7 @@ export default function AgentEditDialog({ open, agent, onClose, onSaved }: Props
         </>
       }
       initialValue={agent.spec ?? {}}
+      samplesUrl="/samples/agentspecs.yaml"
       onClose={onClose}
       onSave={async (parsed) => {
         // Reject non-object payloads explicitly so the user sees the error

--- a/web/app/certificates/page.tsx
+++ b/web/app/certificates/page.tsx
@@ -78,6 +78,8 @@ export default function CertificatesPage() {
             title="Create certificate"
             description="PEM-encoded cert/privateKey/caCert as JSON strings."
             initialValue={emptyCertificate(namespace)}
+            samplesUrl="/samples/certificates.yaml"
+            samplesVars={{ namespace }}
             onClose={onClose}
             onSave={async (parsed) => {
               await api.post(`/api/v1/namespaces/${namespace}/certificates`, parsed as Certificate);
@@ -90,6 +92,8 @@ export default function CertificatesPage() {
             open={open}
             title={`Edit ${row.metadata.name}`}
             initialValue={row}
+            samplesUrl="/samples/certificates.yaml"
+            samplesVars={{ namespace }}
             onClose={onClose}
             onSave={async (parsed) => {
               await api.put(

--- a/web/app/profile/page.tsx
+++ b/web/app/profile/page.tsx
@@ -1,0 +1,221 @@
+'use client';
+
+import {
+  Alert,
+  Box,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Divider,
+  Paper,
+  Stack,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Typography,
+} from '@mui/material';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import PageHeader from '@/components/PageHeader';
+import { api } from '@/lib/api-client';
+import type { UserProfileResponse } from '@/lib/types';
+
+export default function ProfilePage() {
+  const [profile, setProfile] = useState<UserProfileResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    setLoading(true);
+    api
+      .get<UserProfileResponse>('/api/v1/users/me')
+      .then((p) => {
+        if (!cancelled) setProfile(p);
+      })
+      .catch((err) => {
+        if (!cancelled)
+          setError(err instanceof Error ? err.message : 'Failed to load profile');
+      })
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <Box display="flex" justifyContent="center" mt={6}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  if (error || !profile) {
+    return (
+      <Box>
+        <PageHeader title="My profile" />
+        <Alert severity="error">{error ?? 'No profile data returned'}</Alert>
+      </Box>
+    );
+  }
+
+  const { user, roles } = profile;
+  const labelEntries = Object.entries(user.metadata.labels ?? {});
+
+  return (
+    <Box>
+      <PageHeader
+        title="My profile"
+        subtitle="The account you are currently signed in as, and the roles applied to you."
+      />
+
+      <Card variant="outlined" sx={{ mb: 3 }}>
+        <CardContent>
+          <Stack direction={{ xs: 'column', md: 'row' }} gap={4} flexWrap="wrap">
+            <Field label="Email" value={user.spec.email || '-'} mono />
+            <Field label="Username" value={user.spec.username || '-'} />
+            <Field
+              label="Status"
+              value={
+                <Chip
+                  size="small"
+                  label={user.spec.isActive ? 'active' : 'inactive'}
+                  color={user.spec.isActive ? 'success' : 'default'}
+                />
+              }
+            />
+            <Field label="UID" value={user.metadata.uid || '(no DB record yet)'} mono />
+            <Field label="Created" value={user.metadata.createdAt || '-'} />
+          </Stack>
+          {labelEntries.length > 0 && (
+            <>
+              <Divider sx={{ my: 2 }} />
+              <Typography variant="overline" color="text.secondary">
+                Labels
+              </Typography>
+              <Stack direction="row" gap={0.5} flexWrap="wrap" mt={0.5}>
+                {labelEntries.map(([k, v]) => (
+                  <Chip key={k} label={`${k}: ${v}`} size="small" variant="outlined" />
+                ))}
+              </Stack>
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      <Typography variant="h6" gutterBottom>
+        Roles applied to you
+      </Typography>
+      {(!roles || roles.length === 0) && (
+        <Alert severity="info">
+          No roles are currently applied. Ask an administrator to create a role binding for you.
+        </Alert>
+      )}
+      {roles && roles.length > 0 && (
+        <TableContainer component={Paper} variant="outlined">
+          <Table size="small">
+            <TableHead>
+              <TableRow>
+                <TableCell>Role</TableCell>
+                <TableCell>Source</TableCell>
+                <TableCell>Permissions</TableCell>
+              </TableRow>
+            </TableHead>
+            <TableBody>
+              {roles.map((entry, i) => {
+                const role = entry.role;
+                const rb = entry.roleBinding;
+                const perms = role.spec.permissions ?? [];
+                return (
+                  <TableRow key={`${role.metadata.uid}-${i}`}>
+                    <TableCell>
+                      <Stack direction="row" alignItems="center" gap={1}>
+                        <Link
+                          href="/roles"
+                          style={{ color: 'inherit', textDecoration: 'underline' }}
+                        >
+                          {role.spec.displayName || role.metadata.uid}
+                        </Link>
+                        {role.spec.isBuiltIn && (
+                          <Chip label="built-in" size="small" color="info" variant="outlined" />
+                        )}
+                      </Stack>
+                      {role.spec.description && (
+                        <Typography variant="caption" color="text.secondary">
+                          {role.spec.description}
+                        </Typography>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {rb ? (
+                        <Stack>
+                          <Link href="/rolebindings" style={{ color: 'inherit' }}>
+                            {rb.metadata.namespace}/{rb.metadata.name}
+                          </Link>
+                          <Typography variant="caption" color="text.secondary">
+                            RoleBinding
+                          </Typography>
+                        </Stack>
+                      ) : (
+                        <Typography variant="body2" color="text.secondary">
+                          Auto-assigned (built-in default)
+                        </Typography>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      {perms.length === 0 ? (
+                        <Typography variant="caption" color="text.secondary">
+                          (no permissions)
+                        </Typography>
+                      ) : (
+                        <Stack direction="row" gap={0.5} flexWrap="wrap">
+                          {perms.slice(0, 30).map((p) => (
+                            <Chip key={p} label={p} size="small" variant="outlined" />
+                          ))}
+                          {perms.length > 30 && (
+                            <Chip label={`+${perms.length - 30} more`} size="small" />
+                          )}
+                        </Stack>
+                      )}
+                    </TableCell>
+                  </TableRow>
+                );
+              })}
+            </TableBody>
+          </Table>
+        </TableContainer>
+      )}
+    </Box>
+  );
+}
+
+function Field({
+  label,
+  value,
+  mono,
+}: {
+  label: string;
+  value: React.ReactNode;
+  mono?: boolean;
+}) {
+  return (
+    <Box>
+      <Typography variant="overline" color="text.secondary">
+        {label}
+      </Typography>
+      <Typography
+        variant="body1"
+        sx={mono ? { fontFamily: 'var(--font-geist-mono), monospace', fontSize: 14 } : undefined}
+      >
+        {value}
+      </Typography>
+    </Box>
+  );
+}

--- a/web/app/profile/page.tsx
+++ b/web/app/profile/page.tsx
@@ -31,15 +31,13 @@ export default function ProfilePage() {
 
   useEffect(() => {
     let cancelled = false;
-    setLoading(true);
     api
       .get<UserProfileResponse>('/api/v1/users/me')
       .then((p) => {
         if (!cancelled) setProfile(p);
       })
       .catch((err) => {
-        if (!cancelled)
-          setError(err instanceof Error ? err.message : 'Failed to load profile');
+        if (!cancelled) setError(err instanceof Error ? err.message : 'Failed to load profile');
       })
       .finally(() => {
         if (!cancelled) setLoading(false);
@@ -57,7 +55,7 @@ export default function ProfilePage() {
     );
   }
 
-  if (error || !profile) {
+  if (error || !profile?.user) {
     return (
       <Box>
         <PageHeader title="My profile" />
@@ -196,15 +194,7 @@ export default function ProfilePage() {
   );
 }
 
-function Field({
-  label,
-  value,
-  mono,
-}: {
-  label: string;
-  value: React.ReactNode;
-  mono?: boolean;
-}) {
+function Field({ label, value, mono }: { label: string; value: React.ReactNode; mono?: boolean }) {
   return (
     <Box>
       <Typography variant="overline" color="text.secondary">
@@ -212,6 +202,7 @@ function Field({
       </Typography>
       <Typography
         variant="body1"
+        component="div"
         sx={mono ? { fontFamily: 'var(--font-geist-mono), monospace', fontSize: 14 } : undefined}
       >
         {value}

--- a/web/app/rolebindings/page.tsx
+++ b/web/app/rolebindings/page.tsx
@@ -64,6 +64,8 @@ export default function RoleBindingsPage() {
             title="Create role binding"
             description="metadata.name + spec.roleRef + spec.subjects[]."
             initialValue={emptyRoleBinding(namespace)}
+            samplesUrl="/samples/rolebindings.yaml"
+            samplesVars={{ namespace }}
             onClose={onClose}
             onSave={async (parsed) => {
               await api.post(`/api/v1/namespaces/${namespace}/rolebindings`, parsed as RoleBinding);
@@ -76,6 +78,8 @@ export default function RoleBindingsPage() {
             open={open}
             title={`Edit ${row.metadata.name}`}
             initialValue={row}
+            samplesUrl="/samples/rolebindings.yaml"
+            samplesVars={{ namespace }}
             onClose={onClose}
             onSave={async (parsed) => {
               await api.put(

--- a/web/app/roles/page.tsx
+++ b/web/app/roles/page.tsx
@@ -67,6 +67,7 @@ export default function RolesPage() {
             title="Create role"
             description="Set spec.displayName, spec.description, spec.permissions[]."
             initialValue={emptyRole()}
+            samplesUrl="/samples/roles.yaml"
             onClose={onClose}
             onSave={async (parsed) => {
               await api.post('/api/v1/roles', parsed as Role);
@@ -79,6 +80,7 @@ export default function RolesPage() {
             open={open}
             title={`Edit ${row.spec.displayName}`}
             initialValue={row}
+            samplesUrl="/samples/roles.yaml"
             onClose={onClose}
             onSave={async (parsed) => {
               await api.put(`/api/v1/roles/${row.metadata.uid}`, parsed as Role);

--- a/web/app/users/page.tsx
+++ b/web/app/users/page.tsx
@@ -55,6 +55,7 @@ export default function UsersPage() {
             title="Create user"
             description="Set spec.email, spec.username, spec.isActive."
             initialValue={emptyUser()}
+            samplesUrl="/samples/users.yaml"
             onClose={onClose}
             onSave={async (parsed) => {
               await api.post('/api/v1/users', parsed as User);

--- a/web/components/AppLayout.tsx
+++ b/web/components/AppLayout.tsx
@@ -32,6 +32,7 @@ import {
   Link as RoleBindingIcon,
   Logout as LogoutIcon,
   AccountCircle as AccountIcon,
+  Badge as BadgeIcon,
   Menu as MenuIcon,
 } from '@mui/icons-material';
 import Link from 'next/link';
@@ -158,6 +159,16 @@ export default function AppLayout({ children }: { children: ReactNode }) {
               <Typography variant="body2">{email || 'unknown'}</Typography>
             </MenuItem>
             <Divider />
+            <MenuItem
+              component={Link}
+              href="/profile"
+              onClick={() => setMenuAnchor(null)}
+            >
+              <ListItemIcon>
+                <BadgeIcon fontSize="small" />
+              </ListItemIcon>
+              My profile
+            </MenuItem>
             <MenuItem
               onClick={() => {
                 setMenuAnchor(null);

--- a/web/components/AppLayout.tsx
+++ b/web/components/AppLayout.tsx
@@ -159,11 +159,7 @@ export default function AppLayout({ children }: { children: ReactNode }) {
               <Typography variant="body2">{email || 'unknown'}</Typography>
             </MenuItem>
             <Divider />
-            <MenuItem
-              component={Link}
-              href="/profile"
-              onClick={() => setMenuAnchor(null)}
-            >
+            <MenuItem component={Link} href="/profile" onClick={() => setMenuAnchor(null)}>
               <ListItemIcon>
                 <BadgeIcon fontSize="small" />
               </ListItemIcon>

--- a/web/components/CodeEditorDialog.tsx
+++ b/web/components/CodeEditorDialog.tsx
@@ -18,7 +18,7 @@ import {
   Typography,
 } from '@mui/material';
 import { ArrowDropDown as ArrowDropDownIcon } from '@mui/icons-material';
-import { type ReactNode, useEffect, useState } from 'react';
+import { type ReactNode, useEffect, useRef, useState } from 'react';
 import { loadSamples, type SamplesPath } from '@/lib/samples';
 import { fromYAML, toYAML } from '@/lib/yaml';
 
@@ -82,22 +82,42 @@ export default function CodeEditorDialog({
   const [loadedSamples, setLoadedSamples] = useState<CodeSample[] | null>(null);
   const [samplesError, setSamplesError] = useState<string | null>(null);
 
+  // Reset buffer only on the closed→open transition. Parents commonly pass a
+  // freshly-constructed initialValue (e.g. emptyFoo()) each render; depending
+  // on its identity would wipe in-progress edits on every parent re-render.
+  const wasOpen = useRef(false);
+  const initialValueRef = useRef(initialValue);
+  const defaultFormatRef = useRef(defaultFormat);
+  initialValueRef.current = initialValue;
+  defaultFormatRef.current = defaultFormat;
   useEffect(() => {
-    if (open) {
-      setFormat(defaultFormat);
-      setText(serialize(initialValue, defaultFormat));
+    if (open && !wasOpen.current) {
+      setFormat(defaultFormatRef.current);
+      setText(serialize(initialValueRef.current, defaultFormatRef.current));
       setError(null);
     }
-  }, [open, initialValue, defaultFormat]);
+    wasOpen.current = open;
+  }, [open]);
 
-  // Stable JSON key so we don't refetch every render when the parent
-  // creates a fresh samplesVars object each time.
+  // Stable JSON key so we don't refetch every render when the parent creates
+  // a fresh samplesVars object each time. samplesVars itself MUST stay out of
+  // the dep array — using both defeats the stabilization.
   const varsKey = samplesVars ? JSON.stringify(samplesVars) : '';
+  const samplesVarsRef = useRef(samplesVars);
+  samplesVarsRef.current = samplesVars;
   useEffect(() => {
-    if (!open || !samplesUrl) return;
-    let cancelled = false;
+    if (!open) {
+      // Drop stale samples loaded for a previous open/URL so the next open
+      // shows "Loading…" instead of the previous file's entries.
+      setLoadedSamples(null);
+      setSamplesError(null);
+      return;
+    }
+    if (!samplesUrl) return;
+    setLoadedSamples(null);
     setSamplesError(null);
-    loadSamples(samplesUrl, samplesVars ?? {})
+    let cancelled = false;
+    loadSamples(samplesUrl, samplesVarsRef.current ?? {})
       .then((list) => {
         if (!cancelled) setLoadedSamples(list);
       })
@@ -110,7 +130,7 @@ export default function CodeEditorDialog({
     return () => {
       cancelled = true;
     };
-  }, [open, samplesUrl, varsKey, samplesVars]);
+  }, [open, samplesUrl, varsKey]);
 
   const effectiveSamples = samples ?? loadedSamples ?? [];
 
@@ -176,8 +196,8 @@ export default function CodeEditorDialog({
                   {effectiveSamples.length === 0 && (
                     <MenuItem disabled>No samples available</MenuItem>
                   )}
-                  {effectiveSamples.map((s) => (
-                    <MenuItem key={s.label} onClick={() => applySample(s)}>
+                  {effectiveSamples.map((s, i) => (
+                    <MenuItem key={`${i}-${s.label}`} onClick={() => applySample(s)}>
                       <ListItemText primary={s.label} secondary={s.description} />
                     </MenuItem>
                   ))}

--- a/web/components/CodeEditorDialog.tsx
+++ b/web/components/CodeEditorDialog.tsx
@@ -8,16 +8,27 @@ import {
   DialogActions,
   DialogContent,
   DialogTitle,
+  ListItemText,
+  Menu,
+  MenuItem,
   Stack,
   TextField,
   ToggleButton,
   ToggleButtonGroup,
   Typography,
 } from '@mui/material';
+import { ArrowDropDown as ArrowDropDownIcon } from '@mui/icons-material';
 import { type ReactNode, useEffect, useState } from 'react';
+import { loadSamples, type SamplesPath } from '@/lib/samples';
 import { fromYAML, toYAML } from '@/lib/yaml';
 
 export type CodeFormat = 'yaml' | 'json';
+
+export interface CodeSample {
+  label: string;
+  description?: string;
+  value: unknown;
+}
 
 interface Props {
   open: boolean;
@@ -25,6 +36,13 @@ interface Props {
   description?: ReactNode;
   initialValue: unknown;
   defaultFormat?: CodeFormat;
+  // Inline list of samples (synchronous). Prefer samplesUrl in new code.
+  samples?: CodeSample[];
+  // Path under /samples/*.yaml (see web/public/samples/). When set, the menu
+  // is populated on dialog open from this file. {{namespace}}, {{now}}, etc.
+  // in the YAML are substituted from samplesVars (plus a built-in `now`).
+  samplesUrl?: SamplesPath;
+  samplesVars?: Record<string, string>;
   onClose: () => void;
   onSave: (parsed: unknown) => Promise<void> | void;
 }
@@ -50,6 +68,9 @@ export default function CodeEditorDialog({
   description,
   initialValue,
   defaultFormat = 'yaml',
+  samples,
+  samplesUrl,
+  samplesVars,
   onClose,
   onSave,
 }: Props) {
@@ -57,6 +78,9 @@ export default function CodeEditorDialog({
   const [text, setText] = useState('');
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [sampleAnchor, setSampleAnchor] = useState<HTMLElement | null>(null);
+  const [loadedSamples, setLoadedSamples] = useState<CodeSample[] | null>(null);
+  const [samplesError, setSamplesError] = useState<string | null>(null);
 
   useEffect(() => {
     if (open) {
@@ -65,6 +89,30 @@ export default function CodeEditorDialog({
       setError(null);
     }
   }, [open, initialValue, defaultFormat]);
+
+  // Stable JSON key so we don't refetch every render when the parent
+  // creates a fresh samplesVars object each time.
+  const varsKey = samplesVars ? JSON.stringify(samplesVars) : '';
+  useEffect(() => {
+    if (!open || !samplesUrl) return;
+    let cancelled = false;
+    setSamplesError(null);
+    loadSamples(samplesUrl, samplesVars ?? {})
+      .then((list) => {
+        if (!cancelled) setLoadedSamples(list);
+      })
+      .catch((err) => {
+        if (!cancelled) {
+          setSamplesError(err instanceof Error ? err.message : String(err));
+          setLoadedSamples([]);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, samplesUrl, varsKey, samplesVars]);
+
+  const effectiveSamples = samples ?? loadedSamples ?? [];
 
   const switchFormat = (next: CodeFormat) => {
     if (next === format) return;
@@ -83,6 +131,12 @@ export default function CodeEditorDialog({
     }
   };
 
+  const applySample = (sample: CodeSample) => {
+    setText(serialize(sample.value, format));
+    setError(null);
+    setSampleAnchor(null);
+  };
+
   const save = async () => {
     setBusy(true);
     setError(null);
@@ -99,18 +153,48 @@ export default function CodeEditorDialog({
   return (
     <Dialog open={open} onClose={onClose} fullWidth maxWidth="md">
       <DialogTitle>
-        <Stack direction="row" alignItems="center" justifyContent="space-between">
+        <Stack direction="row" alignItems="center" justifyContent="space-between" gap={1}>
           <Box>{title}</Box>
-          <ToggleButtonGroup
-            size="small"
-            exclusive
-            value={format}
-            onChange={(_, v: CodeFormat | null) => v && switchFormat(v)}
-            aria-label="format"
-          >
-            <ToggleButton value="yaml">YAML</ToggleButton>
-            <ToggleButton value="json">JSON</ToggleButton>
-          </ToggleButtonGroup>
+          <Stack direction="row" alignItems="center" gap={1}>
+            {(samples || samplesUrl) && (
+              <>
+                <Button
+                  size="small"
+                  variant="outlined"
+                  endIcon={<ArrowDropDownIcon />}
+                  onClick={(e) => setSampleAnchor(e.currentTarget)}
+                  aria-label="load sample"
+                  disabled={!samples && !loadedSamples}
+                >
+                  {samples || loadedSamples ? 'Load sample' : 'Loading…'}
+                </Button>
+                <Menu
+                  anchorEl={sampleAnchor}
+                  open={Boolean(sampleAnchor)}
+                  onClose={() => setSampleAnchor(null)}
+                >
+                  {effectiveSamples.length === 0 && (
+                    <MenuItem disabled>No samples available</MenuItem>
+                  )}
+                  {effectiveSamples.map((s) => (
+                    <MenuItem key={s.label} onClick={() => applySample(s)}>
+                      <ListItemText primary={s.label} secondary={s.description} />
+                    </MenuItem>
+                  ))}
+                </Menu>
+              </>
+            )}
+            <ToggleButtonGroup
+              size="small"
+              exclusive
+              value={format}
+              onChange={(_, v: CodeFormat | null) => v && switchFormat(v)}
+              aria-label="format"
+            >
+              <ToggleButton value="yaml">YAML</ToggleButton>
+              <ToggleButton value="json">JSON</ToggleButton>
+            </ToggleButtonGroup>
+          </Stack>
         </Stack>
       </DialogTitle>
       <DialogContent>
@@ -120,6 +204,7 @@ export default function CodeEditorDialog({
               {description}
             </Typography>
           )}
+          {samplesError && <Alert severity="warning">Failed to load samples: {samplesError}</Alert>}
           {error && <Alert severity="error">{error}</Alert>}
           <TextField
             value={text}

--- a/web/lib/samples.ts
+++ b/web/lib/samples.ts
@@ -1,0 +1,56 @@
+// Loads sample payloads for the YAML/JSON editor dialogs.
+//
+// The actual samples live as plain YAML files under web/public/samples/ so
+// anyone (no TS knowledge required) can add, tweak, or remove them. See
+// web/public/samples/README.md for the file format.
+
+import type { CodeSample } from '@/components/CodeEditorDialog';
+import type { AgentGroupSpec } from '@/lib/types';
+import { fromYAML } from '@/lib/yaml';
+
+export type SamplesPath = `/samples/${string}.yaml`;
+
+function interpolate(text: string, vars: Record<string, string>): string {
+  return text.replace(/\{\{(\w+)\}\}/g, (_, key) =>
+    Object.prototype.hasOwnProperty.call(vars, key) ? vars[key] : `{{${key}}}`,
+  );
+}
+
+async function fetchYaml<T>(path: SamplesPath, vars: Record<string, string>): Promise<T> {
+  const res = await fetch(path);
+  if (!res.ok) {
+    throw new Error(`Failed to load ${path}: ${res.status} ${res.statusText}`);
+  }
+  const text = await res.text();
+  const merged = { now: new Date().toISOString(), ...vars };
+  return fromYAML(interpolate(text, merged)) as T;
+}
+
+export async function loadSamples(
+  path: SamplesPath,
+  vars: Record<string, string> = {},
+): Promise<CodeSample[]> {
+  const data = await fetchYaml<unknown>(path, vars);
+  if (!Array.isArray(data)) {
+    throw new Error(`Expected ${path} to be a YAML list of samples`);
+  }
+  return data as CodeSample[];
+}
+
+// AgentGroup samples carry extra top-level fields (name, attributes, spec)
+// because the AgentGroup editor splits them into separate text areas.
+export interface AgentGroupSample {
+  label: string;
+  description?: string;
+  name: string;
+  attributes: Record<string, string>;
+  spec: AgentGroupSpec;
+}
+
+export async function loadAgentGroupSamples(): Promise<AgentGroupSample[]> {
+  const data = await fetchYaml<unknown>('/samples/agentgroups.yaml', {});
+  if (!Array.isArray(data)) {
+    throw new Error('Expected /samples/agentgroups.yaml to be a YAML list');
+  }
+  return data as AgentGroupSample[];
+}

--- a/web/lib/samples.ts
+++ b/web/lib/samples.ts
@@ -11,9 +11,12 @@ import { fromYAML } from '@/lib/yaml';
 export type SamplesPath = `/samples/${string}.yaml`;
 
 function interpolate(text: string, vars: Record<string, string>): string {
-  return text.replace(/\{\{(\w+)\}\}/g, (_, key) =>
-    Object.prototype.hasOwnProperty.call(vars, key) ? vars[key] : `{{${key}}}`,
-  );
+  return text.replace(/\{\{(\w+)\}\}/g, (match, key) => {
+    if (!Object.prototype.hasOwnProperty.call(vars, key)) return match;
+    const v = vars[key];
+    if (typeof v !== 'string') return match;
+    return v;
+  });
 }
 
 async function fetchYaml<T>(path: SamplesPath, vars: Record<string, string>): Promise<T> {

--- a/web/public/samples/README.md
+++ b/web/public/samples/README.md
@@ -1,0 +1,41 @@
+# Editor samples
+
+These YAML files back the **Load sample** dropdown in the web UI's resource
+editors. Each file is a YAML list of `{ label, description, value }` entries —
+add, remove, or rewrite samples here without touching TypeScript.
+
+The shape is identical to the resource body the editor saves, so a sample is
+just a valid request payload pre-filled.
+
+## Tokens
+
+Place-holders are substituted at fetch time:
+
+| Token           | Meaning                                                    |
+|-----------------|------------------------------------------------------------|
+| `{{namespace}}` | The currently selected namespace (for namespace-scoped UIs) |
+| `{{now}}`       | Current ISO-8601 timestamp                                 |
+
+## Files
+
+| File | Used by |
+|---|---|
+| `roles.yaml` | `/roles` create + edit |
+| `rolebindings.yaml` | `/rolebindings` create + edit |
+| `certificates.yaml` | `/certificates` create + edit |
+| `users.yaml` | `/users` create |
+| `agentpackages.yaml` | `/agentpackages` create + edit |
+| `agentremoteconfigs.yaml` | `/agentremoteconfigs` create + edit |
+| `agentspecs.yaml` | Agent detail "Edit spec" dialog (spec subtree only) |
+| `agentgroups.yaml` | `/agentgroups` create + edit (entries include `name`, `attributes`, `spec`) |
+
+## Adding a sample
+
+```yaml
+- label: Short human-readable name shown in the menu
+  description: One-liner shown as secondary text
+  value:
+    # ...the payload, exactly as you would type it in the editor...
+```
+
+Save the file — the next time the dialog is opened the new entry appears.

--- a/web/public/samples/agentgroups.yaml
+++ b/web/public/samples/agentgroups.yaml
@@ -1,0 +1,73 @@
+# AgentGroup samples. Unlike the other files these entries carry top-level
+# `name`, `attributes`, and `spec` because the edit dialog has three separate
+# text areas (Name, Attributes, Spec) rather than one combined editor.
+
+- label: Match all agents
+  description: Lowest priority, empty selector
+  name: match-all
+  attributes:
+    description: Catch-all group
+  spec:
+    priority: 0
+    selector:
+      identifyingAttributes: {}
+      nonIdentifyingAttributes: {}
+
+- label: Match by service.name
+  description: Selector against an identifying attribute
+  name: svc-otelcol
+  attributes:
+    team: platform
+  spec:
+    priority: 10
+    selector:
+      identifyingAttributes:
+        service.name: otelcol
+      nonIdentifyingAttributes: {}
+
+- label: With agentConfig → remote config ref
+  description: Apply an existing AgentRemoteConfig by name
+  name: prod-otelcol
+  attributes:
+    env: prod
+  spec:
+    priority: 100
+    selector:
+      identifyingAttributes:
+        service.namespace: prod
+      nonIdentifyingAttributes: {}
+    agentConfig:
+      agentRemoteConfig:
+        agentRemoteConfigRef: otlp-to-backend
+
+- label: Inline agentConfig (text/yaml)
+  description: Embed the collector config directly in the spec
+  name: inline-config
+  attributes: {}
+  spec:
+    priority: 50
+    selector:
+      identifyingAttributes:
+        service.name: otelcol
+      nonIdentifyingAttributes: {}
+    agentConfig:
+      agentRemoteConfig:
+        agentRemoteConfigSpec:
+          contentType: text/yaml
+          value: |
+            receivers:
+              otlp:
+                protocols:
+                  grpc:
+                    endpoint: 0.0.0.0:4317
+            processors:
+              batch: {}
+            exporters:
+              debug:
+                verbosity: basic
+            service:
+              pipelines:
+                traces:
+                  receivers: [otlp]
+                  processors: [batch]
+                  exporters: [debug]

--- a/web/public/samples/agentpackages.yaml
+++ b/web/public/samples/agentpackages.yaml
@@ -1,0 +1,32 @@
+# AgentPackage samples — replace SHA256s/URLs with the real values.
+
+- label: OTel Collector — linux/amd64 tarball
+  description: Top-level package with download URL + version
+  value:
+    metadata:
+      name: otelcol-contrib-linux-amd64
+      namespace: "{{namespace}}"
+      attributes: {}
+      createdAt: "{{now}}"
+    spec:
+      packageType: TopLevel
+      version: 0.110.0
+      downloadUrl: https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.110.0/otelcol-contrib_0.110.0_linux_amd64.tar.gz
+      contentHash: sha256:REPLACE_WITH_RELEASE_SHA256
+
+- label: Add-on package with signature
+  description: Non-top-level package and a signature blob placeholder
+  value:
+    metadata:
+      name: custom-receiver-addon
+      namespace: "{{namespace}}"
+      attributes: {}
+      createdAt: "{{now}}"
+    spec:
+      packageType: AddOn
+      version: 1.2.3
+      downloadUrl: https://example.com/packages/custom-receiver-1.2.3.tar.gz
+      contentHash: sha256:REPLACE_WITH_SHA256
+      signature: base64-encoded-signature
+      headers:
+        Authorization: Bearer REPLACE_TOKEN

--- a/web/public/samples/agentpackages.yaml
+++ b/web/public/samples/agentpackages.yaml
@@ -1,4 +1,9 @@
-# AgentPackage samples — replace SHA256s/URLs with the real values.
+# AgentPackage samples.
+#
+# spec.contentHash and spec.signature are []byte server-side and therefore
+# decoded as base64 from JSON — supply real base64-encoded bytes (e.g. the
+# output of `sha256sum file | xxd -r -p | base64`). The placeholders below
+# parse but obviously do not match real artifacts.
 
 - label: OTel Collector — linux/amd64 tarball
   description: Top-level package with download URL + version
@@ -12,7 +17,7 @@
       packageType: TopLevel
       version: 0.110.0
       downloadUrl: https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.110.0/otelcol-contrib_0.110.0_linux_amd64.tar.gz
-      contentHash: sha256:REPLACE_WITH_RELEASE_SHA256
+      contentHash: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
 
 - label: Add-on package with signature
   description: Non-top-level package and a signature blob placeholder
@@ -26,7 +31,7 @@
       packageType: AddOn
       version: 1.2.3
       downloadUrl: https://example.com/packages/custom-receiver-1.2.3.tar.gz
-      contentHash: sha256:REPLACE_WITH_SHA256
-      signature: base64-encoded-signature
+      contentHash: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
+      signature: AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=
       headers:
         Authorization: Bearer REPLACE_TOKEN

--- a/web/public/samples/agentremoteconfigs.yaml
+++ b/web/public/samples/agentremoteconfigs.yaml
@@ -1,0 +1,117 @@
+# AgentRemoteConfig samples. spec.value carries the actual collector config
+# string — kept as a YAML block scalar (|) so it stays readable.
+
+- label: OTLP → debug (minimal)
+  description: Receive OTLP, log to stdout via debug exporter
+  value:
+    metadata:
+      name: otlp-debug
+      namespace: "{{namespace}}"
+      attributes: {}
+      createdAt: "{{now}}"
+    spec:
+      contentType: text/yaml
+      value: |
+        receivers:
+          otlp:
+            protocols:
+              grpc:
+                endpoint: 0.0.0.0:4317
+              http:
+                endpoint: 0.0.0.0:4318
+
+        processors:
+          batch: {}
+
+        exporters:
+          debug:
+            verbosity: basic
+
+        service:
+          pipelines:
+            traces:
+              receivers: [otlp]
+              processors: [batch]
+              exporters: [debug]
+            metrics:
+              receivers: [otlp]
+              processors: [batch]
+              exporters: [debug]
+            logs:
+              receivers: [otlp]
+              processors: [batch]
+              exporters: [debug]
+
+- label: OTLP → remote backend (OTLP HTTP)
+  description: Includes batch + memory_limiter and an auth header
+  value:
+    metadata:
+      name: otlp-to-backend
+      namespace: "{{namespace}}"
+      attributes: {}
+      createdAt: "{{now}}"
+    spec:
+      contentType: text/yaml
+      value: |
+        receivers:
+          otlp:
+            protocols:
+              grpc:
+                endpoint: 0.0.0.0:4317
+
+        processors:
+          batch: {}
+          memory_limiter:
+            check_interval: 1s
+            limit_mib: 512
+
+        exporters:
+          otlphttp:
+            endpoint: https://otlp.example.com
+            headers:
+              authorization: Bearer REPLACE_ME
+
+        service:
+          pipelines:
+            traces:
+              receivers: [otlp]
+              processors: [memory_limiter, batch]
+              exporters: [otlphttp]
+            metrics:
+              receivers: [otlp]
+              processors: [memory_limiter, batch]
+              exporters: [otlphttp]
+
+- label: Prometheus scrape pipeline
+  description: Scrape an HTTP target and forward via OTLP HTTP
+  value:
+    metadata:
+      name: prometheus-scrape
+      namespace: "{{namespace}}"
+      attributes: {}
+      createdAt: "{{now}}"
+    spec:
+      contentType: text/yaml
+      value: |
+        receivers:
+          prometheus:
+            config:
+              scrape_configs:
+                - job_name: app
+                  scrape_interval: 30s
+                  static_configs:
+                    - targets: ['localhost:9090']
+
+        processors:
+          batch: {}
+
+        exporters:
+          otlphttp:
+            endpoint: https://otlp.example.com
+
+        service:
+          pipelines:
+            metrics:
+              receivers: [prometheus]
+              processors: [batch]
+              exporters: [otlphttp]

--- a/web/public/samples/agentspecs.yaml
+++ b/web/public/samples/agentspecs.yaml
@@ -1,0 +1,40 @@
+# Samples for the Agent detail "Edit spec" dialog. Each value is the
+# *spec* subtree only — the dialog edits agent.spec, not the whole agent.
+
+- label: Set OpAMP endpoint
+  description: Point the agent at a different OpAMP server
+  value:
+    connectionSettings:
+      opamp:
+        destinationEndpoint: wss://opamp.example.com/v1/opamp
+        headers:
+          Authorization:
+            - Bearer REPLACE_ME
+
+- label: Bind a remote config
+  description: Apply an AgentRemoteConfig by name
+  value:
+    remoteConfig:
+      remoteConfigNames:
+        - otlp-debug
+
+- label: Request restart
+  description: Sets restartRequiredAt to now
+  value:
+    restartRequiredAt: "{{now}}"
+
+- label: Full example (endpoint + mTLS + remote config + package)
+  description: Combine the common knobs
+  value:
+    connectionSettings:
+      opamp:
+        destinationEndpoint: wss://opamp.example.com/v1/opamp
+        certificateName: agent-client-mtls
+      ownMetrics:
+        destinationEndpoint: https://otlp.example.com/v1/metrics
+    remoteConfig:
+      remoteConfigNames:
+        - otlp-to-backend
+    packagesAvailable:
+      packages:
+        - otelcol-contrib-linux-amd64

--- a/web/public/samples/certificates.yaml
+++ b/web/public/samples/certificates.yaml
@@ -1,0 +1,61 @@
+# Certificate samples — PEM blobs are placeholders; replace before saving.
+
+- label: mTLS client cert
+  description: cert + privateKey for an agent to authenticate to OpAMP
+  value:
+    kind: Certificate
+    apiVersion: v1
+    metadata:
+      name: agent-client-mtls
+      namespace: "{{namespace}}"
+      attributes: {}
+      createdAt: "{{now}}"
+    spec:
+      cert: |
+        -----BEGIN CERTIFICATE-----
+        MIIBkTCB+wIJA...replace me...
+        -----END CERTIFICATE-----
+      privateKey: |
+        -----BEGIN PRIVATE KEY-----
+        MIIEvAIBADANB...replace me...
+        -----END PRIVATE KEY-----
+
+- label: CA bundle only
+  description: Trust roots for verifying the server
+  value:
+    kind: Certificate
+    apiVersion: v1
+    metadata:
+      name: opamp-ca-bundle
+      namespace: "{{namespace}}"
+      attributes: {}
+      createdAt: "{{now}}"
+    spec:
+      caCert: |
+        -----BEGIN CERTIFICATE-----
+        MIIDazCCAlOgAw...replace me...
+        -----END CERTIFICATE-----
+
+- label: Full mTLS (cert + key + CA)
+  description: Client cert and trust roots together
+  value:
+    kind: Certificate
+    apiVersion: v1
+    metadata:
+      name: agent-mtls-bundle
+      namespace: "{{namespace}}"
+      attributes: {}
+      createdAt: "{{now}}"
+    spec:
+      cert: |
+        -----BEGIN CERTIFICATE-----
+        MIIBkTCB+wIJA...replace me...
+        -----END CERTIFICATE-----
+      privateKey: |
+        -----BEGIN PRIVATE KEY-----
+        MIIEvAIBADANB...replace me...
+        -----END PRIVATE KEY-----
+      caCert: |
+        -----BEGIN CERTIFICATE-----
+        MIIDazCCAlOgAw...replace me...
+        -----END CERTIFICATE-----

--- a/web/public/samples/rolebindings.yaml
+++ b/web/public/samples/rolebindings.yaml
@@ -1,0 +1,51 @@
+# RoleBinding samples.
+
+- label: Bind built-in Viewer to a user
+  description: Subject kind=User, identified by email
+  value:
+    kind: RoleBinding
+    apiVersion: v1
+    metadata:
+      namespace: "{{namespace}}"
+      name: viewer-alice
+    spec:
+      roleRef:
+        kind: Role
+        name: Viewer
+      subjects:
+        - kind: User
+          name: alice@example.com
+
+- label: Bind built-in Admin to a GitHub org
+  description: Anyone with the github-org-acme label gets Admin
+  value:
+    kind: RoleBinding
+    apiVersion: v1
+    metadata:
+      namespace: "{{namespace}}"
+      name: admin-github-acme
+    spec:
+      roleRef:
+        kind: Role
+        name: Admin
+      subjects:
+        - kind: Group
+          name: github-org-acme
+
+- label: Bind custom role to multiple users
+  description: Two subjects against a user-defined role name
+  value:
+    kind: RoleBinding
+    apiVersion: v1
+    metadata:
+      namespace: "{{namespace}}"
+      name: agent-operators
+    spec:
+      roleRef:
+        kind: Role
+        name: Agent operator
+      subjects:
+        - kind: User
+          name: alice@example.com
+        - kind: User
+          name: bob@example.com

--- a/web/public/samples/rolebindings.yaml
+++ b/web/public/samples/rolebindings.yaml
@@ -1,39 +1,31 @@
 # RoleBinding samples.
+#
+# Subject kind 'User' (identified by email) is currently the only kind the
+# apiserver expands during RBAC sync; 'Group' subjects are accepted in the
+# request body but produce no Casbin groupings yet.
+#
+# Role names referenced below must already exist as a Role's spec.displayName.
+# Only "default" is auto-seeded — create the other roles first (or change
+# roleRef.name to a role you have created).
 
-- label: Bind built-in Viewer to a user
+- label: Bind a role to a single user
   description: Subject kind=User, identified by email
   value:
     kind: RoleBinding
     apiVersion: v1
     metadata:
       namespace: "{{namespace}}"
-      name: viewer-alice
+      name: agent-operator-alice
     spec:
       roleRef:
         kind: Role
-        name: Viewer
+        name: Agent operator
       subjects:
         - kind: User
           name: alice@example.com
 
-- label: Bind built-in Admin to a GitHub org
-  description: Anyone with the github-org-acme label gets Admin
-  value:
-    kind: RoleBinding
-    apiVersion: v1
-    metadata:
-      namespace: "{{namespace}}"
-      name: admin-github-acme
-    spec:
-      roleRef:
-        kind: Role
-        name: Admin
-      subjects:
-        - kind: Group
-          name: github-org-acme
-
-- label: Bind custom role to multiple users
-  description: Two subjects against a user-defined role name
+- label: Bind a role to multiple users
+  description: Two subjects against the same role
   value:
     kind: RoleBinding
     apiVersion: v1

--- a/web/public/samples/roles.yaml
+++ b/web/public/samples/roles.yaml
@@ -1,0 +1,171 @@
+# Role samples. Edit freely — entries appear in the editor's "Load sample" menu.
+# Keep "Default role (built-in floor)" in sync with
+# pkg/apiserver/module/infrastructure/default_role.go (defaultRoleBuiltInPermissions).
+
+- label: Default role (built-in floor)
+  description: Reset spec.permissions to the read-only floor every user gets
+  value:
+    kind: Role
+    apiVersion: v1
+    metadata:
+      uid: ""
+      createdAt: "{{now}}"
+      updatedAt: "{{now}}"
+    spec:
+      displayName: default
+      description: Default role assigned to all new users on first login
+      isBuiltIn: true
+      permissions:
+        - agent:GET
+        - agent:LIST
+        - agentgroup:GET
+        - agentgroup:LIST
+        - agentpackage:GET
+        - agentpackage:LIST
+        - agentremoteconfig:GET
+        - agentremoteconfig:LIST
+        - connection:GET
+        - connection:LIST
+        - rolebinding:GET
+
+- label: Read-only viewer
+  description: GET/LIST on every resource
+  value:
+    kind: Role
+    apiVersion: v1
+    metadata:
+      uid: ""
+      createdAt: "{{now}}"
+      updatedAt: "{{now}}"
+    spec:
+      displayName: Viewer (custom)
+      description: Read-only access to all resources
+      isBuiltIn: false
+      permissions:
+        - agent:GET
+        - agent:LIST
+        - agentgroup:GET
+        - agentgroup:LIST
+        - agentpackage:GET
+        - agentpackage:LIST
+        - agentremoteconfig:GET
+        - agentremoteconfig:LIST
+        - certificate:GET
+        - certificate:LIST
+        - connection:GET
+        - connection:LIST
+        - rolebinding:GET
+        - rolebinding:LIST
+        - server:GET
+        - server:LIST
+        - user:GET
+        - user:LIST
+        - role:GET
+        - role:LIST
+        - permission:GET
+        - permission:LIST
+
+- label: Agent operator
+  description: Full control over agents + agent groups, read elsewhere
+  value:
+    kind: Role
+    apiVersion: v1
+    metadata:
+      uid: ""
+      createdAt: "{{now}}"
+      updatedAt: "{{now}}"
+    spec:
+      displayName: Agent operator
+      description: Manage agents and groups; read other resources
+      isBuiltIn: false
+      permissions:
+        - agent:GET
+        - agent:LIST
+        - agent:CREATE
+        - agent:UPDATE
+        - agent:DELETE
+        - agentgroup:GET
+        - agentgroup:LIST
+        - agentgroup:CREATE
+        - agentgroup:UPDATE
+        - agentgroup:DELETE
+        - agentremoteconfig:GET
+        - agentremoteconfig:LIST
+        - agentremoteconfig:CREATE
+        - agentremoteconfig:UPDATE
+        - agentremoteconfig:DELETE
+        - agentpackage:GET
+        - agentpackage:LIST
+        - agentpackage:CREATE
+        - agentpackage:UPDATE
+        - agentpackage:DELETE
+        - connection:GET
+        - connection:LIST
+        - certificate:GET
+        - certificate:LIST
+
+- label: Namespace admin
+  description: All actions on every namespace-scoped resource
+  value:
+    kind: Role
+    apiVersion: v1
+    metadata:
+      uid: ""
+      createdAt: "{{now}}"
+      updatedAt: "{{now}}"
+    spec:
+      displayName: Namespace admin
+      description: Full control of namespace-scoped resources
+      isBuiltIn: false
+      permissions:
+        - agent:GET
+        - agent:LIST
+        - agent:CREATE
+        - agent:UPDATE
+        - agent:DELETE
+        - agentgroup:GET
+        - agentgroup:LIST
+        - agentgroup:CREATE
+        - agentgroup:UPDATE
+        - agentgroup:DELETE
+        - agentpackage:GET
+        - agentpackage:LIST
+        - agentpackage:CREATE
+        - agentpackage:UPDATE
+        - agentpackage:DELETE
+        - agentremoteconfig:GET
+        - agentremoteconfig:LIST
+        - agentremoteconfig:CREATE
+        - agentremoteconfig:UPDATE
+        - agentremoteconfig:DELETE
+        - certificate:GET
+        - certificate:LIST
+        - certificate:CREATE
+        - certificate:UPDATE
+        - certificate:DELETE
+        - connection:GET
+        - connection:LIST
+        - connection:CREATE
+        - connection:UPDATE
+        - connection:DELETE
+        - rolebinding:GET
+        - rolebinding:LIST
+        - rolebinding:CREATE
+        - rolebinding:UPDATE
+        - rolebinding:DELETE
+
+- label: Cluster admin (everything)
+  description: "Wildcard: any action on any resource"
+  value:
+    kind: Role
+    apiVersion: v1
+    metadata:
+      uid: ""
+      createdAt: "{{now}}"
+      updatedAt: "{{now}}"
+    spec:
+      displayName: Cluster admin
+      description: Wildcard access to everything
+      isBuiltIn: false
+      permissions:
+        - "*:*"

--- a/web/public/samples/roles.yaml
+++ b/web/public/samples/roles.yaml
@@ -1,9 +1,18 @@
 # Role samples. Edit freely — entries appear in the editor's "Load sample" menu.
-# Keep "Default role (built-in floor)" in sync with
-# pkg/apiserver/module/infrastructure/default_role.go (defaultRoleBuiltInPermissions).
+#
+# Notes:
+# - spec.isBuiltIn is ignored by CreateRole (always false on create) and is
+#   immutable on PUT. Use these samples in the *edit* dialog to reset/replace
+#   the permissions of an existing role, or in the *create* dialog as a
+#   permission template under a new displayName.
+# - Permission names must match an existing Permission record (the apiserver
+#   seeds one per resource×action). Wildcards like "*:*" are NOT seeded.
+# - Keep "Default role (reset baseline)" in sync with
+#   pkg/apiserver/module/infrastructure/default_role.go
+#   (defaultRoleBuiltInPermissions).
 
-- label: Default role (built-in floor)
-  description: Reset spec.permissions to the read-only floor every user gets
+- label: Default role (reset baseline)
+  description: Restore spec.permissions on the existing "default" role to the read-only floor
   value:
     kind: Role
     apiVersion: v1
@@ -14,7 +23,6 @@
     spec:
       displayName: default
       description: Default role assigned to all new users on first login
-      isBuiltIn: true
       permissions:
         - agent:GET
         - agent:LIST
@@ -40,7 +48,6 @@
     spec:
       displayName: Viewer (custom)
       description: Read-only access to all resources
-      isBuiltIn: false
       permissions:
         - agent:GET
         - agent:LIST
@@ -77,7 +84,6 @@
     spec:
       displayName: Agent operator
       description: Manage agents and groups; read other resources
-      isBuiltIn: false
       permissions:
         - agent:GET
         - agent:LIST
@@ -116,7 +122,6 @@
     spec:
       displayName: Namespace admin
       description: Full control of namespace-scoped resources
-      isBuiltIn: false
       permissions:
         - agent:GET
         - agent:LIST
@@ -153,19 +158,3 @@
         - rolebinding:CREATE
         - rolebinding:UPDATE
         - rolebinding:DELETE
-
-- label: Cluster admin (everything)
-  description: "Wildcard: any action on any resource"
-  value:
-    kind: Role
-    apiVersion: v1
-    metadata:
-      uid: ""
-      createdAt: "{{now}}"
-      updatedAt: "{{now}}"
-    spec:
-      displayName: Cluster admin
-      description: Wildcard access to everything
-      isBuiltIn: false
-      permissions:
-        - "*:*"

--- a/web/public/samples/users.yaml
+++ b/web/public/samples/users.yaml
@@ -1,0 +1,29 @@
+# User samples.
+
+- label: Active user
+  description: Email + username, isActive=true
+  value:
+    kind: User
+    apiVersion: v1
+    metadata:
+      uid: ""
+      createdAt: "{{now}}"
+      updatedAt: "{{now}}"
+    spec:
+      email: alice@example.com
+      username: alice
+      isActive: true
+
+- label: Inactive user
+  description: Disabled account (cannot sign in)
+  value:
+    kind: User
+    apiVersion: v1
+    metadata:
+      uid: ""
+      createdAt: "{{now}}"
+      updatedAt: "{{now}}"
+    spec:
+      email: legacy@example.com
+      username: legacy-bot
+      isActive: false

--- a/web/public/samples/users.yaml
+++ b/web/public/samples/users.yaml
@@ -1,7 +1,10 @@
 # User samples.
+#
+# CreateUser always provisions an active user (spec.isActive is ignored on
+# POST); use a follow-up PUT to deactivate.
 
-- label: Active user
-  description: Email + username, isActive=true
+- label: New user
+  description: Email + username
   value:
     kind: User
     apiVersion: v1
@@ -12,18 +15,3 @@
     spec:
       email: alice@example.com
       username: alice
-      isActive: true
-
-- label: Inactive user
-  description: Disabled account (cannot sign in)
-  value:
-    kind: User
-    apiVersion: v1
-    metadata:
-      uid: ""
-      createdAt: "{{now}}"
-      updatedAt: "{{now}}"
-    spec:
-      email: legacy@example.com
-      username: legacy-bot
-      isActive: false


### PR DESCRIPTION
## Summary

Two related web UX improvements that came out of trying to use the YAML-first editing flow with limited permissions:

- **"Load sample" in every YAML editor.** Every resource edit dialog (roles, rolebindings, users, certificates, agent packages, agent remote configs, agent specs, agent groups) now has a *Load sample ▼* menu that fills the editor with a working example. The first roles sample is the built-in default role, so it doubles as a reset baseline.
- **`/profile` page.** Users without `role:LIST` couldn't check which roles applied to them. The new page renders `/api/v1/users/me`: account metadata + a table of every applied role with source rolebinding and permission chips. Linked from the AppBar account dropdown.

## How samples are stored

Samples live as YAML files under `web/public/samples/` so anyone — not just frontend devs — can edit them. A small loader in `web/lib/samples.ts` fetches the file lazily when the dialog opens and interpolates `{{namespace}}` and `{{now}}` tokens. Each sample re-serializes to whichever format (YAML or JSON) the editor is currently in.

```
web/public/samples/
├── README.md
├── agentgroups.yaml
├── agentpackages.yaml
├── agentremoteconfigs.yaml
├── agentspecs.yaml
├── certificates.yaml
├── rolebindings.yaml
├── roles.yaml          # first entry == built-in default role
└── users.yaml
```

## Test plan

- [ ] `cd web && npm run dev`, sign in
- [ ] On `/roles` → New → *Load sample* → "Default role (built-in floor)" → save
- [ ] On `/rolebindings`, `/certificates`, `/agentpackages`, `/agentremoteconfigs` → each *Load sample* entry serializes with the current namespace
- [ ] Toggle editor between YAML and JSON, load a sample again — output reflects the active format
- [ ] On `/agents/<id>` edit dialog and `/agentgroups` edit dialog — samples load into their respective shapes (agent spec subtree vs. 3-field group form)
- [ ] Click the account icon (top-right) → *My profile* → page renders email, status, uid, labels (if any), and the roles table; the built-in default role row says "Auto-assigned (built-in default)"

🤖 Generated with [Claude Code](https://claude.com/claude-code)