### PR TITLE
fix(agentgroup): surface remote-config apply failures and clear config on delete

### DIFF
--- a/internal/domain/agent/model/agentgroup.go
+++ b/internal/domain/agent/model/agentgroup.go
@@ -193,6 +193,55 @@ func (ag *AgentGroup) MarkDeleted(deletedAt time.Time, deletedBy string) {
 	})
 }
 
+// SetCondition upserts a condition in the agent group's status. LastTransitionTime only
+// advances when the status actually changes (standard condition semantics); Reason and
+// Message are always refreshed so the latest detail — e.g. the current failure message —
+// is visible even across repeated reconciles that keep the same status.
+func (ag *AgentGroup) SetCondition(
+	conditionType model.ConditionType,
+	status model.ConditionStatus,
+	now time.Time,
+	reason string,
+	message string,
+) {
+	for idx, condition := range ag.Status.Conditions {
+		if condition.Type != conditionType {
+			continue
+		}
+
+		if condition.Status != status {
+			ag.Status.Conditions[idx].LastTransitionTime = now
+		}
+
+		ag.Status.Conditions[idx].Status = status
+		ag.Status.Conditions[idx].Reason = reason
+		ag.Status.Conditions[idx].Message = message
+
+		return
+	}
+
+	ag.Status.Conditions = append(ag.Status.Conditions, model.Condition{
+		Type:               conditionType,
+		LastTransitionTime: now,
+		Status:             status,
+		Reason:             reason,
+		Message:            message,
+	})
+}
+
+// GetCondition returns a copy of the condition of the given type, or nil if absent.
+func (ag *AgentGroup) GetCondition(conditionType model.ConditionType) *model.Condition {
+	for _, condition := range ag.Status.Conditions {
+		if condition.Type == conditionType {
+			cond := condition
+
+			return &cond
+		}
+	}
+
+	return nil
+}
+
 // GetCreatedAt returns the timestamp when the agent group was created.
 func (ag *AgentGroup) GetCreatedAt() *time.Time {
 	for _, condition := range ag.Status.Conditions {

--- a/internal/domain/agent/service/agentgroup.go
+++ b/internal/domain/agent/service/agentgroup.go
@@ -14,6 +14,7 @@ import (
 	agentport "github.com/minuk-dev/opampcommander/internal/domain/agent/port"
 	"github.com/minuk-dev/opampcommander/internal/domain/model"
 	"github.com/minuk-dev/opampcommander/internal/domain/model/vo"
+	"github.com/minuk-dev/opampcommander/pkg/utils/clock"
 )
 
 const (
@@ -26,6 +27,13 @@ const (
 	// to repair any drift the event-driven path missed (e.g. messages dropped because the
 	// buffered channel was full, or a SaveAgent that failed midway).
 	DefaultReconcileInterval = 5 * time.Minute
+	// DeletedGroupReconcileWindow is how long after deletion the reconcile loop keeps
+	// re-processing a deleted group so its former members get the deleted group's config
+	// dropped even if the delete-time propagation event was lost (full buffer, or a crash
+	// between persisting the deletion and queuing it). Past this window the group's members
+	// are assumed already cleared and re-scanning it would be wasted work, so it is skipped.
+	// Sized above DefaultReconcileInterval so at least one reconcile tick falls inside it.
+	DeletedGroupReconcileWindow = 3 * DefaultReconcileInterval
 )
 
 // ErrInvalidRemoteConfig is returned when inline remote config is missing required fields.
@@ -50,6 +58,7 @@ type AgentGroupService struct {
 	changedAgentGroupCh chan *agentmodel.AgentGroup
 
 	// utils
+	clock  clock.Clock
 	logger *slog.Logger
 }
 
@@ -66,9 +75,15 @@ func NewAgentGroupService(
 		remoteConfigPersistencePort: agentRemoteConfigPersistencePort,
 		certificatePersistencePort:  certificatePersistencePort,
 		agentUsecase:                agentUsecase,
+		clock:                       clock.NewRealClock(),
 		logger:                      logger,
 		changedAgentGroupCh:         make(chan *agentmodel.AgentGroup, ChangedAgentGroupBufferSize),
 	}
+}
+
+// SetClock overrides the clock used for condition timestamps. Intended for tests.
+func (s *AgentGroupService) SetClock(c clock.Clock) {
+	s.clock = c
 }
 
 // Name implements lifecycle.Runner.
@@ -168,6 +183,25 @@ func (s *AgentGroupService) DeleteAgentGroup(
 	_, err = s.persistencePort.PutAgentGroup(ctx, namespace, name, agentGroup)
 	if err != nil {
 		return fmt.Errorf("failed to delete agent group: %w", err)
+	}
+
+	// Propagate the deletion so agents that matched this group have their remote config
+	// recomputed (the union of the remaining non-deleted matching groups). Without this an
+	// agent keeps the deleted group's config indefinitely: the reconcile loop and the event
+	// path are group-driven, and a deleted group is otherwise never revisited. The deleted
+	// group still carries its selector, so updateAgentsByAgentGroup can find its former
+	// members and ApplyMatchingAgentGroupsToAgent drops the now-deleted group's contribution.
+	//
+	// Best-effort, non-blocking: a full buffer must not hang this request handler. The
+	// reconcile loop re-processes recently-deleted groups (DeletedGroupReconcileWindow) as
+	// the durable safety net, so a dropped event still self-heals.
+	select {
+	case s.changedAgentGroupCh <- agentGroup:
+	default:
+		s.logger.Warn("agent group deletion not queued (buffer full); reconcile will drain former members",
+			slog.String("agent_group", name),
+			slog.String("namespace", namespace),
+		)
 	}
 
 	return nil
@@ -300,7 +334,17 @@ func (s *AgentGroupService) ApplyMatchingAgentGroupsToAgent(
 	for _, group := range groups {
 		configs, err := s.collectGroupRemoteConfigs(ctx, group)
 		if err != nil {
-			return fmt.Errorf("collect remote configs from group %s: %w", group.Metadata.Name, err)
+			// A single group with an invalid/unresolvable config must not block the
+			// other matching groups from applying. The failure is surfaced on that
+			// group's RemoteConfigApplied condition (see recordRemoteConfigCondition),
+			// so skipping here is observable rather than silent.
+			s.logger.Warn("skip agent group with unresolved remote config",
+				slog.String("agent_group", group.Metadata.Name),
+				slog.String("namespace", group.Metadata.Namespace),
+				slog.String("error", err.Error()),
+			)
+
+			continue
 		}
 
 		maps.Copy(desired, configs)
@@ -400,9 +444,11 @@ func (s *AgentGroupService) propagateAgentGroupChangesToAgents(
 	}
 }
 
-// reconcileAll re-scans every non-deleted agent group and re-applies it to its matching
-// agents. updateAgentsByAgentGroup is idempotent — it only writes when the agent's
-// desired spec actually changed — so this is cheap when nothing has drifted.
+// reconcileAll re-scans every agent group and re-applies it to its matching agents.
+// updateAgentsByAgentGroup is idempotent — it only writes when the agent's desired spec
+// actually changed — so this is cheap when nothing has drifted. Recently-deleted groups
+// are processed too (see shouldReconcileDeletedGroup) so a dropped delete event still
+// results in the deleted group's config being dropped from its former members.
 func (s *AgentGroupService) reconcileAll(ctx context.Context) {
 	groups, err := s.persistencePort.ListAgentGroups(ctx, nil)
 	if err != nil {
@@ -413,7 +459,7 @@ func (s *AgentGroupService) reconcileAll(ctx context.Context) {
 	}
 
 	for _, group := range groups.Items {
-		if group.IsDeleted() {
+		if group.IsDeleted() && !s.shouldReconcileDeletedGroup(group) {
 			continue
 		}
 
@@ -426,6 +472,19 @@ func (s *AgentGroupService) reconcileAll(ctx context.Context) {
 			)
 		}
 	}
+}
+
+// shouldReconcileDeletedGroup reports whether a deleted group is still inside the window
+// during which the reconcile loop keeps draining its former members (see
+// DeletedGroupReconcileWindow). Groups missing a deletion timestamp are treated as in-window
+// so they are not stranded with stale config on their members.
+func (s *AgentGroupService) shouldReconcileDeletedGroup(group *agentmodel.AgentGroup) bool {
+	deletedAt := group.GetDeletedAt()
+	if deletedAt == nil {
+		return true
+	}
+
+	return s.clock.Now().Sub(*deletedAt) <= DeletedGroupReconcileWindow
 }
 
 // agentSpecFingerprint hashes the parts of an agent's spec that are mutated by
@@ -483,10 +542,91 @@ func agentGroupReferencesRemoteConfig(group *agentmodel.AgentGroup, name string)
 	return false
 }
 
+// remoteConfigConditionReason identifies this service as the actor that records the
+// RemoteConfigApplied condition on agent groups.
+const remoteConfigConditionReason = agentGroupServiceName
+
+// groupDeclaresRemoteConfig reports whether the group declares any remote config at all.
+// Groups that declare none never get a RemoteConfigApplied condition — there is nothing
+// to apply, so recording one would be noise.
+func groupDeclaresRemoteConfig(group *agentmodel.AgentGroup) bool {
+	//nolint:staticcheck // backward compatibility - AgentRemoteConfig is deprecated
+	return group.Spec.AgentRemoteConfig != nil || len(group.Spec.AgentRemoteConfigs) > 0
+}
+
+// recordRemoteConfigCondition resolves the group's declared remote configs and records the
+// outcome on its RemoteConfigApplied condition so both failures and recoveries are visible
+// through the API instead of only the server log. The condition is written onto a freshly
+// re-read copy of the group — never onto the passed-in pointer, which is aliased to the one
+// SaveAgentGroup hands back to the HTTP caller (writing it would be a data race on
+// Status.Conditions) and may be a stale snapshot the reconcile loop read minutes ago
+// (writing it would clobber a concurrent edit). The group is re-persisted only when the
+// condition's status or message actually changed, so the periodic reconcile does not write
+// on every tick. The resolution error (if any) is returned so callers can react.
+func (s *AgentGroupService) recordRemoteConfigCondition(
+	ctx context.Context,
+	group *agentmodel.AgentGroup,
+) error {
+	// A deleted group is only processed to drain its former members; recording a condition
+	// (and re-persisting it) on a tombstone would be misleading and pointless.
+	if group.IsDeleted() || !groupDeclaresRemoteConfig(group) {
+		return nil
+	}
+
+	_, resolveErr := s.collectGroupRemoteConfigs(ctx, group)
+
+	status := model.ConditionStatusTrue
+	message := "remote config resolved successfully"
+
+	if resolveErr != nil {
+		status = model.ConditionStatusFalse
+		message = resolveErr.Error()
+	}
+
+	// Re-read the current persisted group so we mutate/persist a private copy rather than the
+	// shared (and possibly stale) pointer. Failure to load is non-fatal: the resolve result
+	// still flows back to the caller and the next reconcile retries the condition write.
+	fresh, err := s.persistencePort.GetAgentGroup(ctx, group.Metadata.Namespace, group.Metadata.Name, nil)
+	if err != nil {
+		s.logger.Warn("failed to load agent group to record RemoteConfigApplied condition",
+			slog.String("agent_group", group.Metadata.Name),
+			slog.String("namespace", group.Metadata.Namespace),
+			slog.String("error", err.Error()),
+		)
+
+		return resolveErr
+	}
+
+	// Skip the write when nothing changed to keep the reconcile loop idempotent.
+	if existing := fresh.GetCondition(model.ConditionTypeRemoteConfigApplied); existing != nil &&
+		existing.Status == status && existing.Message == message {
+		return resolveErr
+	}
+
+	fresh.SetCondition(model.ConditionTypeRemoteConfigApplied, status,
+		s.clock.Now(), remoteConfigConditionReason, message)
+
+	_, putErr := s.persistencePort.PutAgentGroup(ctx, fresh.Metadata.Namespace, fresh.Metadata.Name, fresh)
+	if putErr != nil {
+		s.logger.Warn("failed to persist RemoteConfigApplied condition on agent group",
+			slog.String("agent_group", fresh.Metadata.Name),
+			slog.String("namespace", fresh.Metadata.Namespace),
+			slog.String("error", putErr.Error()),
+		)
+	}
+
+	return resolveErr
+}
+
 func (s *AgentGroupService) updateAgentsByAgentGroup(
 	ctx context.Context,
 	agentGroup *agentmodel.AgentGroup,
 ) error {
+	// Resolve this group's config once up front and record the outcome on its condition.
+	// This is what makes an invalid config (e.g. an inline config missing its name, or a
+	// dangling AgentRemoteConfigRef) observable instead of failing silently per agent.
+	_ = s.recordRemoteConfigCondition(ctx, agentGroup)
+
 	var continueToken string
 
 	for {
@@ -583,7 +723,7 @@ func (s *AgentGroupService) applyConnectionSettings(
 		slog.String("agentgroup.metadata.name", agentGroup.Metadata.Name),
 	)
 
-	if agentGroup.HasAgentConnectionConfig() {
+	if !agentGroup.HasAgentConnectionConfig() {
 		logger.Debug("skip to apply connection settings because agentGroup has no connection config")
 
 		return nil

--- a/internal/domain/agent/service/agentgroup_internal_test.go
+++ b/internal/domain/agent/service/agentgroup_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -623,6 +624,230 @@ func TestNameCollisionPrevention(t *testing.T) {
 	})
 }
 
+func TestRecordRemoteConfigCondition(t *testing.T) {
+	t.Parallel()
+
+	newSvc := func() (*AgentGroupService, *mockAgentGroupPersistence) {
+		mockPersistence := new(mockAgentGroupPersistence)
+		svc := NewAgentGroupService(
+			mockPersistence,
+			new(mockRemoteConfigPersistence),
+			new(mockCertPersistence),
+			new(mockAgentUsecase),
+			slog.Default(),
+		)
+
+		return svc, mockPersistence
+	}
+
+	t.Run("records False condition with error message when inline config is invalid", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		svc, mockPersistence := newSvc()
+
+		// Inline config missing AgentRemoteConfigName -> ErrInvalidRemoteConfig.
+		inlineSpec := &agentmodel.AgentRemoteConfigSpec{Value: []byte("x"), ContentType: "text/plain"}
+		group := &agentmodel.AgentGroup{
+			Metadata: agentmodel.AgentGroupMetadata{Namespace: "default", Name: "broken"},
+			Spec: agentmodel.AgentGroupSpec{
+				AgentRemoteConfigs: []agentmodel.AgentGroupAgentRemoteConfig{
+					{AgentRemoteConfigSpec: inlineSpec},
+				},
+			},
+		}
+
+		// recordRemoteConfigCondition re-reads the group before writing the condition.
+		mockPersistence.On("GetAgentGroup", mock.Anything, "default", "broken", (*model.GetOptions)(nil)).
+			Return(group, nil)
+		mockPersistence.On("PutAgentGroup", mock.Anything, "default", "broken", mock.Anything).
+			Return(group, nil)
+
+		err := svc.recordRemoteConfigCondition(ctx, group)
+
+		require.ErrorIs(t, err, ErrInvalidRemoteConfig)
+
+		cond := group.GetCondition(model.ConditionTypeRemoteConfigApplied)
+		require.NotNil(t, cond)
+		assert.Equal(t, model.ConditionStatusFalse, cond.Status)
+		assert.Contains(t, cond.Message, "invalid remote config")
+		mockPersistence.AssertExpectations(t)
+	})
+
+	t.Run("records True condition when inline config resolves", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		svc, mockPersistence := newSvc()
+
+		name := "ok-config"
+		group := &agentmodel.AgentGroup{
+			Metadata: agentmodel.AgentGroupMetadata{Namespace: "default", Name: "good"},
+			Spec: agentmodel.AgentGroupSpec{
+				AgentRemoteConfigs: []agentmodel.AgentGroupAgentRemoteConfig{
+					{
+						AgentRemoteConfigName: &name,
+						AgentRemoteConfigSpec: &agentmodel.AgentRemoteConfigSpec{
+							Value:       []byte("receivers: {}"),
+							ContentType: "text/yaml",
+						},
+					},
+				},
+			},
+		}
+
+		// recordRemoteConfigCondition re-reads the group before writing the condition.
+		mockPersistence.On("GetAgentGroup", mock.Anything, "default", "good", (*model.GetOptions)(nil)).
+			Return(group, nil)
+		mockPersistence.On("PutAgentGroup", mock.Anything, "default", "good", mock.Anything).
+			Return(group, nil)
+
+		err := svc.recordRemoteConfigCondition(ctx, group)
+
+		require.NoError(t, err)
+
+		cond := group.GetCondition(model.ConditionTypeRemoteConfigApplied)
+		require.NotNil(t, cond)
+		assert.Equal(t, model.ConditionStatusTrue, cond.Status)
+		mockPersistence.AssertExpectations(t)
+	})
+
+	t.Run("skips groups that declare no remote config", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		svc, mockPersistence := newSvc()
+
+		group := &agentmodel.AgentGroup{
+			Metadata: agentmodel.AgentGroupMetadata{Namespace: "default", Name: "no-config"},
+			Spec:     agentmodel.AgentGroupSpec{},
+		}
+
+		err := svc.recordRemoteConfigCondition(ctx, group)
+
+		require.NoError(t, err)
+		assert.Nil(t, group.GetCondition(model.ConditionTypeRemoteConfigApplied))
+		// No remote config declared -> nothing to record -> no persistence write.
+		mockPersistence.AssertNotCalled(t, "PutAgentGroup", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+	})
+
+	t.Run("does not re-persist when condition is unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		svc, mockPersistence := newSvc()
+
+		name := "ok-config"
+		group := &agentmodel.AgentGroup{
+			Metadata: agentmodel.AgentGroupMetadata{Namespace: "default", Name: "good"},
+			Spec: agentmodel.AgentGroupSpec{
+				AgentRemoteConfigs: []agentmodel.AgentGroupAgentRemoteConfig{
+					{
+						AgentRemoteConfigName: &name,
+						AgentRemoteConfigSpec: &agentmodel.AgentRemoteConfigSpec{
+							Value:       []byte("receivers: {}"),
+							ContentType: "text/yaml",
+						},
+					},
+				},
+			},
+		}
+
+		// The re-read returns the same object both times; after the first write it carries
+		// the condition, so the second call sees no change.
+		mockPersistence.On("GetAgentGroup", mock.Anything, "default", "good", (*model.GetOptions)(nil)).
+			Return(group, nil)
+		// Only the first call should persist; the second sees an unchanged condition.
+		mockPersistence.On("PutAgentGroup", mock.Anything, "default", "good", mock.Anything).
+			Return(group, nil).Once()
+
+		require.NoError(t, svc.recordRemoteConfigCondition(ctx, group))
+		require.NoError(t, svc.recordRemoteConfigCondition(ctx, group))
+
+		mockPersistence.AssertExpectations(t)
+	})
+}
+
+func TestDeleteAgentGroup_PropagatesDeletion(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	mockPersistence := new(mockAgentGroupPersistence)
+	svc := NewAgentGroupService(
+		mockPersistence,
+		new(mockRemoteConfigPersistence),
+		new(mockCertPersistence),
+		new(mockAgentUsecase),
+		slog.Default(),
+	)
+
+	existing := &agentmodel.AgentGroup{
+		Metadata: agentmodel.AgentGroupMetadata{Namespace: "default", Name: "to-delete"},
+		Spec: agentmodel.AgentGroupSpec{
+			Selector: agentmodel.AgentSelector{
+				IdentifyingAttributes: map[string]string{"service.name": "my-service"},
+			},
+		},
+	}
+
+	mockPersistence.On("GetAgentGroup", ctx, "default", "to-delete", (*model.GetOptions)(nil)).
+		Return(existing, nil)
+	mockPersistence.On("PutAgentGroup", ctx, "default", "to-delete", mock.Anything).
+		Return(existing, nil)
+
+	err := svc.DeleteAgentGroup(ctx, "default", "to-delete", time.Date(2026, time.May, 31, 12, 0, 0, 0, time.UTC), "admin")
+	require.NoError(t, err)
+
+	// The deletion must be queued so former members get the group's config dropped.
+	select {
+	case queued := <-svc.changedAgentGroupCh:
+		assert.True(t, queued.IsDeleted(), "queued group should be marked deleted")
+		assert.Equal(t, "to-delete", queued.Metadata.Name)
+	default:
+		t.Fatal("DeleteAgentGroup did not propagate the deletion to agents")
+	}
+
+	mockPersistence.AssertExpectations(t)
+}
+
+func TestShouldReconcileDeletedGroup(t *testing.T) {
+	t.Parallel()
+
+	// Uses the default real clock; offsets are far larger than the test runtime so the
+	// in/out-of-window comparisons are not racy.
+	svc := NewAgentGroupService(
+		new(mockAgentGroupPersistence),
+		new(mockRemoteConfigPersistence),
+		new(mockCertPersistence),
+		new(mockAgentUsecase),
+		slog.Default(),
+	)
+
+	newDeletedGroup := func(deletedAt time.Time) *agentmodel.AgentGroup {
+		group := &agentmodel.AgentGroup{
+			Metadata: agentmodel.AgentGroupMetadata{Namespace: "default", Name: "g"},
+			Spec:     agentmodel.AgentGroupSpec{},
+		}
+		group.MarkDeleted(deletedAt, "admin")
+
+		return group
+	}
+
+	t.Run("within window", func(t *testing.T) {
+		t.Parallel()
+
+		group := newDeletedGroup(time.Now().Add(-DeletedGroupReconcileWindow / 2))
+		assert.True(t, svc.shouldReconcileDeletedGroup(group))
+	})
+
+	t.Run("outside window", func(t *testing.T) {
+		t.Parallel()
+
+		group := newDeletedGroup(time.Now().Add(-2 * DeletedGroupReconcileWindow))
+		assert.False(t, svc.shouldReconcileDeletedGroup(group))
+	})
+}
+
 func TestUpdateAgentsByAgentGroup(t *testing.T) {
 	t.Parallel()
 
@@ -679,6 +904,12 @@ func TestUpdateAgentsByAgentGroup(t *testing.T) {
 			Return(&model.ListResponse[*agentmodel.AgentGroup]{Items: []*agentmodel.AgentGroup{agentGroup}}, nil)
 		mockRemoteConfigPort.On("GetAgentRemoteConfig", mock.Anything, "", refName, (*model.GetOptions)(nil)).
 			Return(referencedConfig, nil)
+		// updateAgentsByAgentGroup records the RemoteConfigApplied condition on the group;
+		// recordRemoteConfigCondition re-reads it first, then persists.
+		mockPersistence.On("GetAgentGroup", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(agentGroup, nil)
+		mockPersistence.On("PutAgentGroup", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(agentGroup, nil)
 		mockAgentUC.On("SaveAgent", ctx, mock.MatchedBy(func(a *agentmodel.Agent) bool {
 			_, exists := a.Spec.RemoteConfig.ConfigMap.ConfigMap[refName]
 
@@ -740,6 +971,12 @@ func TestUpdateAgentsByAgentGroup(t *testing.T) {
 		// updateAgentsByAgentGroup → ApplyMatchingAgentGroupsToAgent → GetAgentGroupsForAgent.
 		mockPersistence.On("ListAgentGroups", mock.Anything, (*model.ListOptions)(nil)).
 			Return(&model.ListResponse[*agentmodel.AgentGroup]{Items: []*agentmodel.AgentGroup{agentGroup}}, nil)
+		// updateAgentsByAgentGroup records the RemoteConfigApplied condition on the group;
+		// recordRemoteConfigCondition re-reads it first, then persists.
+		mockPersistence.On("GetAgentGroup", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(agentGroup, nil)
+		mockPersistence.On("PutAgentGroup", mock.Anything, mock.Anything, mock.Anything, mock.Anything).
+			Return(agentGroup, nil)
 		mockAgentUC.On("SaveAgent", ctx, mock.MatchedBy(func(a *agentmodel.Agent) bool {
 			// Verify the config has the prefixed name
 			_, exists := a.Spec.RemoteConfig.ConfigMap.ConfigMap["staging/inline-config"]

--- a/internal/domain/model/condition.go
+++ b/internal/domain/model/condition.go
@@ -28,6 +28,12 @@ const (
 	ConditionTypeDeleted ConditionType = "Deleted"
 	// ConditionTypeAlive represents the condition when the server is alive.
 	ConditionTypeAlive ConditionType = "Alive"
+	// ConditionTypeRemoteConfigApplied represents whether the agent group's declared
+	// remote config could be resolved and applied to its matching agents. It is set to
+	// True on a successful resolve and False (with the error in Message) when the config
+	// is invalid or a referenced resource cannot be fetched, so failures surface through
+	// the API instead of only the server log.
+	ConditionTypeRemoteConfigApplied ConditionType = "RemoteConfigApplied"
 )
 
 // ConditionStatus represents the status of a condition.


### PR DESCRIPTION
## Problem

Diagnosed live against the alpha cluster (same code as HEAD). AgentGroup remote-config propagation had three gaps:

1. **Silent apply failure** — an invalid group config (inline config missing its name, or a dangling `agentRemoteConfigRef`) failed silently per agent. Group creation succeeded with no validation, only a server log was emitted, and one bad group aborted the whole apply so other matching groups were skipped too. The user sees "config is set but never reaches the agent."
2. **Config never cleared on delete** — `DeleteAgentGroup` didn't propagate, and the reconcile loop is group-driven, so a deleted group's former members kept its `spec.remoteConfig` indefinitely (reproduced live: agents retained an orphaned config after the group was gone).
3. **Inverted condition** in `applyConnectionSettings` skipped applying connection settings exactly when the group *had* them.

## Changes

- **Record a `RemoteConfigApplied` condition** on the group — `True` on a successful resolve, `False` with the error in `Message` — so both failures and recoveries are visible via the API (`opampctl get agentgroup <name> -o yaml` → `status.conditions`). Written onto a freshly re-read copy of the group (never the pointer `SaveAgentGroup` returns to the caller → avoids a data race on `Status.Conditions` and a stale-snapshot lost update), and only when it actually changed.
- **Resilience**: `ApplyMatchingAgentGroupsToAgent` skips a group whose config can't be resolved instead of failing the whole apply, so one broken group no longer blocks the others (and the new-agent path stays robust).
- **Clear-on-delete**: propagate group deletion to former members (best-effort, non-blocking so the DELETE handler can't hang), and re-process recently-deleted groups in the reconcile loop within `DeletedGroupReconcileWindow` so a dropped delete event self-heals.
- **Fix** the inverted `applyConnectionSettings` condition.
- Inject a clock into `AgentGroupService` for condition timestamps (per the no-`time.Now()`-in-production convention).

## Tests

- New `TestRecordRemoteConfigCondition` (False/True/skip-no-config/no-rewrite-when-unchanged), `TestDeleteAgentGroup_PropagatesDeletion`, `TestShouldReconcileDeletedGroup`.
- Updated existing `TestUpdateAgentsByAgentGroup` for the new condition write.
- `go build ./...`, `go test -race ./internal/domain/agent/service/`, `golangci-lint run ./internal/domain/...` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)