### PR TITLE
fix(apiserver): propagate AgentRemoteConfig content to agents

### DIFF
--- a/internal/adapter/out/persistence/mongodb/entity/agent.go
+++ b/internal/adapter/out/persistence/mongodb/entity/agent.go
@@ -151,9 +151,18 @@ type AgentConfigFile struct {
 	ContentType string      `bson:"contentType"`
 }
 
-// AgentSpecRemoteConfig is a struct to manage remote config names for agent spec.
+// AgentSpecRemoteConfig stores the remote config files materialised onto the agent's spec.
+// Both name and content (Body/ContentType) are persisted so the next OpAMP response can
+// reproduce the AgentRemoteConfig message even after a cache miss or server restart.
+//
+// LegacyRemoteConfig holds the names-only array used by the pre-content schema. We still
+// decode it so existing documents are not silently emptied on first read after upgrade —
+// the names become placeholders so AgentGroup reconcile knows what to re-resolve.
+// New writes only populate ConfigMap; LegacyRemoteConfig has `omitempty` so it never
+// persists once a fresh write happens.
 type AgentSpecRemoteConfig struct {
-	RemoteConfig []string `bson:"remoteConfig"`
+	ConfigMap          map[string]AgentConfigFile `bson:"configMap,omitempty"`
+	LegacyRemoteConfig []string                   `bson:"remoteConfig,omitempty"`
 }
 
 // AgentRemoteConfigData is a struct to manage remote config data.
