### PR TITLE
fix(auth): stop recreating user records on every login

### DIFF
--- a/internal/adapter/in/http/auth/basic/controller.go
+++ b/internal/adapter/in/http/auth/basic/controller.go
@@ -219,6 +219,13 @@ func (c *Controller) ensureUser(ctx context.Context, username, email, provider s
 		return
 	}
 
+	// No active user with this email. If a soft-deleted record exists, the user was
+	// deliberately deleted: do not resurrect or duplicate it. They can still authenticate
+	// but stay without a record (RBAC denies) until an admin restores them.
+	if c.isDeletedUser(ctx, email) {
+		return
+	}
+
 	newUser := usermodel.NewUserWithIdentity(provider, username, email, username)
 	newUser.SetLabel(usermodel.LabelLoginType, provider)
 
@@ -233,6 +240,32 @@ func (c *Controller) ensureUser(ctx context.Context, username, email, provider s
 	}
 
 	c.syncRBACPolicies(ctx, email)
+}
+
+// isDeletedUser reports whether a soft-deleted user record exists for the email.
+// On lookup failure it returns true (fail-closed): recreating on a transient error is the
+// behaviour that produced duplicate accounts, so we'd rather skip creation and let the user retry.
+func (c *Controller) isDeletedUser(ctx context.Context, email string) bool {
+	deleted, err := c.userUsecase.GetUserByEmailIncludingDeleted(ctx, email)
+	if err != nil {
+		if errors.Is(err, port.ErrResourceNotExist) {
+			return false
+		}
+
+		c.logger.Warn("failed to check for soft-deleted user on login; skipping user creation",
+			slog.String("email", email),
+			slog.Any("error", err),
+		)
+
+		return true
+	}
+
+	c.logger.Warn("not recreating soft-deleted user on login",
+		slog.String("email", email),
+		slog.String("uid", deleted.Metadata.UID.String()),
+	)
+
+	return true
 }
 
 // syncRBACPolicies re-runs the Casbin policy sync so newly persisted users/bindings take effect.

--- a/internal/adapter/in/http/auth/github/controller.go
+++ b/internal/adapter/in/http/auth/github/controller.go
@@ -471,6 +471,13 @@ func (c *Controller) ensureUser(ctx context.Context, email, provider string, gro
 		return
 	}
 
+	// No active user with this email. If a soft-deleted record exists, the user was
+	// deliberately deleted: do not resurrect or duplicate it. They can still authenticate
+	// but stay without a record (RBAC denies) until an admin restores them.
+	if c.isDeletedUser(ctx, email) {
+		return
+	}
+
 	newUser := usermodel.NewUserWithIdentity(provider, email, email, email)
 	c.syncLabels(ctx, newUser, provider, groups)
 
@@ -485,6 +492,32 @@ func (c *Controller) ensureUser(ctx context.Context, email, provider string, gro
 	}
 
 	c.syncRBACPolicies(ctx, email)
+}
+
+// isDeletedUser reports whether a soft-deleted user record exists for the email.
+// On lookup failure it returns true (fail-closed): recreating on a transient error is the
+// behaviour that produced duplicate accounts, so we'd rather skip creation and let the user retry.
+func (c *Controller) isDeletedUser(ctx context.Context, email string) bool {
+	deleted, err := c.userUsecase.GetUserByEmailIncludingDeleted(ctx, email)
+	if err != nil {
+		if errors.Is(err, port.ErrResourceNotExist) {
+			return false
+		}
+
+		c.logger.Warn("failed to check for soft-deleted user on login; skipping user creation",
+			slog.String("email", email),
+			slog.Any("error", err),
+		)
+
+		return true
+	}
+
+	c.logger.Warn("not recreating soft-deleted user on login",
+		slog.String("email", email),
+		slog.String("uid", deleted.Metadata.UID.String()),
+	)
+
+	return true
 }
 
 // syncRBACPolicies re-runs the Casbin policy sync so newly persisted users/bindings take effect.

--- a/internal/adapter/out/persistence/mongodb/mongodb.go
+++ b/internal/adapter/out/persistence/mongodb/mongodb.go
@@ -10,6 +10,7 @@ import (
 	"github.com/samber/lo"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
 
 // sanitizeResourceName validates and returns a safe resource name for MongoDB queries.
@@ -187,6 +188,20 @@ var (
 						{Key: "serverId", Value: 1},
 					},
 					Options: nil,
+				},
+			},
+		},
+		{
+			collectionName: userCollectionName,
+			indexes: []mongo.IndexModel{
+				{
+					Keys: bson.D{
+						{Key: "spec.email", Value: 1},
+					},
+					// Case-insensitive collation so this index backs the collated GetUserByEmail
+					// lookups (same emailCollation), which run on every login and every
+					// authenticated request's user resolution — otherwise they full-scan users.
+					Options: options.Index().SetCollation(emailCollation),
 				},
 			},
 		},

