### PR TITLE
feat(agentgroup): record remote-config apply result on the agent's condition

### DIFF
--- a/internal/domain/agent/model/agent.go
+++ b/internal/domain/agent/model/agent.go
@@ -379,6 +379,11 @@ const (
 	// AgentConditionTypeInstanceUIDConflict records that another agent attempted to use this
 	// agent's instanceUID and was redirected to a freshly issued one.
 	AgentConditionTypeInstanceUIDConflict AgentConditionType = "InstanceUIDConflict"
+	// AgentConditionTypeRemoteConfigApplied records the result of an agent group assigning a
+	// remote config to this agent: True when the config was applied to a config-accepting
+	// agent, False when a group assigned a config but the agent cannot accept remote config
+	// (missing the AcceptsRemoteConfig capability) so it will never be delivered.
+	AgentConditionTypeRemoteConfigApplied AgentConditionType = "RemoteConfigApplied"
 )
 
 // AgentConditionStatus represents the status of an agent condition.
@@ -1106,30 +1111,50 @@ func (a *Agent) HasRemoteConfig() bool {
 		len(a.Spec.RemoteConfig.ConfigMap.ConfigMap) > 0
 }
 
-// SetCondition sets or updates a condition in the agent's status.
+// HasAssignedRemoteConfig reports whether a remote config has been assigned to the agent's
+// spec, regardless of whether the agent can actually accept it. Unlike HasRemoteConfig this
+// does NOT require the AcceptsRemoteConfig capability — it is used to detect that something
+// (e.g. an agent group) assigned a config that may never be deliverable.
+func (a *Agent) HasAssignedRemoteConfig() bool {
+	return a.Spec.RemoteConfig != nil && len(a.Spec.RemoteConfig.ConfigMap.ConfigMap) > 0
+}
+
+// SetCondition sets or updates a condition in the agent's status using the current wall
+// clock. Prefer SetConditionAt from code that holds an injected clock.
 func (a *Agent) SetCondition(
 	conditionType AgentConditionType,
 	status AgentConditionStatus,
 	triggeredBy, message string,
 ) {
-	now := time.Now()
+	a.SetConditionAt(conditionType, status, time.Now(), triggeredBy, message)
+}
 