@@ -401,7 +410,7 @@ func (ach *AgentComponentHealth) ToDomain() *agentmodel.AgentComponentHealth {
 
 // ToDomain converts the AgentSpecRemoteConfig to domain model.
 func (asrc *AgentSpecRemoteConfig) ToDomain() agentmodel.AgentSpecRemoteConfig {
-	if asrc == nil || len(asrc.RemoteConfig) == 0 {
+	if asrc == nil || (len(asrc.ConfigMap) == 0 && len(asrc.LegacyRemoteConfig) == 0) {
 		return agentmodel.AgentSpecRemoteConfig{
 			ConfigMap: agentmodel.AgentConfigMap{
 				ConfigMap: nil,
@@ -409,14 +418,7 @@ func (asrc *AgentSpecRemoteConfig) ToDomain() agentmodel.AgentSpecRemoteConfig {
 		}
 	}
 
-	// Convert RemoteConfig names to ConfigMap with empty placeholders
-	configMap := make(map[string]agentmodel.AgentConfigFile)
-	for _, name := range asrc.RemoteConfig {
-		configMap[name] = agentmodel.AgentConfigFile{
-			Body:        nil,
-			ContentType: "",
-		}
-	}
+	configMap := asrc.buildDomainConfigMap()
 
 	return agentmodel.AgentSpecRemoteConfig{
 		ConfigMap: agentmodel.AgentConfigMap{
@@ -427,24 +429,44 @@ func (asrc *AgentSpecRemoteConfig) ToDomain() agentmodel.AgentSpecRemoteConfig {
 
 // ToDomainPtr converts the AgentSpecRemoteConfig to domain model pointer.
 func (asrc *AgentSpecRemoteConfig) ToDomainPtr() *agentmodel.AgentSpecRemoteConfig {
-	if asrc == nil || len(asrc.RemoteConfig) == 0 {
+	if asrc == nil || (len(asrc.ConfigMap) == 0 && len(asrc.LegacyRemoteConfig) == 0) {
 		return nil
 	}
 
-	// Convert RemoteConfig names to ConfigMap with empty placeholders
-	configMap := make(map[string]agentmodel.AgentConfigFile)
-	for _, name := range asrc.RemoteConfig {
-		configMap[name] = agentmodel.AgentConfigFile{
-			Body:        nil,
-			ContentType: "",
-		}
-	}
+	configMap := asrc.buildDomainConfigMap()
 
 	return &agentmodel.AgentSpecRemoteConfig{
 		ConfigMap: agentmodel.AgentConfigMap{
 			ConfigMap: configMap,
 		},
 	}
+}
+
+// buildDomainConfigMap merges the new content-bearing ConfigMap with the legacy
+// names-only array. Legacy names appear as empty placeholders; the AgentGroup
+// reconcile loop sees the key set, recognises this agent as in-scope, and rewrites
+// the spec with full content on the next pass. The reconcile loop's "skip when
+// fingerprint unchanged" guard intentionally does not engage here because the
+// before/after content differs (nil placeholders vs. real bytes).
+func (asrc *AgentSpecRemoteConfig) buildDomainConfigMap() map[string]agentmodel.AgentConfigFile {
+	configMap := make(map[string]agentmodel.AgentConfigFile, len(asrc.ConfigMap)+len(asrc.LegacyRemoteConfig))
+
+	for _, name := range asrc.LegacyRemoteConfig {
+		configMap[name] = agentmodel.AgentConfigFile{
+			Body:        nil,
+			ContentType: "",
+		}
+	}
+
+	// New-shape entries win over legacy placeholders for the same name.
+	for name, file := range asrc.ConfigMap {
+		configMap[name] = agentmodel.AgentConfigFile{
+			Body:        file.Body.Data,
+			ContentType: file.ContentType,
+		}
+	}
+
+	return configMap
 }
 
 // ToDomain converts the AgentCustomCapabilities to domain model.
@@ -640,14 +662,20 @@ func AgentSpecRemoteConfigFromDomain(arc *agentmodel.AgentSpecRemoteConfig) *Age
 		return nil
 	}
 
-	// Extract config names from ConfigMap
-	names := make([]string, 0, len(arc.ConfigMap.ConfigMap))
-	for name := range arc.ConfigMap.ConfigMap {
-		names = append(names, name)
+	configMap := make(map[string]AgentConfigFile, len(arc.ConfigMap.ConfigMap))
+	for name, file := range arc.ConfigMap.ConfigMap {
+		configMap[name] = AgentConfigFile{
+			Body: bson.Binary{
+				Subtype: bson.TypeBinaryGeneric,
+				Data:    file.Body,
+			},
+			ContentType: file.ContentType,
+		}
 	}
 
 	return &AgentSpecRemoteConfig{
-		RemoteConfig: names,
+		ConfigMap:          configMap,
+		LegacyRemoteConfig: nil,
 	}
 }
 

--- a/internal/application/service/agentremoteconfig/agentremoteconfig.go
+++ b/internal/application/service/agentremoteconfig/agentremoteconfig.go
@@ -24,6 +24,7 @@ var _ port.AgentRemoteConfigManageUsecase = (*Service)(nil)
 // Service is a service for managing agent remote configs.
 type Service struct {
 	agentRemoteConfigUsecase agentport.AgentRemoteConfigUsecase
+	agentGroupUsecase        agentport.AgentGroupUsecase
 	mapper                   *helper.Mapper
 	sanityFilter             *filter.Sanity
 	clock                    clock.Clock
@@ -33,12 +34,14 @@ type Service struct {
 // NewAgentRemoteConfigService creates a new AgentRemoteConfigService.
 func NewAgentRemoteConfigService(
 	agentRemoteConfigUsecase agentport.AgentRemoteConfigUsecase,
+	agentGroupUsecase agentport.AgentGroupUsecase,
 	logger *slog.Logger,
 ) *Service {
 	realClock := clock.NewRealClock()
 
 	return &Service{
 		agentRemoteConfigUsecase: agentRemoteConfigUsecase,
+		agentGroupUsecase:        agentGroupUsecase,
 		mapper:                   helper.NewMapper(realClock, 0),
 		sanityFilter:             filter.NewSanity(),
 		clock:                    realClock,
@@ -131,6 +134,8 @@ func (s *Service) CreateAgentRemoteConfig(
 		return nil, fmt.Errorf("create agent remote config: %w", err)
 	}
 
+	s.triggerGroupPropagation(ctx, saved.Metadata.Namespace, saved.Metadata.Name)
+
 	return s.mapper.MapAgentRemoteConfigToAPI(saved), nil
 }
 
@@ -158,6 +163,8 @@ func (s *Service) UpdateAgentRemoteConfig(
 		return nil, fmt.Errorf("update agent remote config: %w", err)
 	}
 
+	s.triggerGroupPropagation(ctx, updated.Metadata.Namespace, updated.Metadata.Name)
+
 	return s.mapper.MapAgentRemoteConfigToAPI(updated), nil
 }
 
@@ -184,5 +191,30 @@ func (s *Service) DeleteAgentRemoteConfig(
 		return fmt.Errorf("delete agent remote config: %w", err)
 	}
 
+	s.triggerGroupPropagation(ctx, namespace, name)
+
 	return nil
+}
+
+// triggerGroupPropagation asks the agent group service to re-apply any groups in the
+// namespace that reference this config. Runs in its own goroutine so a slow
+// changedAgentGroupCh consumer cannot block the HTTP handler; the periodic
+// reconciliation loop is the durable safety net.
+//
+// We detach the goroutine from the request ctx with context.WithoutCancel so the
+// propagation finishes even if the HTTP request is cancelled right after mutation.
+func (s *Service) triggerGroupPropagation(ctx context.Context, namespace, name string) {
+	bgCtx := context.WithoutCancel(ctx)
+
+	go func() {
+		err := s.agentGroupUsecase.PropagateAgentRemoteConfigChange(bgCtx, namespace, name)
+		if err != nil {
+			s.logger.Warn(
+				"failed to propagate agent remote config change to groups",
+				slog.String("namespace", namespace),
+				slog.String("name", name),
+				slog.String("error", err.Error()),
+			)
+		}
+	}()
 }

--- a/internal/application/service/namespace/namespace_manage_service_test.go
+++ b/internal/application/service/namespace/namespace_manage_service_test.go
@@ -112,6 +112,18 @@ func (f *fakeAgentGroupUsecase) GetAgentGroupsForAgent(
 	return nil, errNotImplemented
 }
 
+func (f *fakeAgentGroupUsecase) PropagateAgentRemoteConfigChange(
+	context.Context, string, string,
+) error {
+	return nil
+}
+
+func (f *fakeAgentGroupUsecase) ApplyMatchingAgentGroupsToAgent(
+	context.Context, *agentmodel.Agent,
+) error {
+	return nil
+}
+
 type fakeCertificateUsecase struct{}
 
 func (f *fakeCertificateUsecase) GetCertificate(

--- a/internal/application/service/opamp/opamp.go
+++ b/internal/application/service/opamp/opamp.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
 	"sync"
 	"time"
 
@@ -224,19 +225,9 @@ func (s *Service) OnMessage(
 	// Update agent connection status
 	agent.UpdateLastCommunicationInfo(receivedAt, connection)
 
-	err = s.report(agent, message, currentServer)
-	if err != nil {
-		logger.Error("failed to report agent", slog.String("error", err.Error()))
-	}
+	s.reportAndReconcileGroups(ctx, logger, message, agent, currentServer)
 
-	if s.shouldPersistAgent(instanceUID, message) {
-		err = s.agentUsecase.SaveAgent(ctx, agent)
-		if err != nil {
-			logger.Error("failed to save agent", slog.String("error", err.Error()))
-		} else {
-			s.lastSaveAt.Store(instanceUID.String(), receivedAt)
-		}
-	}
+	s.maybePersistAgent(ctx, logger, instanceUID, message, agent, receivedAt)
 
 	// Note: NotifyAgentUpdated is NOT called here to avoid infinite loop.
 	// OnMessage already sends a response via fetchServerToAgent.
@@ -569,6 +560,110 @@ func isHeartbeatOnly(msg *protobufs.AgentToServer) bool {
 		msg.GetAgentDisconnect() == nil &&
 		msg.GetConnectionSettingsRequest() == nil &&
 		msg.GetFlags() == 0
+}
+
+// identitySnapshot captures the fields of an agent that determine which agent groups
+// match it. We compare these before and after applying the incoming AgentToServer
+// message to decide whether to re-evaluate matching agent groups.
+type identitySnapshot struct {
+	namespace                string
+	identifyingAttributes    map[string]string
+	nonIdentifyingAttributes map[string]string
+}
+
+func snapshotIdentity(agent *agentmodel.Agent) identitySnapshot {
+	return identitySnapshot{
+		namespace:                agent.Metadata.Namespace,
+		identifyingAttributes:    maps.Clone(agent.Metadata.Description.IdentifyingAttributes),
+		nonIdentifyingAttributes: maps.Clone(agent.Metadata.Description.NonIdentifyingAttributes),
+	}
+}
+
+func identityChanged(prev identitySnapshot, agent *agentmodel.Agent) bool {
+	if prev.namespace != agent.Metadata.Namespace {
+		return true
+	}
+
+	if !maps.Equal(prev.identifyingAttributes, agent.Metadata.Description.IdentifyingAttributes) {
+		return true
+	}
+
+	return !maps.Equal(prev.nonIdentifyingAttributes, agent.Metadata.Description.NonIdentifyingAttributes)
+}
+
+// reportAndReconcileGroups absorbs incoming AgentToServer reports into the agent and
+// re-evaluates which agent groups apply when the description changed. The identity
+// snapshot/compare is skipped unless the incoming message carries an AgentDescription —
+// that is the only report() input that can affect AgentGroup selectors, and skipping
+// the snapshot avoids two map allocations on every heartbeat plus a full ListAgentGroups
+// scan when agents put monotonic counters under NonIdentifyingAttributes.
+func (s *Service) reportAndReconcileGroups(
+	ctx context.Context,
+	logger *slog.Logger,
+	message *protobufs.AgentToServer,
+	agent *agentmodel.Agent,
+	currentServer *agentmodel.Server,
+) {
+	hasDescription := message.GetAgentDescription() != nil
+
+	var prevIdentity identitySnapshot
+	if hasDescription {
+		prevIdentity = snapshotIdentity(agent)
+	}
+
+	err := s.report(agent, message, currentServer)
+	if err != nil {
+		logger.Error("failed to report agent", slog.String("error", err.Error()))
+	}
+
+	if hasDescription {
+		s.maybeApplyMatchingAgentGroups(ctx, logger, agent, prevIdentity)
+	}
+}
+
+// maybePersistAgent writes the agent through the throttle if the message warrants it,
+// updating the lastSaveAt anchor on success so the next throttle window is measured
+// from this arrival time.
+func (s *Service) maybePersistAgent(
+	ctx context.Context,
+	logger *slog.Logger,
+	instanceUID uuid.UUID,
+	message *protobufs.AgentToServer,
+	agent *agentmodel.Agent,
+	receivedAt time.Time,
+) {
+	if !s.shouldPersistAgent(instanceUID, message) {
+		return
+	}
+
+	err := s.agentUsecase.SaveAgent(ctx, agent)
+	if err != nil {
+		logger.Error("failed to save agent", slog.String("error", err.Error()))
+
+		return
+	}
+
+	s.lastSaveAt.Store(instanceUID.String(), receivedAt)
+}
+
+// maybeApplyMatchingAgentGroups re-evaluates which agent groups apply to the agent when
+// its identity changed after processing the incoming AgentToServer message. This is the
+// trigger that picks up groups for a newly-described agent without waiting for either a
+// group update or the periodic reconciler.
+func (s *Service) maybeApplyMatchingAgentGroups(
+	ctx context.Context,
+	logger *slog.Logger,
+	agent *agentmodel.Agent,
+	prev identitySnapshot,
+) {
+	if !identityChanged(prev, agent) {
+		return
+	}
+
+	err := s.agentGroupUsecase.ApplyMatchingAgentGroupsToAgent(ctx, agent)
+	if err != nil {
+		logger.Warn("failed to apply matching agent groups", slog.String("error", err.Error()))
+	}
 }
 
 func (s *Service) syncConnectionNamespace(

--- a/internal/domain/agent/port/in.go
+++ b/internal/domain/agent/port/in.go
@@ -115,6 +115,15 @@ type AgentGroupUsecase interface {
 		deletedAt time.Time, deletedBy string) error
 	// GetAgentGroupsForAgent retrieves all agent groups that match the agent's attributes.
 	GetAgentGroupsForAgent(ctx context.Context, agent *agentmodel.Agent) ([]*agentmodel.AgentGroup, error)
+	// PropagateAgentRemoteConfigChange re-applies all agent groups in the given namespace that
+	// reference the named AgentRemoteConfig (via AgentRemoteConfigRef). Use this when the
+	// AgentRemoteConfig resource itself changes — the agent group itself was not modified, so
+	// the normal SaveAgentGroup-triggered propagation does not fire.
+	PropagateAgentRemoteConfigChange(ctx context.Context, namespace, remoteConfigName string) error
+	// ApplyMatchingAgentGroupsToAgent finds all agent groups that match the given agent and
+	// applies their remote configs and connection settings. Use this when an agent reports a
+	// new description so it picks up its assigned configs without waiting for a group update.
+	ApplyMatchingAgentGroupsToAgent(ctx context.Context, agent *agentmodel.Agent) error
 }
 
 // AgentGroupRelatedUsecase is an interface that defines methods related to agent groups.

--- a/internal/domain/agent/service/agentgroup.go
+++ b/internal/domain/agent/service/agentgroup.go
@@ -5,11 +5,15 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"maps"
+	"strconv"
+	"sync/atomic"
 	"time"
 
 	agentmodel "github.com/minuk-dev/opampcommander/internal/domain/agent/model"
 	agentport "github.com/minuk-dev/opampcommander/internal/domain/agent/port"
 	"github.com/minuk-dev/opampcommander/internal/domain/model"
+	"github.com/minuk-dev/opampcommander/internal/domain/model/vo"
 )
 
 const (
@@ -18,6 +22,10 @@ const (
 	ChangedAgentGroupBufferSize = 100
 	// PropagationChunkSize is the number of agents to process in each batch when propagating changes.
 	PropagationChunkSize = 50
+	// DefaultReconcileInterval is how often the background loop re-scans every agent group
+	// to repair any drift the event-driven path missed (e.g. messages dropped because the
+	// buffered channel was full, or a SaveAgent that failed midway).
+	DefaultReconcileInterval = 5 * time.Minute
 )
 
 // ErrInvalidRemoteConfig is returned when inline remote config is missing required fields.
@@ -69,7 +77,14 @@ func (s *AgentGroupService) Name() string {
 }
 
 // Run implements lifecycle.Runner.
+//
+// Reconciliation runs on its own goroutine so a long pass (full collection scan +
+// per-group agent updates) never blocks the changedAgentGroupCh consumer below.
+// An initial reconcile fires immediately so post-restart drift is repaired without
+// waiting the full DefaultReconcileInterval.
 func (s *AgentGroupService) Run(ctx context.Context) error {
+	go s.runReconcileLoop(ctx)
+
 	for {
 		select {
 		case <-ctx.Done():
@@ -226,6 +241,153 @@ func matchesSelector(agent *agentmodel.Agent, selector agentmodel.AgentSelector)
 	return true
 }
 
+// PropagateAgentRemoteConfigChange queues propagation for every agent group in the
+// namespace that references the named AgentRemoteConfig via AgentRemoteConfigRef. Inline
+// configs are stored on the group itself and need no re-propagation when an external
+// AgentRemoteConfig changes.
+//
+// Per-group queue failures are logged and the loop continues — the reconcile loop is
+// the durable safety net, but stopping mid-list would leave later groups stale until
+// the next tick for no good reason.
+func (s *AgentGroupService) PropagateAgentRemoteConfigChange(
+	ctx context.Context,
+	namespace string,
+	remoteConfigName string,
+) error {
+	groups, err := s.persistencePort.ListAgentGroups(ctx, nil)
+	if err != nil {
+		return fmt.Errorf("list agent groups for remote-config change: %w", err)
+	}
+
+	for _, group := range groups.Items {
+		if group.IsDeleted() || group.Metadata.Namespace != namespace {
+			continue
+		}
+
+		if !agentGroupReferencesRemoteConfig(group, remoteConfigName) {
+			continue
+		}
+
+		err := s.propagateAgentGroupChangesToAgents(ctx, group)
+		if err != nil {
+			s.logger.Warn("failed to queue agent group propagation after remote config change",
+				slog.String("agent_group", group.Metadata.Name),
+				slog.String("namespace", group.Metadata.Namespace),
+				slog.String("remote_config", remoteConfigName),
+				slog.String("error", err.Error()),
+			)
+		}
+	}
+
+	return nil
+}
+
+// ApplyMatchingAgentGroupsToAgent computes the desired remote-config and connection
+// state from the union of all matching, non-deleted agent groups and applies it to the
+// agent in place. RemoteConfigs are REPLACED (not merged) so entries left behind by
+// previously-matching groups are cleared. The caller is responsible for persisting.
+func (s *AgentGroupService) ApplyMatchingAgentGroupsToAgent(
+	ctx context.Context,
+	agent *agentmodel.Agent,
+) error {
+	groups, err := s.GetAgentGroupsForAgent(ctx, agent)
+	if err != nil {
+		return fmt.Errorf("get agent groups for agent: %w", err)
+	}
+
+	desired := make(map[string]agentmodel.AgentConfigFile)
+
+	for _, group := range groups {
+		configs, err := s.collectGroupRemoteConfigs(ctx, group)
+		if err != nil {
+			return fmt.Errorf("collect remote configs from group %s: %w", group.Metadata.Name, err)
+		}
+
+		maps.Copy(desired, configs)
+	}
+
+	setAgentRemoteConfigs(agent, desired)
+
+	// Connection settings still follow per-group apply semantics (last group wins).
+	// Multi-group connection conflicts remain a known limitation.
+	for _, group := range groups {
+		err := s.applyConnectionSettings(ctx, group, agent)
+		if err != nil {
+			return fmt.Errorf("apply connection settings from group %s: %w", group.Metadata.Name, err)
+		}
+	}
+
+	return nil
+}
+
+// collectGroupRemoteConfigs resolves every remote config declared on the group into a
+// flat name → file map without mutating any agent. ApplyMatchingAgentGroupsToAgent
+// composes the result across all matching groups so an agent's spec reflects the
+// current desired state — not the cumulative history of every group that ever matched.
+func (s *AgentGroupService) collectGroupRemoteConfigs(
+	ctx context.Context,
+	group *agentmodel.AgentGroup,
+) (map[string]agentmodel.AgentConfigFile, error) {
+	out := make(map[string]agentmodel.AgentConfigFile)
+
+	agentGroupName := group.Metadata.Name
+	namespace := group.Metadata.Namespace
+
+	//nolint:staticcheck // backward compatibility - AgentRemoteConfig is deprecated
+	if cfg := group.Spec.AgentRemoteConfig; cfg != nil {
+		file, name, err := s.resolveRemoteConfig(ctx, namespace, agentGroupName, *cfg)
+		if err != nil {
+			return nil, err
+		}
+
+		out[name] = file
+	}
+
+	for _, cfg := range group.Spec.AgentRemoteConfigs {
+		file, name, err := s.resolveRemoteConfig(ctx, namespace, agentGroupName, cfg)
+		if err != nil {
+			return nil, err
+		}
+
+		out[name] = file
+	}
+
+	return out, nil
+}
+
+// setAgentRemoteConfigs replaces the agent's spec.RemoteConfig with exactly the given
+// set, nil-ing the field when the desired set is empty. This is what enables drop-on-
+// reconcile semantics — any keys not present in `configs` are removed.
+func setAgentRemoteConfigs(agent *agentmodel.Agent, configs map[string]agentmodel.AgentConfigFile) {
+	if len(configs) == 0 {
+		agent.Spec.RemoteConfig = nil
+
+		return
+	}
+
+	agent.Spec.RemoteConfig = &agentmodel.AgentSpecRemoteConfig{
+		ConfigMap: agentmodel.AgentConfigMap{
+			ConfigMap: configs,
+		},
+	}
+}
+
+func (s *AgentGroupService) runReconcileLoop(ctx context.Context) {
+	s.reconcileAll(ctx)
+
+	ticker := time.NewTicker(DefaultReconcileInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.reconcileAll(ctx)
+		}
+	}
+}
+
 func (s *AgentGroupService) propagateAgentGroupChangesToAgents(
 	ctx context.Context,
 	agentGroup *agentmodel.AgentGroup,
@@ -236,6 +398,89 @@ func (s *AgentGroupService) propagateAgentGroupChangesToAgents(
 	case <-ctx.Done():
 		return fmt.Errorf("context cancelled: %w", ctx.Err())
 	}
+}
+
+// reconcileAll re-scans every non-deleted agent group and re-applies it to its matching
+// agents. updateAgentsByAgentGroup is idempotent — it only writes when the agent's
+// desired spec actually changed — so this is cheap when nothing has drifted.
+func (s *AgentGroupService) reconcileAll(ctx context.Context) {
+	groups, err := s.persistencePort.ListAgentGroups(ctx, nil)
+	if err != nil {
+		s.logger.Error("reconcile loop: failed to list agent groups",
+			slog.String("error", err.Error()))
+
+		return
+	}
+
+	for _, group := range groups.Items {
+		if group.IsDeleted() {
+			continue
+		}
+
+		err := s.updateAgentsByAgentGroup(ctx, group)
+		if err != nil {
+			s.logger.Warn("reconcile loop: failed to update agents for group",
+				slog.String("agent_group", group.Metadata.Name),
+				slog.String("namespace", group.Metadata.Namespace),
+				slog.String("error", err.Error()),
+			)
+		}
+	}
+}
+
+// agentSpecFingerprint hashes the parts of an agent's spec that are mutated by
+// applyAgentGroupToAgent. The reconcile loop uses this to skip SaveAgent (and the
+// cache write that follows) when applying a group leaves the agent unchanged.
+//
+// On marshalling failure the caller's `before == after` comparison must NOT skip the
+// save, so we return a unique sentinel keyed on the agent identity — two unique
+// sentinels never compare equal across calls for the same agent (they include a
+// counter), forcing the save path on error.
+func agentSpecFingerprint(agent *agentmodel.Agent) string {
+	var connHash []byte
+	if agent.Spec.ConnectionInfo != nil {
+		connHash = agent.Spec.ConnectionInfo.Hash
+	}
+
+	payload := struct {
+		RemoteConfig *agentmodel.AgentSpecRemoteConfig
+		ConnHash     []byte
+	}{
+		RemoteConfig: agent.Spec.RemoteConfig,
+		ConnHash:     connHash,
+	}
+
+	hash, err := vo.NewHashFromAny(payload)
+	if err != nil {
+		// Unique per call so before != after; the caller will fall through to SaveAgent.
+		return "err:" + agent.Metadata.InstanceUID.String() + ":" + strconv.FormatInt(fingerprintErrSeq.Add(1), 10)
+	}
+
+	return hash.String()
+}
+
+// successive marshal failures so before != after in agentSpecFingerprint's callers;
+// not a configuration knob.
+//
+//nolint:gochecknoglobals // process-wide error-path counter used only to differentiate
+var fingerprintErrSeq atomic.Int64
+
+// agentGroupReferencesRemoteConfig reports whether any of the group's remote configs
+// references the named AgentRemoteConfig resource (i.e. via AgentRemoteConfigRef).
+func agentGroupReferencesRemoteConfig(group *agentmodel.AgentGroup, name string) bool {
+	//nolint:staticcheck // backward compatibility - AgentRemoteConfig is deprecated
+	if cfg := group.Spec.AgentRemoteConfig; cfg != nil && cfg.AgentRemoteConfigRef != nil &&
+		*cfg.AgentRemoteConfigRef == name {
+		return true
+	}
+
+	for _, cfg := range group.Spec.AgentRemoteConfigs {
+		if cfg.AgentRemoteConfigRef != nil && *cfg.AgentRemoteConfigRef == name {
+			return true
+		}
+	}
+
+	return false
 }
 
 func (s *AgentGroupService) updateAgentsByAgentGroup(
@@ -259,9 +504,19 @@ func (s *AgentGroupService) updateAgentsByAgentGroup(
 		}
 
 		for _, agent := range agentsResp.Items {
-			err := s.applyAgentGroupToAgent(ctx, agentGroup, agent)
+			before := agentSpecFingerprint(agent)
+
+			// Apply the full desired state (union of every matching group), not just
+			// this group's contribution — otherwise we'd keep adding configs without
+			// ever dropping ones a group removed.
+			err := s.ApplyMatchingAgentGroupsToAgent(ctx, agent)
 			if err != nil {
-				return fmt.Errorf("apply agent group to agent %s: %w", agent.Metadata.InstanceUID, err)
+				return fmt.Errorf("apply matching groups to agent %s: %w", agent.Metadata.InstanceUID, err)
+			}
+
+			after := agentSpecFingerprint(agent)
+			if before == after {
+				continue
 			}
 
 			err = s.agentUsecase.SaveAgent(ctx, agent)
@@ -276,64 +531,6 @@ func (s *AgentGroupService) updateAgentsByAgentGroup(
 		}
 
 		continueToken = agentsResp.Continue
-	}
-
-	return nil
-}
-
-func (s *AgentGroupService) applyAgentGroupToAgent(
-	ctx context.Context,
-	agentGroup *agentmodel.AgentGroup,
-	agent *agentmodel.Agent,
-) error {
-	err := s.applyRemoteConfigs(ctx, agentGroup, agent)
-	if err != nil {
-		return err
-	}
-
-	err = s.applyConnectionSettings(ctx, agentGroup, agent)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (s *AgentGroupService) applyRemoteConfigs(
-	ctx context.Context,
-	agentGroup *agentmodel.AgentGroup,
-	agent *agentmodel.Agent,
-) error {
-	agentGroupName := agentGroup.Metadata.Name
-	namespace := agentGroup.Metadata.Namespace
-
-	// Handle single remote config (API compatibility)
-	//nolint:staticcheck // backward compatibility - AgentRemoteConfig is deprecated
-	if agentGroup.Spec.AgentRemoteConfig != nil {
-		//nolint:staticcheck // backward compatibility
-		configFile, configName, err := s.resolveRemoteConfig(
-			ctx, namespace, agentGroupName, *agentGroup.Spec.AgentRemoteConfig)
-		if err != nil {
-			return err
-		}
-
-		err = agent.ApplyRemoteConfig(configName, configFile)
-		if err != nil {
-			return fmt.Errorf("apply remote config %s: %w", configName, err)
-		}
-	}
-
-	// Handle multiple remote configs
-	for _, remoteConfig := range agentGroup.Spec.AgentRemoteConfigs {
-		configFile, configName, err := s.resolveRemoteConfig(ctx, namespace, agentGroupName, remoteConfig)
-		if err != nil {
-			return err
-		}
-
-		err = agent.ApplyRemoteConfig(configName, configFile)
-		if err != nil {
-			return fmt.Errorf("apply remote config %s: %w", configName, err)
-		}
 	}
 
 	return nil

--- a/internal/domain/agent/service/agentgroup_internal_test.go
+++ b/internal/domain/agent/service/agentgroup_internal_test.go
@@ -487,14 +487,16 @@ func TestApplyRemoteConfigs(t *testing.T) {
 		mockRemoteConfigPort.On("GetAgentRemoteConfig", ctx, "", refName, (*model.GetOptions)(nil)).
 			Return(referencedConfig, nil)
 
-		err := svc.applyRemoteConfigs(ctx, agentGroup, testAgent)
+		resolved, err := svc.collectGroupRemoteConfigs(ctx, agentGroup)
 
 		require.NoError(t, err)
-		// Verify config was applied with original name (no prefix)
-		configFile, exists := testAgent.Spec.RemoteConfig.ConfigMap.ConfigMap[refName]
-		assert.True(t, exists, "Config should be applied with original name")
+		// Verify config was resolved under its original name (no prefix)
+		configFile, exists := resolved[refName]
+		assert.True(t, exists, "Config should be resolved under its original name")
 		assert.Equal(t, referencedConfig.Spec.Value, configFile.Body)
 		mockRemoteConfigPort.AssertExpectations(t)
+
+		_ = testAgent
 	})
 
 	t.Run("Applies inline config to agent with AgentGroupName prefix", func(t *testing.T) {
@@ -530,14 +532,16 @@ func TestApplyRemoteConfigs(t *testing.T) {
 			},
 		}
 
-		err := svc.applyRemoteConfigs(ctx, agentGroup, testAgent)
+		resolved, err := svc.collectGroupRemoteConfigs(ctx, agentGroup)
 
 		require.NoError(t, err)
-		// Verify config was applied with prefixed name
+		// Verify config was resolved under its prefixed name
 		expectedName := "staging/local-config"
-		configFile, exists := testAgent.Spec.RemoteConfig.ConfigMap.ConfigMap[expectedName]
-		assert.True(t, exists, "Config should be applied with prefixed name: %s", expectedName)
+		configFile, exists := resolved[expectedName]
+		assert.True(t, exists, "Config should be resolved under prefixed name: %s", expectedName)
 		assert.Equal(t, inlineValue, configFile.Body)
+
+		_ = testAgent
 	})
 }
 
@@ -595,24 +599,27 @@ func TestNameCollisionPrevention(t *testing.T) {
 			},
 		}
 
-		// Apply configs from both groups
-		err := svc.applyRemoteConfigs(ctx, groupAlpha, testAgent)
+		// Resolve configs from both groups
+		alphaResolved, err := svc.collectGroupRemoteConfigs(ctx, groupAlpha)
 		require.NoError(t, err)
 
-		err = svc.applyRemoteConfigs(ctx, groupBeta, testAgent)
+		betaResolved, err := svc.collectGroupRemoteConfigs(ctx, groupBeta)
 		require.NoError(t, err)
 
 		// Verify both configs exist with different prefixed names
-		alphaConfig, alphaExists := testAgent.Spec.RemoteConfig.ConfigMap.ConfigMap["group-alpha/config"]
-		betaConfig, betaExists := testAgent.Spec.RemoteConfig.ConfigMap.ConfigMap["group-beta/config"]
+		alphaConfig, alphaExists := alphaResolved["group-alpha/config"]
+		betaConfig, betaExists := betaResolved["group-beta/config"]
 
 		assert.True(t, alphaExists, "Alpha config should exist")
 		assert.True(t, betaExists, "Beta config should exist")
 		assert.Equal(t, []byte("content from alpha"), alphaConfig.Body)
 		assert.Equal(t, []byte("content from beta"), betaConfig.Body)
 
-		// Verify we have exactly 2 configs (no collision)
-		assert.Len(t, testAgent.Spec.RemoteConfig.ConfigMap.ConfigMap, 2)
+		// Verify each group resolves to exactly its own config (no collision when keyed by prefixed name)
+		assert.Len(t, alphaResolved, 1)
+		assert.Len(t, betaResolved, 1)
+
+		_ = testAgent
 	})
 }
 
@@ -666,7 +673,11 @@ func TestUpdateAgentsByAgentGroup(t *testing.T) {
 
 		mockAgentUC.On("ListAgentsBySelector", ctx, agentGroup.Spec.Selector, mock.Anything).
 			Return(agentsResponse, nil)
-		mockRemoteConfigPort.On("GetAgentRemoteConfig", ctx, "", refName, (*model.GetOptions)(nil)).
+		// updateAgentsByAgentGroup now applies the union of all matching groups per agent
+		// (ApplyMatchingAgentGroupsToAgent), which calls GetAgentGroupsForAgent → ListAgentGroups.
+		mockPersistence.On("ListAgentGroups", mock.Anything, (*model.ListOptions)(nil)).
+			Return(&model.ListResponse[*agentmodel.AgentGroup]{Items: []*agentmodel.AgentGroup{agentGroup}}, nil)
+		mockRemoteConfigPort.On("GetAgentRemoteConfig", mock.Anything, "", refName, (*model.GetOptions)(nil)).
 			Return(referencedConfig, nil)
 		mockAgentUC.On("SaveAgent", ctx, mock.MatchedBy(func(a *agentmodel.Agent) bool {
 			_, exists := a.Spec.RemoteConfig.ConfigMap.ConfigMap[refName]
@@ -726,6 +737,9 @@ func TestUpdateAgentsByAgentGroup(t *testing.T) {
 
 		mockAgentUC.On("ListAgentsBySelector", ctx, agentGroup.Spec.Selector, mock.Anything).
 			Return(agentsResponse, nil)
+		// updateAgentsByAgentGroup → ApplyMatchingAgentGroupsToAgent → GetAgentGroupsForAgent.
+		mockPersistence.On("ListAgentGroups", mock.Anything, (*model.ListOptions)(nil)).
+			Return(&model.ListResponse[*agentmodel.AgentGroup]{Items: []*agentmodel.AgentGroup{agentGroup}}, nil)
 		mockAgentUC.On("SaveAgent", ctx, mock.MatchedBy(func(a *agentmodel.Agent) bool {
 			// Verify the config has the prefixed name
 			_, exists := a.Spec.RemoteConfig.ConfigMap.ConfigMap["staging/inline-config"]


### PR DESCRIPTION
## Summary

- **Root-cause fix**: `AgentSpecRemoteConfigFromDomain` / `ToDomain` in the MongoDB entity persisted only the *names* of an agent's remote configs, dropping `Body`/`ContentType` on every write. After cache TTL expiry (30s), server restart, or a different server handling the message, `fetchServerToAgent` then sent empty configs to collectors. Persistence now keeps full content; existing documents written under the old `remoteConfig: []string` shape are decoded as placeholders via a new `LegacyRemoteConfig` field so the reconcile loop can repopulate them without data loss on rollout.
- **Propagation triggers**:
  - `AgentRemoteConfig` create/update/delete now re-applies every `AgentGroup` in the namespace that references the resource (`AgentGroupUsecase.PropagateAgentRemoteConfigChange`). Runs in its own goroutine with `context.WithoutCancel` so HTTP handlers don't block on the size-100 channel under load.
  - `OnMessage` calls `ApplyMatchingAgentGroupsToAgent` when the incoming message carries an `AgentDescription` and identity (`namespace` + identifying/non-identifying attrs) actually changed — gated on `message.GetAgentDescription() != nil` so heartbeats don't trigger a `ListAgentGroups` scan.
- **Reconcile loop**: 5-min ticker on its own goroutine (so a long pass doesn't starve the `changedAgentGroupCh` consumer) plus an immediate run at startup. `agentSpecFingerprint` guards `SaveAgent` so steady-state reconciles are no-op writes; marshal-failure returns a per-call sentinel that forces the save (the prior code silently skipped on error).
- **Stale-entry removal**: `ApplyMatchingAgentGroupsToAgent` now computes the *desired* `ConfigMap` from the union of all matching groups and REPLACES `Spec.RemoteConfig` rather than additively merging. Removing a config from a group now actually deletes it from the agent on the next reconcile pass, not just adds the new ones.

### Files touched
- `internal/adapter/out/persistence/mongodb/entity/agent.go` — `AgentSpecRemoteConfig` persists `configMap` (full content); decodes legacy `remoteConfig` array as placeholders.
- `internal/domain/agent/service/agentgroup.go` — reconcile loop, `PropagateAgentRemoteConfigChange`, `ApplyMatchingAgentGroupsToAgent` (replace semantics), fingerprint-based idempotency.
- `internal/domain/agent/port/in.go` — adds the two new methods to `AgentGroupUsecase`.
- `internal/application/service/opamp/opamp.go` — identity-change detection on description-bearing messages.
- `internal/application/service/agentremoteconfig/agentremoteconfig.go` — async trigger on CRUD.
- `internal/domain/agent/service/agentgroup_internal_test.go`, `internal/application/service/namespace/namespace_manage_service_test.go` — adjusted to new helper layout and interface.

## Test plan

- [x] `go build ./...`
- [x] `make lint` — 0 issues
- [x] `make unittest` — all packages pass (incl. `internal/domain/agent/service` `TestUpdateAgentsByAgentGroup`)
- [ ] `make test-e2e-basic` — exercises `TestE2E_AgentGroup_RemoteConfig_DirectMode` / `_NameCollision` (currently only checks `RemoteConfigNames`; full Body/ContentType round-trip on the wire is still not asserted — known gap from the review)
- [ ] Manual smoke: create an `AgentRemoteConfig`, attach to an `AgentGroup`, observe collector receiving the actual config body in `RemoteConfig.Config.ConfigMap[name].Body`
- [ ] Manual rollout: confirm agents written under the old `remoteConfig: []string` schema get their content rehydrated within one reconcile cycle (5 minutes) after deploy
- [ ] Manual: delete a config from an `AgentGroup`'s `AgentRemoteConfigs` list and verify the agent stops receiving it on the next reconcile

🤖 Generated with [Claude Code](https://claude.com/claude-code)