--- a/internal/adapter/out/persistence/mongodb/user.go
+++ b/internal/adapter/out/persistence/mongodb/user.go
@@ -5,11 +5,11 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
-	"regexp"
 
 	"github.com/google/uuid"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 
 	"github.com/minuk-dev/opampcommander/internal/adapter/out/persistence/mongodb/entity"
 	"github.com/minuk-dev/opampcommander/internal/domain/model"
@@ -20,12 +20,21 @@ import (
 
 var _ userport.UserPersistencePort = (*UserMongoAdapter)(nil)
 
-// emailRegex validates and extracts a safe email string to prevent query injection.
-var emailRegex = regexp.MustCompile(`^[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}$`)
-
 const (
 	userCollectionName = "users"
+
+	// collationStrengthCaseInsensitive is Collation.Strength=2: compare ignoring case but
+	// keeping accents — the standard "case-insensitive" comparison level.
+	collationStrengthCaseInsensitive = 2
 )
+
+// emailCollation matches email addresses case-insensitively. Emails are stored as the provider
+// supplied them, but looked up case-insensitively so that "Admin@x" and "admin@x" resolve to the
+// same record — without this, a varying-case email would be treated as a new user and recreated
+// on every login. The matching index in mongodb.go declares the same collation so lookups stay indexed.
+//
+//nolint:gochecknoglobals,exhaustruct // shared, immutable collation; only Locale/Strength apply.
+var emailCollation = &options.Collation{Locale: "en", Strength: collationStrengthCaseInsensitive}
 
 // UserMongoAdapter is a struct that implements the UserPersistencePort interface.
 type UserMongoAdapter struct {
@@ -69,38 +78,20 @@ func (a *UserMongoAdapter) GetUser(
 }
 
 // GetUserByEmail implements userport.UserPersistencePort.
+// Soft-deleted records are excluded, so callers treat a deleted user as absent.
 func (a *UserMongoAdapter) GetUserByEmail(
 	ctx context.Context, email string,
 ) (*usermodel.User, error) {
-	sanitized := emailRegex.FindString(email)
-	if sanitized == "" {
-		return nil, fmt.Errorf("invalid email address %q: %w", email, port.ErrResourceNotExist)
-	}
+	return a.findUserByEmail(ctx, email, false)
+}
 
-	filter := bson.M{
-		"spec.email":         sanitized,
-		"metadata.deletedAt": nil,
-	}
-
-	result := a.common.collection.FindOne(ctx, filter)
-
-	err := result.Err()
-	if err != nil {
-		if errors.Is(err, mongo.ErrNoDocuments) {
-			return nil, port.ErrResourceNotExist
-		}
-
-		return nil, fmt.Errorf("get user by email: %w", err)
-	}
-
-	var userEntity entity.User
-
-	err = result.Decode(&userEntity)
-	if err != nil {
-		return nil, fmt.Errorf("decode user by email: %w", err)
-	}
-
-	return userEntity.ToDomain(), nil
+// GetUserByEmailIncludingDeleted implements userport.UserPersistencePort.
+// Unlike GetUserByEmail it also returns soft-deleted records, so the login flow can tell a
+// brand-new email apart from one whose user was deliberately deleted (and must not be recreated).
+func (a *UserMongoAdapter) GetUserByEmailIncludingDeleted(
+	ctx context.Context, email string,
+) (*usermodel.User, error) {
+	return a.findUserByEmail(ctx, email, true)
 }
 
 // PutUser implements userport.UserPersistencePort.
@@ -158,4 +149,43 @@ func (a *UserMongoAdapter) DeleteUser(
 	}
 
 	return nil
+}
+
+// findUserByEmail looks up a single user by email. The email is used only as an exact-match
+// value (not a $regex/operator), so the BSON driver encodes it as a plain string value — a
+// caller-supplied string cannot inject a query operator. Matching is case-insensitive
+// (emailCollation) so dedup works regardless of how the provider cased the address; this is
+// also why non-standard-but-valid emails like "admin@admin" are findable instead of being
+// recreated on every login.
+func (a *UserMongoAdapter) findUserByEmail(
+	ctx context.Context, email string, includeDeleted bool,
+) (*usermodel.User, error) {
+	if email == "" {
+		return nil, fmt.Errorf("empty email address: %w", port.ErrResourceNotExist)
+	}
+
+	filter := bson.M{"spec.email": email}
+	if !includeDeleted {
+		filter["metadata.deletedAt"] = nil
+	}
+
+	result := a.common.collection.FindOne(ctx, filter, options.FindOne().SetCollation(emailCollation))
+
+	err := result.Err()
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, port.ErrResourceNotExist
+		}
+
+		return nil, fmt.Errorf("get user by email: %w", err)
+	}
+
+	var userEntity entity.User
+
+	err = result.Decode(&userEntity)
+	if err != nil {
+		return nil, fmt.Errorf("decode user by email: %w", err)
+	}
+
+	return userEntity.ToDomain(), nil
 }

