### PR TITLE
feat(web): RBAC-aware sidebar with show-restricted toggle

### DIFF
--- a/web/components/AppLayout.tsx
+++ b/web/components/AppLayout.tsx
@@ -165,7 +165,8 @@ export default function AppLayout({ children }: { children: ReactNode }) {
     .map((section) => ({
       ...section,
       items: section.items.filter(
-        (item) => showAll || !item.requires || hasPermission(item.requires.resource, item.requires.action),
+        (item) =>
+          showAll || !item.requires || hasPermission(item.requires.resource, item.requires.action),
       ),
     }))
     .filter((section) => section.items.length > 0);

--- a/web/components/AppLayout.tsx
+++ b/web/components/AppLayout.tsx
@@ -4,12 +4,15 @@ import {
   AppBar,
   Box,
   Drawer,
+  FormControlLabel,
   List,
   ListItem,
   ListItemButton,
   ListItemIcon,
   ListItemText,
   ListSubheader,
+  Stack,
+  Switch,
   Toolbar,
   Typography,
   IconButton,
@@ -40,6 +43,7 @@ import { usePathname } from 'next/navigation';
 import { type ReactNode, useEffect, useState } from 'react';
 import { useAuth } from './AuthProvider';
 import NamespaceSelector from './NamespaceSelector';
+import { usePermissions } from './PermissionsProvider';
 import VersionFooter from './VersionFooter';
 
 const drawerWidth = 240;
@@ -49,6 +53,9 @@ interface NavItem {
   text: string;
   icon: ReactNode;
   href: string;
+  // RBAC requirement to make this item visible. Items with no `requires`
+  // (e.g. Dashboard) are always shown.
+  requires?: { resource: string; action: string };
 }
 interface NavSection {
   heading: string;
@@ -69,33 +76,108 @@ const sections: NavSection[] = [
   {
     heading: 'Agents',
     items: [
-      { text: 'Agent Groups', icon: <GroupIcon />, href: '/agentgroups' },
-      { text: 'Agents', icon: <ComputerIcon />, href: '/agents' },
-      { text: 'Connections', icon: <CableIcon />, href: '/connections' },
-      { text: 'Agent Packages', icon: <PackageIcon />, href: '/agentpackages' },
-      { text: 'Remote Configs', icon: <TuneIcon />, href: '/agentremoteconfigs' },
-      { text: 'Certificates', icon: <CertIcon />, href: '/certificates' },
+      {
+        text: 'Agent Groups',
+        icon: <GroupIcon />,
+        href: '/agentgroups',
+        requires: { resource: 'agentgroup', action: 'LIST' },
+      },
+      {
+        text: 'Agents',
+        icon: <ComputerIcon />,
+        href: '/agents',
+        requires: { resource: 'agent', action: 'LIST' },
+      },
+      {
+        text: 'Connections',
+        icon: <CableIcon />,
+        href: '/connections',
+        requires: { resource: 'connection', action: 'LIST' },
+      },
+      {
+        text: 'Agent Packages',
+        icon: <PackageIcon />,
+        href: '/agentpackages',
+        requires: { resource: 'agentpackage', action: 'LIST' },
+      },
+      {
+        text: 'Remote Configs',
+        icon: <TuneIcon />,
+        href: '/agentremoteconfigs',
+        requires: { resource: 'agentremoteconfig', action: 'LIST' },
+      },
+      {
+        text: 'Certificates',
+        icon: <CertIcon />,
+        href: '/certificates',
+        requires: { resource: 'certificate', action: 'LIST' },
+      },
     ],
   },
   {
     heading: 'Access',
     items: [
-      { text: 'Users', icon: <PeopleIcon />, href: '/users' },
-      { text: 'Roles', icon: <RoleIcon />, href: '/roles' },
-      { text: 'Role Bindings', icon: <RoleBindingIcon />, href: '/rolebindings' },
+      {
+        text: 'Users',
+        icon: <PeopleIcon />,
+        href: '/users',
+        requires: { resource: 'user', action: 'LIST' },
+      },
+      {
+        text: 'Roles',
+        icon: <RoleIcon />,
+        href: '/roles',
+        requires: { resource: 'role', action: 'LIST' },
+      },
+      {
+        text: 'Role Bindings',
+        icon: <RoleBindingIcon />,
+        href: '/rolebindings',
+        requires: { resource: 'rolebinding', action: 'LIST' },
+      },
     ],
   },
   {
     heading: 'Admin',
-    items: [{ text: 'Servers', icon: <DnsIcon />, href: '/servers' }],
+    items: [
+      {
+        text: 'Servers',
+        icon: <DnsIcon />,
+        href: '/servers',
+        requires: { resource: 'server', action: 'LIST' },
+      },
+    ],
   },
 ];
 
 export default function AppLayout({ children }: { children: ReactNode }) {
   const pathname = usePathname();
   const { email, logout } = useAuth();
+  const { hasPermission, showAll, setShowAll } = usePermissions();
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
   const [drawerOpen, setDrawerOpen] = useState(true);
+
+  // Filter nav items by RBAC. Items without `requires` (Dashboard) always show;
+  // others need the resource:LIST permission unless the user has toggled
+  // "Show restricted menus" on (e.g. for exploration). Sections with no
+  // visible items are dropped entirely so we don't leave dangling headers.
+  const visibleSections = sections
+    .map((section) => ({
+      ...section,
+      items: section.items.filter(
+        (item) => showAll || !item.requires || hasPermission(item.requires.resource, item.requires.action),
+      ),
+    }))
+    .filter((section) => section.items.length > 0);
+
+  const hiddenCount = sections.reduce(
+    (sum, s) =>
+      sum +
+      s.items.filter(
+        (item) => item.requires && !hasPermission(item.requires.resource, item.requires.action),
+      ).length,
+    0,
+  );
 
   // Hydrate persisted sidebar state after mount (avoids SSR/CSR mismatch).
   useEffect(() => {
@@ -195,7 +277,7 @@ export default function AppLayout({ children }: { children: ReactNode }) {
       >
         <Toolbar />
         <Box sx={{ overflow: 'auto', flexGrow: 1 }}>
-          {sections.map((section) => (
+          {visibleSections.map((section) => (
             <List
               key={section.heading}
               dense
@@ -224,6 +306,44 @@ export default function AppLayout({ children }: { children: ReactNode }) {
               })}
             </List>
           ))}
+        </Box>
+        <Box
+          sx={{
+            px: 2,
+            py: 1,
+            borderTop: '1px solid',
+            borderColor: 'divider',
+          }}
+        >
+          <Tooltip
+            title={
+              hiddenCount > 0
+                ? `Reveal ${hiddenCount} menu item${hiddenCount === 1 ? '' : 's'} hidden because you lack LIST permission. Pages may still return 403 when opened.`
+                : 'Reveal menu items hidden by RBAC. You currently have access to all items.'
+            }
+            placement="right"
+          >
+            <FormControlLabel
+              control={
+                <Switch
+                  size="small"
+                  checked={showAll}
+                  onChange={(e) => setShowAll(e.target.checked)}
+                />
+              }
+              label={
+                <Stack direction="row" spacing={0.5} alignItems="baseline">
+                  <Typography variant="caption">Show restricted menus</Typography>
+                  {hiddenCount > 0 && !showAll && (
+                    <Typography variant="caption" color="text.disabled">
+                      ({hiddenCount})
+                    </Typography>
+                  )}
+                </Stack>
+              }
+              sx={{ m: 0, '& .MuiFormControlLabel-label': { ml: 1 } }}
+            />
+          </Tooltip>
         </Box>
         <VersionFooter />
       </Drawer>

--- a/web/components/AppShell.tsx
+++ b/web/components/AppShell.tsx
@@ -4,6 +4,7 @@ import { type ReactNode } from 'react';
 import { usePathname } from 'next/navigation';
 import { AuthProvider, useAuth } from './AuthProvider';
 import { NamespaceProvider } from './NamespaceProvider';
+import { PermissionsProvider } from './PermissionsProvider';
 import AppLayout from './AppLayout';
 
 const PUBLIC_ROUTES = new Set<string>(['/login', '/login/github/callback']);
@@ -23,7 +24,9 @@ function ShellInner({ children }: { children: ReactNode }) {
 
   return (
     <NamespaceProvider>
-      <AppLayout>{children}</AppLayout>
+      <PermissionsProvider>
+        <AppLayout>{children}</AppLayout>
+      </PermissionsProvider>
     </NamespaceProvider>
   );
 }

--- a/web/components/PermissionsProvider.tsx
+++ b/web/components/PermissionsProvider.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import { api } from '@/lib/api-client';
+import type { UserProfileResponse } from '@/lib/types';
+import { useAuth } from './AuthProvider';
+
+const SHOW_ALL_KEY = 'opamp.menuShowAll';
+
+interface PermissionsContextValue {
+  permissions: Set<string>;
+  loading: boolean;
+  hasPermission: (resource: string, action: string) => boolean;
+  showAll: boolean;
+  setShowAll: (v: boolean) => void;
+  refresh: () => Promise<void>;
+}
+
+const PermissionsContext = createContext<PermissionsContextValue | undefined>(undefined);
+
+// Permission strings are of the form "<resource>:<action>" (e.g. "agent:LIST").
+// Roles may also hold wildcards like "agent:*", "*:LIST", or "*:*".
+function matches(perms: Set<string>, resource: string, action: string): boolean {
+  return (
+    perms.has(`${resource}:${action}`) ||
+    perms.has(`${resource}:*`) ||
+    perms.has(`*:${action}`) ||
+    perms.has('*:*')
+  );
+}
+
+export function PermissionsProvider({ children }: { children: ReactNode }) {
+  const { authenticated } = useAuth();
+  const [permissions, setPermissions] = useState<Set<string>>(new Set());
+  const [loading, setLoading] = useState(true);
+  const [showAll, setShowAllState] = useState(false);
+
+  // Hydrate showAll from localStorage after mount (avoid SSR/CSR mismatch).
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const stored = window.localStorage.getItem(SHOW_ALL_KEY);
+    if (stored === null) return;
+    setShowAllState(stored === '1');
+  }, []);
+
+  const refresh = useCallback(async () => {
+    if (!authenticated) {
+      setPermissions(new Set());
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    try {
+      const profile = await api.get<UserProfileResponse>('/api/v1/users/me');
+      const set = new Set<string>();
+      for (const entry of profile.roles ?? []) {
+        for (const p of entry.role.spec.permissions ?? []) {
+          set.add(p);
+        }
+      }
+      setPermissions(set);
+    } catch {
+      // On failure leave permissions empty; the toggle still lets the user
+      // navigate. api-client handles 401 globally.
+      setPermissions(new Set());
+    } finally {
+      setLoading(false);
+    }
+  }, [authenticated]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const setShowAll = useCallback((v: boolean) => {
+    setShowAllState(v);
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(SHOW_ALL_KEY, v ? '1' : '0');
+    }
+  }, []);
+
+  const hasPermission = useCallback(
+    (resource: string, action: string) => matches(permissions, resource, action),
+    [permissions],
+  );
+
+  const value = useMemo<PermissionsContextValue>(
+    () => ({ permissions, loading, hasPermission, showAll, setShowAll, refresh }),
+    [permissions, loading, hasPermission, showAll, setShowAll, refresh],
+  );
+
+  return <PermissionsContext.Provider value={value}>{children}</PermissionsContext.Provider>;
+}
+
+export function usePermissions(): PermissionsContextValue {
+  const ctx = useContext(PermissionsContext);
+  if (!ctx) throw new Error('usePermissions must be used within PermissionsProvider');
+  return ctx;
+}


### PR DESCRIPTION
## Summary
- New `PermissionsProvider` loads `/api/v1/users/me`, aggregates the user's permissions, and offers `hasPermission(resource, action)` with wildcard support (`*:*`, `r:*`, `*:a`).
- Sidebar nav items each declare a `resource:LIST` requirement (Dashboard has none). Items the user can't LIST — and any section that ends up empty — are dropped from the drawer.
- New "Show restricted menus" toggle in the sidebar bottom-left (above the version footer, persisted to `localStorage`). Flipping it on reveals every menu; tooltip warns the page itself may still return 403.

## Test plan
- [ ] Sign in as a user with only the default role (no `certificate:LIST`, `user:LIST`, `role:LIST`, `rolebinding:LIST`, `server:LIST`) — confirm those items and the now-empty `Access`/`Admin` sections do not render.
- [ ] Flip the bottom-left "Show restricted menus" toggle — all menu items reappear; the hidden-count chip disappears.
- [ ] Reload the page — toggle state persists.
- [ ] Sign in as Admin/SuperAdmin (or a role with `*:*`) — the toggle shows no hidden count and every item renders even when off.
- [ ] Click a hidden item with the toggle on — the page loads and any backend 403 is surfaced as the existing error path (not a crash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)