### PR TITLE
fix(web): bake image tag into web bundle as WEB_VERSION

### DIFF
--- a/.github/workflows/web-release.yaml
+++ b/.github/workflows/web-release.yaml
@@ -50,6 +50,8 @@ jobs:
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ghcr.io/minuk-dev/opampcommander-web:${{ env.VERSION }}
+          build-args: |
+            VERSION=${{ env.VERSION }}
           provenance: false
           cache-from: type=gha,scope=opampcommander-web
           cache-to: type=gha,mode=max,scope=opampcommander-web

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -16,10 +16,19 @@ RUN apk add --no-cache libc6-compat && npm ci --no-audit --no-fund
 # --- builder: produce .next/standalone ---------------------------------------
 FROM node:${NODE_VERSION} AS builder
 WORKDIR /app
-ENV NEXT_TELEMETRY_DISABLED=1
+# VERSION is the tag this image will be pushed under (computed by
+# scripts/version.sh in CI). It's baked into the bundle as
+# NEXT_PUBLIC_WEB_VERSION so the running app can show its own version
+# without a separate runtime lookup. Required — fail the build rather
+# than silently shipping the stale package.json fallback when CI forgets
+# to pass it. For local builds, pass e.g. `--build-arg VERSION=dev`.
+ARG VERSION
+ENV NEXT_TELEMETRY_DISABLED=1 \
+    NEXT_PUBLIC_WEB_VERSION=${VERSION}
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
-RUN npm run build
+RUN test -n "${VERSION}" || (echo "ERROR: VERSION build-arg is required (pass --build-arg VERSION=...)" >&2 && exit 1) \
+ && npm run build
 
 # --- runtime: minimal, non-root ---------------------------------------------
 FROM node:${NODE_VERSION} AS runner

--- a/web/app/version/page.tsx
+++ b/web/app/version/page.tsx
@@ -5,52 +5,82 @@ import { useEffect, useState } from 'react';
 import PageHeader from '@/components/PageHeader';
 import JsonBlock from '@/components/JsonBlock';
 import { api } from '@/lib/api-client';
+import { WEB_VERSION } from '@/lib/web-version';
+
+function InfoRows({ entries }: { entries: Array<[string, unknown]> }) {
+  return (
+    <Stack spacing={1}>
+      {entries.map(([k, v]) => (
+        <Stack key={k} direction="row" justifyContent="space-between">
+          <Typography variant="body2" color="text.secondary">
+            {k}
+          </Typography>
+          <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
+            {typeof v === 'string' ? v : JSON.stringify(v)}
+          </Typography>
+        </Stack>
+      ))}
+    </Stack>
+  );
+}
 
 export default function VersionPage() {
-  const [info, setInfo] = useState<Record<string, unknown> | null>(null);
+  const [apiInfo, setApiInfo] = useState<Record<string, unknown> | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
     void (async () => {
       try {
         const data = await api.get<Record<string, unknown>>('/api/v1/version');
-        setInfo(data);
+        setApiInfo(data);
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Failed to fetch version');
       }
     })();
   }, []);
 
+  const webInfo = { version: WEB_VERSION };
+
   return (
     <Box>
-      <PageHeader title="Server version" />
-      {error && <Alert severity="error">{error}</Alert>}
-      {!info && !error && (
-        <Box display="flex" justifyContent="center" mt={4}>
-          <CircularProgress />
-        </Box>
-      )}
-      {info && (
-        <Stack spacing={2}>
-          <Card>
-            <CardContent>
-              <Stack spacing={1}>
-                {Object.entries(info).map(([k, v]) => (
-                  <Stack key={k} direction="row" justifyContent="space-between">
-                    <Typography variant="body2" color="text.secondary">
-                      {k}
-                    </Typography>
-                    <Typography variant="body2" sx={{ fontFamily: 'monospace' }}>
-                      {typeof v === 'string' ? v : JSON.stringify(v)}
-                    </Typography>
-                  </Stack>
-                ))}
-              </Stack>
-            </CardContent>
-          </Card>
-          <JsonBlock title="Raw" value={info} />
-        </Stack>
-      )}
+      <PageHeader title="Version" />
+      <Stack spacing={2}>
+        <Card>
+          <CardContent>
+            <Typography variant="overline" color="text.secondary">
+              Web
+            </Typography>
+            <Box mt={1}>
+              <InfoRows entries={Object.entries(webInfo)} />
+            </Box>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardContent>
+            <Typography variant="overline" color="text.secondary">
+              API server
+            </Typography>
+            {error && (
+              <Box mt={1}>
+                <Alert severity="error">{error}</Alert>
+              </Box>
+            )}
+            {!apiInfo && !error && (
+              <Box display="flex" justifyContent="center" mt={2}>
+                <CircularProgress size={24} />
+              </Box>
+            )}
+            {apiInfo && (
+              <Box mt={1}>
+                <InfoRows entries={Object.entries(apiInfo)} />
+              </Box>
+            )}
+          </CardContent>
+        </Card>
+
+        {apiInfo && <JsonBlock title="Raw" value={{ web: webInfo, apiserver: apiInfo }} />}
+      </Stack>
     </Box>
   );
 }

--- a/web/lib/web-version.ts
+++ b/web/lib/web-version.ts
@@ -1,6 +1,7 @@
-// Web app version pulled from package.json at build time.
-// tsconfig has resolveJsonModule enabled so the import below is type-safe
-// and tree-shakes down to a constant string in the bundle.
+// Web app version. In release/container builds, NEXT_PUBLIC_WEB_VERSION is
+// injected at `next build` time from scripts/version.sh — the same source
+// that tags the image — so the footer matches the deployed image tag. In
+// local dev (no env var), fall back to package.json's version.
 import pkg from '../package.json';
 
-export const WEB_VERSION: string = pkg.version;
+export const WEB_VERSION: string = process.env.NEXT_PUBLIC_WEB_VERSION || pkg.version;


### PR DESCRIPTION
## Summary
- Sidebar footer and `/version` page were reading the web version from `package.json` (hardcoded `0.1.0`), so deployed builds never matched the container image tag computed by `scripts/version.sh`.
- Web image build now forwards that same `VERSION` into Next.js via `NEXT_PUBLIC_WEB_VERSION`, baked into the bundle at `next build` time. The Dockerfile fails the build if the arg is missing so a misconfigured pipeline can't silently ship the stale `package.json` fallback.
- `/version` page restructured into a Web card (sync data, always rendered) and an API server card with internal loading/error/data states. Raw JSON block is gated on `apiInfo` so users never see a misleading `apiserver: null` payload during loading or after a fetch error.

## Test plan
- [x] `npm run lint`, `npm run format:check`, `npm test`, `npm run build` all pass locally.
- [ ] Confirm CI `web-release` run pushes an image whose footer and `/version` page report the same tag as the image (e.g. `0.1.40-SNAPSHOT-<sha>`).
- [ ] Manually verify `/version` UX during loading and on simulated API error (no `apiserver: null` in the Raw block, spinner/error live inside the API server card).
- [ ] Confirm `docker build ./web` without `--build-arg VERSION=...` now fails loudly with the expected message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)