--- a/internal/domain/user/port/in.go
+++ b/internal/domain/user/port/in.go
@@ -13,8 +13,11 @@ import (
 type UserUsecase interface {
 	// GetUser retrieves a user by their UID.
 	GetUser(ctx context.Context, uid uuid.UUID, options *model.GetOptions) (*usermodel.User, error)
-	// GetUserByEmail retrieves a user by their email.
+	// GetUserByEmail retrieves a user by their email, excluding soft-deleted records.
 	GetUserByEmail(ctx context.Context, email string) (*usermodel.User, error)
+	// GetUserByEmailIncludingDeleted retrieves a user by their email, including soft-deleted records.
+	// Used by the login flow to avoid recreating a user that was deliberately deleted.
+	GetUserByEmailIncludingDeleted(ctx context.Context, email string) (*usermodel.User, error)
 	// ListUsers lists all users.
 	ListUsers(ctx context.Context, options *model.ListOptions) (*model.ListResponse[*usermodel.User], error)
 	// SaveUser saves the user.

--- a/internal/domain/user/port/out.go
+++ b/internal/domain/user/port/out.go
@@ -13,8 +13,11 @@ import (
 type UserPersistencePort interface {
 	// GetUser retrieves a user by their UID.
 	GetUser(ctx context.Context, uid uuid.UUID, options *model.GetOptions) (*usermodel.User, error)
-	// GetUserByEmail retrieves a user by their email.
+	// GetUserByEmail retrieves a user by their email, excluding soft-deleted records.
 	GetUserByEmail(ctx context.Context, email string) (*usermodel.User, error)
+	// GetUserByEmailIncludingDeleted retrieves a user by their email, including soft-deleted records.
+	// Used by the login flow to avoid recreating a user that was deliberately deleted.
+	GetUserByEmailIncludingDeleted(ctx context.Context, email string) (*usermodel.User, error)
 	// PutUser saves or updates a user.
 	PutUser(ctx context.Context, user *usermodel.User) (*usermodel.User, error)
 	// ListUsers retrieves a list of users with pagination options.

--- a/internal/domain/user/service/user.go
+++ b/internal/domain/user/service/user.go
@@ -58,6 +58,19 @@ func (s *UserService) GetUserByEmail(
 	return user, nil
 }
 
+// GetUserByEmailIncludingDeleted implements [userport.UserUsecase].
+func (s *UserService) GetUserByEmailIncludingDeleted(
+	ctx context.Context,
+	email string,
+) (*usermodel.User, error) {
+	user, err := s.userPersistencePort.GetUserByEmailIncludingDeleted(ctx, email)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user by email (including deleted) from persistence: %w", err)
+	}
+
+	return user, nil
+}
+
 // ListUsers implements [userport.UserUsecase].
 func (s *UserService) ListUsers(
 	ctx context.Context,


### PR DESCRIPTION
## Problem

In real use, **admin user records multiply** — a new `admin@admin` user is created on (almost) every login.

Root cause chain:
1. Basic-auth login (`admin`/`admin`) issues a token for `auth.admin.email` (default `admin@admin`) and calls `ensureUser`.
2. `ensureUser` decides create-vs-update via `GetUserByEmail`, which first ran the email through a strict regex (`^…@…\.[a-zA-Z]{2,}$`) and returned `ErrResourceNotExist` **without querying the DB** when it failed.
3. `admin@admin` has no `.TLD`, so it never matched → always "not found" → a brand-new record (`uuid.New()`) was created every login.
4. The `users` collection has **no unique index on email**, so nothing stopped the duplicates.

The same dedup weakness also bites case-varying emails and soft-deleted-then-re-login users.

## Changes

- **Drop the regex gate** in `GetUserByEmail`; look up by exact email value. The filter is an equality match (not a `$regex`/operator), so a caller-supplied string can't inject a query operator — the regex was unnecessary and lossy.
- **Case-insensitive matching** via a shared collation (`{Locale:"en", Strength:2}`), so `Admin@x` and `admin@x` resolve to one record. Stored values are left as-is (preserves RoleBinding subject matching, etc.).
- **Index `users.spec.email`** with the same collation so the per-login and per-authenticated-request email lookups are backed by an index instead of a full collection scan. Non-unique, so existing duplicates don't break startup.
- **Block recreation of soft-deleted users** (chosen policy): add `GetUserByEmailIncludingDeleted` and have `ensureUser` (basic + github) skip creation when a soft-deleted record exists (fail-closed on lookup error). Deleting a user is no longer undone by their next login.

## Notes / follow-ups

- Already-accumulated duplicate records are inert after this change (lookups now find one and update it), but should be cleaned up manually. After cleanup, promoting the email index to **unique** can be considered.
- Soft-deleted users can still authenticate but have no record → RBAC denies them until an admin restores them (admin itself is unaffected: it's a config-email super-admin bypass that works without a record).

## Testing

- `go build ./...`, `golangci-lint` (changed packages), `go test -short ./internal/...` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)