-	// Check if condition already exists
+// SetConditionAt upserts a condition with an explicit timestamp. LastTransitionTime only
+// advances when the status actually changes (standard condition semantics); Reason and
+// Message are always refreshed so the latest detail — e.g. which agent group last changed
+// the config — is visible even while the status holds steady.
+func (a *Agent) SetConditionAt(
+	conditionType AgentConditionType,
+	status AgentConditionStatus,
+	now time.Time,
+	triggeredBy, message string,
+) {
 	for idx, condition := range a.Status.Conditions {
-		if condition.Type == conditionType {
-			// Update existing condition only if status changed
-			if condition.Status != status {
-				a.Status.Conditions[idx].Status = status
-				a.Status.Conditions[idx].LastTransitionTime = now
-				a.Status.Conditions[idx].Reason = triggeredBy
-				a.Status.Conditions[idx].Message = message
-			}
-
-			return
+		if condition.Type != conditionType {
+			continue
 		}
+
+		if condition.Status != status {
+			a.Status.Conditions[idx].LastTransitionTime = now
+		}
+
+		a.Status.Conditions[idx].Status = status
+		a.Status.Conditions[idx].Reason = triggeredBy
+		a.Status.Conditions[idx].Message = message
+
+		return
 	}
 
-	// Add new condition
 	a.Status.Conditions = append(a.Status.Conditions, AgentCondition{
 		Type:               conditionType,
 		LastTransitionTime: now,

--- a/internal/domain/agent/service/agentgroup.go
+++ b/internal/domain/agent/service/agentgroup.go
@@ -618,6 +618,40 @@ func (s *AgentGroupService) recordRemoteConfigCondition(
 	return resolveErr
 }
 
+// recordAgentRemoteConfigCondition reflects the result of an agent group assigning a remote
+// config to the agent onto the agent's RemoteConfigApplied condition, and reports whether the
+// condition changed (so the caller folds it into the save decision). When a config is assigned
+// to an agent that lacks the AcceptsRemoteConfig capability the condition is set to False with
+// an explanatory message — that attempt is otherwise completely invisible because the config
+// is silently never delivered. When no config is assigned the condition is left untouched.
+func (s *AgentGroupService) recordAgentRemoteConfigCondition(
+	agent *agentmodel.Agent,
+	agentGroup *agentmodel.AgentGroup,
+) bool {
+	if !agent.HasAssignedRemoteConfig() {
+		return false
+	}
+
+	status := agentmodel.AgentConditionStatusTrue
+	message := fmt.Sprintf("remote config applied by agent group %q", agentGroup.Metadata.Name)
+
+	if !agent.IsRemoteConfigSupported() {
+		status = agentmodel.AgentConditionStatusFalse
+		message = fmt.Sprintf(
+			"agent group %q assigned a remote config but the agent does not accept remote config "+
+				"(missing AcceptsRemoteConfig capability); it will not be delivered",
+			agentGroup.Metadata.Name,
+		)
+	}
+
+	prev := agent.GetCondition(agentmodel.AgentConditionTypeRemoteConfigApplied)
+
+	agent.SetConditionAt(agentmodel.AgentConditionTypeRemoteConfigApplied, status,
+		s.clock.Now(), agentGroupServiceName, message)
+
+	return prev == nil || prev.Status != status || prev.Message != message
+}
+
 func (s *AgentGroupService) updateAgentsByAgentGroup(
 	ctx context.Context,
 	agentGroup *agentmodel.AgentGroup,
@@ -655,7 +689,15 @@ func (s *AgentGroupService) updateAgentsByAgentGroup(
 			}
 
 			after := agentSpecFingerprint(agent)
-			if before == after {
+
+			// Record on the agent whether the group-driven config could actually be applied.
+			// Crucially this also flags agents that an agent group assigned a config to but
+			// that cannot accept remote config — otherwise that attempt is invisible. The
+			// condition can change even when the spec did not (e.g. capability flip), so it
+			// participates in the save decision alongside the spec fingerprint.
+			condChanged := s.recordAgentRemoteConfigCondition(agent, agentGroup)
+
+			if before == after && !condChanged {
 				continue
 			}
 

--- a/internal/domain/agent/service/agentgroup_internal_test.go
+++ b/internal/domain/agent/service/agentgroup_internal_test.go
@@ -768,6 +768,82 @@ func TestRecordRemoteConfigCondition(t *testing.T) {
 	})
 }
 
+func TestRecordAgentRemoteConfigCondition(t *testing.T) {
+	t.Parallel()
+
+	svc := NewAgentGroupService(
+		new(mockAgentGroupPersistence),
+		new(mockRemoteConfigPersistence),
+		new(mockCertPersistence),
+		new(mockAgentUsecase),
+		slog.Default(),
+	)
+
+	group := &agentmodel.AgentGroup{
+		Metadata: agentmodel.AgentGroupMetadata{Namespace: "default", Name: "grp"},
+	}
+
+	withAssignedConfig := func(a *agentmodel.Agent) {
+		a.Spec.RemoteConfig = &agentmodel.AgentSpecRemoteConfig{
+			ConfigMap: agentmodel.AgentConfigMap{
+				ConfigMap: map[string]agentmodel.AgentConfigFile{"grp/cfg": {}},
+			},
+		}
+	}
+
+	t.Run("config-accepting agent gets True", func(t *testing.T) {
+		t.Parallel()
+
+		a := agentmodel.NewAgent(uuid.New())
+		a.Metadata.Capabilities = agent.Capabilities(agent.AgentCapabilityAcceptsRemoteConfig)
+		withAssignedConfig(a)
+
+		changed := svc.recordAgentRemoteConfigCondition(a, group)
+		assert.True(t, changed)
+
+		cond := a.GetCondition(agentmodel.AgentConditionTypeRemoteConfigApplied)
+		require.NotNil(t, cond)
+		assert.Equal(t, agentmodel.AgentConditionStatusTrue, cond.Status)
+	})
+
+	t.Run("agent without AcceptsRemoteConfig gets False with explanation", func(t *testing.T) {
+		t.Parallel()
+
+		a := agentmodel.NewAgent(uuid.New()) // default capabilities: none
+		withAssignedConfig(a)
+
+		changed := svc.recordAgentRemoteConfigCondition(a, group)
+		assert.True(t, changed)
+
+		cond := a.GetCondition(agentmodel.AgentConditionTypeRemoteConfigApplied)
+		require.NotNil(t, cond)
+		assert.Equal(t, agentmodel.AgentConditionStatusFalse, cond.Status)
+		assert.Contains(t, cond.Message, "does not accept remote config")
+	})
+
+	t.Run("no assigned config leaves the condition untouched", func(t *testing.T) {
+		t.Parallel()
+
+		a := agentmodel.NewAgent(uuid.New())
+
+		changed := svc.recordAgentRemoteConfigCondition(a, group)
+
+		assert.False(t, changed)
+		assert.Nil(t, a.GetCondition(agentmodel.AgentConditionTypeRemoteConfigApplied))
+	})
+
+	t.Run("unchanged condition reports no change on repeat", func(t *testing.T) {
+		t.Parallel()
+
+		a := agentmodel.NewAgent(uuid.New())
+		a.Metadata.Capabilities = agent.Capabilities(agent.AgentCapabilityAcceptsRemoteConfig)
+		withAssignedConfig(a)
+
+		assert.True(t, svc.recordAgentRemoteConfigCondition(a, group))
+		assert.False(t, svc.recordAgentRemoteConfigCondition(a, group))
+	})
+}
+
 func TestDeleteAgentGroup_PropagatesDeletion(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Why

When an agent group assigns a remote config, the outcome was only visible on the **group** (`RemoteConfigApplied` condition, added in #382). There was no per-agent signal — in particular, an agent that an agent group targets but which **cannot accept remote config** (no `AcceptsRemoteConfig` capability, e.g. a bare otel-collector with only the reporting opamp extension) silently never receives the config: it sits in `spec.remoteConfig`, never reaches the collector, and the effective config never changes. Diagnosed live on alpha: matching agents had `spec.remoteConfigNames=[...]` but unchanged effective config and capability `2053` (AcceptsRemoteConfig bit unset).

## What

Record the result on the **agent's** `RemoteConfigApplied` condition from `updateAgentsByAgentGroup`:

- **True** — config applied to a config-accepting agent (`remote config applied by agent group "X"`).
- **False** — a group assigned a config but the agent does not accept remote config (missing `AcceptsRemoteConfig`); message explains it will not be delivered.

Details:
- New clock-aware `Agent.SetConditionAt`; `SetCondition` delegates to it.
- New `Agent.HasAssignedRemoteConfig` (spec has config regardless of capability) and `AgentConditionTypeRemoteConfigApplied`.
- The condition can change even when the spec fingerprint did not, so it is folded into the save decision.
- No condition is recorded when no config is assigned.

## Tests

- `TestRecordAgentRemoteConfigCondition` (accepting→True, non-accepting→False+explanation, no-config→untouched, idempotent repeat).
- `go build ./...`, `go test -race ./internal/domain/agent/...`, `golangci-lint run ./internal/domain/...` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)