### PR TITLE
feat(web): per-visitor timezone display with preferences + top-bar picker

### DIFF
--- a/web/app/agentgroups/[name]/page.tsx
+++ b/web/app/agentgroups/[name]/page.tsx
@@ -28,6 +28,7 @@ import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { Suspense, useEffect, useState } from 'react';
 import PageHeader from '@/components/PageHeader';
 import JsonBlock from '@/components/JsonBlock';
+import TimeDisplay from '@/components/TimeDisplay';
 import ConfirmDialog from '@/components/ConfirmDialog';
 import { useNamespace } from '@/components/NamespaceProvider';
 import { api } from '@/lib/api-client';
@@ -196,7 +197,9 @@ function AgentGroupDetailInner() {
                 <Typography variant="caption" color="text.secondary">
                   Created
                 </Typography>
-                <Typography variant="body2">{group.metadata.createdAt}</Typography>
+                <Typography variant="body2" component="div">
+                  <TimeDisplay value={group.metadata.createdAt} />
+                </Typography>
               </Box>
             </Stack>
             {group.metadata.deletedAt && (
@@ -204,7 +207,9 @@ function AgentGroupDetailInner() {
                 <Typography variant="caption" color="text.secondary">
                   Deleted
                 </Typography>
-                <Typography variant="body2">{group.metadata.deletedAt}</Typography>
+                <Typography variant="body2" component="div">
+                  <TimeDisplay value={group.metadata.deletedAt} />
+                </Typography>
               </Box>
             )}
             <Box>

--- a/web/app/agentgroups/page.tsx
+++ b/web/app/agentgroups/page.tsx
@@ -29,6 +29,7 @@ import { useState } from 'react';
 import PageHeader from '@/components/PageHeader';
 import ConfirmDialog from '@/components/ConfirmDialog';
 import RowActionsMenu from '@/components/RowActionsMenu';
+import TimeDisplay from '@/components/TimeDisplay';
 import { useNamespace } from '@/components/NamespaceProvider';
 import { api } from '@/lib/api-client';
 import { useApi } from '@/lib/swr';
@@ -165,7 +166,9 @@ export default function AgentGroupsPage() {
                       variant="outlined"
                     />
                   </TableCell>
-                  <TableCell>{g.metadata.createdAt}</TableCell>
+                  <TableCell>
+                    <TimeDisplay value={g.metadata.createdAt} />
+                  </TableCell>
                   <TableCell align="right">
                     <RowActionsMenu
                       actions={[

--- a/web/app/agentpackages/page.tsx
+++ b/web/app/agentpackages/page.tsx
@@ -4,6 +4,7 @@ import { Box } from '@mui/material';
 import { useNamespace } from '@/components/NamespaceProvider';
 import ResourceListPage from '@/components/ResourceListPage';
 import JsonEditorDialog from '@/components/JsonEditorDialog';
+import TimeDisplay from '@/components/TimeDisplay';
 import { api } from '@/lib/api-client';
 import type { AgentPackage } from '@/lib/types';
 
@@ -48,7 +49,7 @@ export default function AgentPackagesPage() {
               </span>
             ),
           },
-          { header: 'Created', render: (p) => p.metadata.createdAt },
+          { header: 'Created', render: (p) => <TimeDisplay value={p.metadata.createdAt} /> },
         ]}
         renderCreate={({ open, onClose, onSaved }) => (
           <JsonEditorDialog

--- a/web/app/agentremoteconfigs/page.tsx
+++ b/web/app/agentremoteconfigs/page.tsx
@@ -6,6 +6,7 @@ import { useState } from 'react';
 import { useNamespace } from '@/components/NamespaceProvider';
 import ResourceListPage from '@/components/ResourceListPage';
 import JsonEditorDialog from '@/components/JsonEditorDialog';
+import TimeDisplay from '@/components/TimeDisplay';
 import { api } from '@/lib/api-client';
 import type { AgentRemoteConfig } from '@/lib/types';
 import ApplyToGroupDialog from './ApplyToGroupDialog';
@@ -55,7 +56,7 @@ export default function AgentRemoteConfigsPage() {
               </span>
             ),
           },
-          { header: 'Created', render: (c) => c.metadata.createdAt },
+          { header: 'Created', render: (c) => <TimeDisplay value={c.metadata.createdAt} /> },
         ]}
         renderCreate={({ open, onClose, onSaved }) => (
           <JsonEditorDialog

--- a/web/app/agents/[id]/page.tsx
+++ b/web/app/agents/[id]/page.tsx
@@ -25,6 +25,7 @@ import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import PageHeader from '@/components/PageHeader';
 import JsonBlock from '@/components/JsonBlock';
+import TimeDisplay from '@/components/TimeDisplay';
 import { useNamespace } from '@/components/NamespaceProvider';
 import { api } from '@/lib/api-client';
 import { useApi } from '@/lib/swr';
@@ -182,7 +183,7 @@ function AgentDetailInner() {
                 )}
               </Stack>
               <Typography variant="body2" mt={1}>
-                Last reported: {agent.status.lastReportedAt || '—'}
+                Last reported: <TimeDisplay value={agent.status.lastReportedAt} />
               </Typography>
               <Typography variant="body2">Sequence #: {agent.status.sequenceNum ?? '—'}</Typography>
             </CardContent>

--- a/web/app/agents/page.tsx
+++ b/web/app/agents/page.tsx
@@ -36,6 +36,7 @@ import { useRouter, useSearchParams } from 'next/navigation';
 import { Suspense, useCallback, useEffect, useState } from 'react';
 import PageHeader from '@/components/PageHeader';
 import RowActionsMenu from '@/components/RowActionsMenu';
+import TimeDisplay from '@/components/TimeDisplay';
 import { useNamespace } from '@/components/NamespaceProvider';
 import { api } from '@/lib/api-client';
 import { useApi } from '@/lib/swr';
@@ -392,7 +393,9 @@ function AgentsInner() {
                     />
                   </TableCell>
                   <TableCell>{agent.status.connectionType || '-'}</TableCell>
-                  <TableCell>{agent.status.lastReportedAt || '-'}</TableCell>
+                  <TableCell>
+                    <TimeDisplay value={agent.status.lastReportedAt} />
+                  </TableCell>
                   <TableCell>{agent.status.sequenceNum ?? '-'}</TableCell>
                   <TableCell align="right">
                     <RowActionsMenu

--- a/web/app/certificates/page.tsx
+++ b/web/app/certificates/page.tsx
@@ -4,6 +4,7 @@ import { Box, Chip } from '@mui/material';
 import { useNamespace } from '@/components/NamespaceProvider';
 import ResourceListPage from '@/components/ResourceListPage';
 import JsonEditorDialog from '@/components/JsonEditorDialog';
+import TimeDisplay from '@/components/TimeDisplay';
 import { api } from '@/lib/api-client';
 import type { Certificate } from '@/lib/types';
 
@@ -70,7 +71,7 @@ export default function CertificatesPage() {
               />
             ),
           },
-          { header: 'Created', render: (c) => c.metadata.createdAt },
+          { header: 'Created', render: (c) => <TimeDisplay value={c.metadata.createdAt} /> },
         ]}
         renderCreate={({ open, onClose, onSaved }) => (
           <JsonEditorDialog

--- a/web/app/connections/page.tsx
+++ b/web/app/connections/page.tsx
@@ -19,6 +19,7 @@ import Link from 'next/link';
 import { useCallback, useEffect, useState } from 'react';
 import PageHeader from '@/components/PageHeader';
 import { useNamespace } from '@/components/NamespaceProvider';
+import TimeDisplay from '@/components/TimeDisplay';
 import { api } from '@/lib/api-client';
 import type { Connection, ListResponse } from '@/lib/types';
 
@@ -103,7 +104,9 @@ export default function ConnectionsPage() {
                       size="small"
                     />
                   </TableCell>
-                  <TableCell>{c.lastCommunicatedAt}</TableCell>
+                  <TableCell>
+                    <TimeDisplay value={c.lastCommunicatedAt} />
+                  </TableCell>
                 </TableRow>
               ))
             )}

--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -4,6 +4,7 @@ import { AppRouterCacheProvider } from '@mui/material-nextjs/v16-appRouter';
 import './globals.css';
 import ThemeRegistry from '@/components/ThemeRegistry';
 import AppShell from '@/components/AppShell';
+import { PreferencesProvider } from '@/components/PreferencesProvider';
 
 const geistSans = Geist({
   variable: '--font-geist-sans',
@@ -31,9 +32,11 @@ export default function RootLayout({
         {/* Emotion cache + useServerInsertedHTML so MUI styles render correctly
             during SSR/RSC and don't cause hydration mismatches. */}
         <AppRouterCacheProvider>
-          <ThemeRegistry>
-            <AppShell>{children}</AppShell>
-          </ThemeRegistry>
+          <PreferencesProvider>
+            <ThemeRegistry>
+              <AppShell>{children}</AppShell>
+            </ThemeRegistry>
+          </PreferencesProvider>
         </AppRouterCacheProvider>
       </body>
     </html>

--- a/web/app/namespaces/page.tsx
+++ b/web/app/namespaces/page.tsx
@@ -24,6 +24,7 @@ import { Add as AddIcon, Delete as DeleteIcon, Refresh as RefreshIcon } from '@m
 import { useCallback, useEffect, useState } from 'react';
 import PageHeader from '@/components/PageHeader';
 import ConfirmDialog from '@/components/ConfirmDialog';
+import TimeDisplay from '@/components/TimeDisplay';
 import { useNamespace } from '@/components/NamespaceProvider';
 import { api } from '@/lib/api-client';
 import type { ListResponse, Namespace } from '@/lib/types';
@@ -144,8 +145,12 @@ export default function NamespacesPage() {
                   <TableCell sx={{ fontFamily: 'monospace', fontSize: 12 }}>
                     {ns.metadata.labels ? JSON.stringify(ns.metadata.labels) : '-'}
                   </TableCell>
-                  <TableCell>{ns.metadata.createdAt}</TableCell>
-                  <TableCell>{ns.metadata.deletedAt || '-'}</TableCell>
+                  <TableCell>
+                    <TimeDisplay value={ns.metadata.createdAt} />
+                  </TableCell>
+                  <TableCell>
+                    <TimeDisplay value={ns.metadata.deletedAt} />
+                  </TableCell>
                   <TableCell align="right">
                     <IconButton size="small" onClick={() => setDeleting(ns)}>
                       <DeleteIcon fontSize="small" />

--- a/web/app/preferences/page.tsx
+++ b/web/app/preferences/page.tsx
@@ -1,0 +1,68 @@
+'use client';
+
+import { Alert, Box, Card, CardContent, Typography } from '@mui/material';
+import { useEffect, useState } from 'react';
+import PageHeader from '@/components/PageHeader';
+import TimeDisplay from '@/components/TimeDisplay';
+import TimezoneSelector from '@/components/TimezoneSelector';
+import { usePreferences } from '@/components/PreferencesProvider';
+
+export default function PreferencesPage() {
+  const { hydrated } = usePreferences();
+
+  // The visitor's resolved browser timezone, shown so they know what "Local"
+  // maps to. Only meaningful client-side, so resolve it after mount.
+  const [localZone, setLocalZone] = useState<string | null>(null);
+  // A live "now" so the preview reflects the current time, not page-load time.
+  const [now, setNow] = useState<string | null>(null);
+  useEffect(() => {
+    try {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setLocalZone(Intl.DateTimeFormat().resolvedOptions().timeZone);
+    } catch {
+      // Leave null; the label simply omits the zone name.
+    }
+    const tick = () => setNow(new Date().toISOString());
+    tick();
+    const id = setInterval(tick, 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <Box>
+      <PageHeader
+        title="Preferences"
+        subtitle="Display settings stored in this browser. They apply only to you and are never sent to the server."
+      />
+
+      <Card variant="outlined" sx={{ mb: 3, maxWidth: 640 }}>
+        <CardContent>
+          <Typography variant="h6" gutterBottom>
+            Timezone
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            How timestamps are displayed throughout the app. Choose your browser&apos;s local time,
+            UTC, or any specific timezone.
+          </Typography>
+
+          <Box sx={{ maxWidth: 360 }}>
+            <TimezoneSelector localZone={localZone} />
+          </Box>
+
+          <Alert severity="info" icon={false} sx={{ mt: 2 }}>
+            <Typography variant="body2">
+              Preview:{' '}
+              <Box component="span" sx={{ fontFamily: 'var(--font-geist-mono), monospace' }}>
+                {hydrated && now ? <TimeDisplay value={now} /> : '…'}
+              </Box>
+            </Typography>
+          </Alert>
+        </CardContent>
+      </Card>
+
+      <Typography variant="caption" color="text.disabled">
+        More settings (theme, dark mode) will appear here.
+      </Typography>
+    </Box>
+  );
+}

--- a/web/app/profile/page.tsx
+++ b/web/app/profile/page.tsx
@@ -20,6 +20,7 @@ import {
 } from '@mui/material';
 import Link from 'next/link';
 import PageHeader from '@/components/PageHeader';
+import TimeDisplay from '@/components/TimeDisplay';
 import { useApi } from '@/lib/swr';
 import type { UserProfileResponse } from '@/lib/types';
 
@@ -77,7 +78,7 @@ export default function ProfilePage() {
               }
             />
             <Field label="UID" value={user.metadata.uid || '(no DB record yet)'} mono />
-            <Field label="Created" value={user.metadata.createdAt || '-'} />
+            <Field label="Created" value={<TimeDisplay value={user.metadata.createdAt} />} />
           </Stack>
           {labelEntries.length > 0 && (
             <>

--- a/web/app/rolebindings/page.tsx
+++ b/web/app/rolebindings/page.tsx
@@ -4,6 +4,7 @@ import { Box, Chip, Stack } from '@mui/material';
 import { useNamespace } from '@/components/NamespaceProvider';
 import ResourceListPage from '@/components/ResourceListPage';
 import JsonEditorDialog from '@/components/JsonEditorDialog';
+import TimeDisplay from '@/components/TimeDisplay';
 import { api } from '@/lib/api-client';
 import type { RoleBinding } from '@/lib/types';
 
@@ -56,7 +57,7 @@ export default function RoleBindingsPage() {
               </Stack>
             ),
           },
-          { header: 'Created', render: (rb) => rb.metadata.createdAt || '-' },
+          { header: 'Created', render: (rb) => <TimeDisplay value={rb.metadata.createdAt} /> },
         ]}
         renderCreate={({ open, onClose, onSaved }) => (
           <JsonEditorDialog

--- a/web/app/servers/page.tsx
+++ b/web/app/servers/page.tsx
@@ -18,6 +18,7 @@ import {
 import { Refresh as RefreshIcon } from '@mui/icons-material';
 import { useCallback, useEffect, useState } from 'react';
 import PageHeader from '@/components/PageHeader';
+import TimeDisplay from '@/components/TimeDisplay';
 import { api } from '@/lib/api-client';
 import type { ListResponse, Server } from '@/lib/types';
 
@@ -85,7 +86,9 @@ export default function ServersPage() {
               items.map((s) => (
                 <TableRow key={s.id} hover>
                   <TableCell sx={{ fontFamily: 'monospace' }}>{s.id}</TableCell>
-                  <TableCell>{s.lastHeartbeatAt}</TableCell>
+                  <TableCell>
+                    <TimeDisplay value={s.lastHeartbeatAt} />
+                  </TableCell>
                   <TableCell>
                     <Stack direction="row" gap={0.5} flexWrap="wrap">
                       {(s.conditions ?? []).map((c, i) => (

--- a/web/app/users/page.tsx
+++ b/web/app/users/page.tsx
@@ -3,6 +3,7 @@
 import { Box, Chip } from '@mui/material';
 import ResourceListPage from '@/components/ResourceListPage';
 import JsonEditorDialog from '@/components/JsonEditorDialog';
+import TimeDisplay from '@/components/TimeDisplay';
 import { api } from '@/lib/api-client';
 import type { User } from '@/lib/types';
 
@@ -47,7 +48,7 @@ export default function UsersPage() {
               <span style={{ fontFamily: 'monospace', fontSize: 12 }}>{u.metadata.uid}</span>
             ),
           },
-          { header: 'Created', render: (u) => u.metadata.createdAt },
+          { header: 'Created', render: (u) => <TimeDisplay value={u.metadata.createdAt} /> },
         ]}
         renderCreate={({ open, onClose, onSaved }) => (
           <JsonEditorDialog

--- a/web/components/AppLayout.tsx
+++ b/web/components/AppLayout.tsx
@@ -37,6 +37,7 @@ import {
   AccountCircle as AccountIcon,
   Badge as BadgeIcon,
   Menu as MenuIcon,
+  Settings as SettingsIcon,
 } from '@mui/icons-material';
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
@@ -44,6 +45,7 @@ import { type ReactNode, useEffect, useState } from 'react';
 import { useAuth } from './AuthProvider';
 import NamespaceSelector from './NamespaceSelector';
 import { usePermissions } from './PermissionsProvider';
+import TimezoneButton from './TimezoneButton';
 import VersionFooter from './VersionFooter';
 
 const drawerWidth = 240;
@@ -233,6 +235,7 @@ export default function AppLayout({ children }: { children: ReactNode }) {
           />
           <NamespaceSelector />
           <Box sx={{ flexGrow: 1 }} />
+          <TimezoneButton />
           <Tooltip title={email || 'Account'}>
             <IconButton
               color="inherit"
@@ -256,6 +259,12 @@ export default function AppLayout({ children }: { children: ReactNode }) {
                 <BadgeIcon fontSize="small" />
               </ListItemIcon>
               My profile
+            </MenuItem>
+            <MenuItem component={Link} href="/preferences" onClick={() => setMenuAnchor(null)}>
+              <ListItemIcon>
+                <SettingsIcon fontSize="small" />
+              </ListItemIcon>
+              Preferences
             </MenuItem>
             <MenuItem
               onClick={() => {

--- a/web/components/PreferencesProvider.tsx
+++ b/web/components/PreferencesProvider.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from 'react';
+import {
+  DEFAULT_PREFERENCES,
+  type Preferences,
+  readPreferences,
+  writePreferences,
+} from '@/lib/preferences';
+
+interface PreferencesContextValue {
+  preferences: Preferences;
+  // Set the display timezone: 'local' (browser zone) or an IANA zone name.
+  setTimeZone: (timeZone: string) => void;
+  // True once the persisted preferences have been read from localStorage on the
+  // client. Components that render timezone-dependent output (which differs
+  // between the server and the visitor's browser) gate on this to stay
+  // hydration-safe: they render a deterministic UTC value until it flips true.
+  hydrated: boolean;
+}
+
+const PreferencesContext = createContext<PreferencesContextValue | undefined>(undefined);
+
+export function PreferencesProvider({ children }: { children: ReactNode }) {
+  // Start from defaults so the server render and the first client render match;
+  // hydrate the real persisted values after mount.
+  const [preferences, setPreferences] = useState<Preferences>(DEFAULT_PREFERENCES);
+  const [hydrated, setHydrated] = useState(false);
+
+  // Hydrate persisted preferences after mount (keeps the server render and the
+  // first client render identical — see `hydrated` above).
+  useEffect(() => {
+    // eslint-disable-next-line react-hooks/set-state-in-effect
+    setPreferences(readPreferences());
+    setHydrated(true);
+  }, []);
+
+  const setTimeZone = useCallback((timeZone: string) => {
+    setPreferences((prev) => {
+      const next = { ...prev, timeZone };
+      writePreferences(next);
+      return next;
+    });
+  }, []);
+
+  const value = useMemo<PreferencesContextValue>(
+    () => ({ preferences, setTimeZone, hydrated }),
+    [preferences, setTimeZone, hydrated],
+  );
+
+  return <PreferencesContext.Provider value={value}>{children}</PreferencesContext.Provider>;
+}
+
+export function usePreferences(): PreferencesContextValue {
+  const ctx = useContext(PreferencesContext);
+  if (!ctx) throw new Error('usePreferences must be used within PreferencesProvider');
+  return ctx;
+}

--- a/web/components/TimeDisplay.tsx
+++ b/web/components/TimeDisplay.tsx
@@ -1,0 +1,42 @@
+'use client';
+
+import { usePreferences } from './PreferencesProvider';
+import { formatTimestamp } from '@/lib/format-time';
+import { LOCAL_TIME_ZONE } from '@/lib/preferences';
+
+interface Props {
+  // ISO-8601 timestamp. Empty/undefined renders `emptyText`.
+  value: string | null | undefined;
+  // Placeholder when there is no value. Defaults to a hyphen.
+  emptyText?: string;
+}
+
+// Renders a timestamp formatted per the user's timezone preference. Until the
+// preferences have hydrated on the client we render in UTC, which is identical
+// on the server and the browser — so switching to the chosen zone happens after
+// hydration without a mismatch. suppressHydrationWarning guards against any
+// residual Intl differences between the Node and browser runtimes.
+export default function TimeDisplay({ value, emptyText = '-' }: Props) {
+  const { preferences, hydrated } = usePreferences();
+
+  if (!value) return <>{emptyText}</>;
+
+  // Before hydration: deterministic UTC. After: 'local' → host zone (undefined),
+  // otherwise the chosen IANA zone.
+  const timeZone = !hydrated
+    ? 'UTC'
+    : preferences.timeZone === LOCAL_TIME_ZONE
+      ? undefined
+      : preferences.timeZone;
+  const formatted = formatTimestamp(value, timeZone);
+  if (!formatted) {
+    // Not a parseable timestamp — fall back to the raw value verbatim.
+    return <span title={value}>{value}</span>;
+  }
+
+  return (
+    <time dateTime={value} title={formatted.title} suppressHydrationWarning>
+      {formatted.text}
+    </time>
+  );
+}

--- a/web/components/TimezoneButton.tsx
+++ b/web/components/TimezoneButton.tsx
@@ -41,7 +41,10 @@ export default function TimezoneButton() {
           onClick={(e) => setAnchor(e.currentTarget)}
           sx={{ textTransform: 'none', maxWidth: 220, minWidth: 0 }}
         >
-          <Box component="span" sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+          <Box
+            component="span"
+            sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}
+          >
             {label}
           </Box>
         </Button>

--- a/web/components/TimezoneButton.tsx
+++ b/web/components/TimezoneButton.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { AccessTime as ClockIcon } from '@mui/icons-material';
+import { Box, Button, Divider, Popover, Tooltip, Typography } from '@mui/material';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { usePreferences } from './PreferencesProvider';
+import TimezoneSelector from './TimezoneSelector';
+import { LOCAL_TIME_ZONE } from '@/lib/preferences';
+
+// Top-bar control showing the active display timezone and opening a quick
+// picker. Mirrors the setting on the Preferences page (same shared state).
+export default function TimezoneButton() {
+  const { preferences, hydrated } = usePreferences();
+  const [anchor, setAnchor] = useState<HTMLElement | null>(null);
+  const [localZone, setLocalZone] = useState<string | null>(null);
+
+  useEffect(() => {
+    try {
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setLocalZone(Intl.DateTimeFormat().resolvedOptions().timeZone);
+    } catch {
+      // Leave null; the label falls back to "Local".
+    }
+  }, []);
+
+  // Render a stable placeholder until hydrated so the server and first client
+  // render match (the resolved zone is only known in the browser).
+  const label = !hydrated
+    ? '…'
+    : preferences.timeZone === LOCAL_TIME_ZONE
+      ? (localZone ?? 'Local')
+      : preferences.timeZone;
+
+  return (
+    <>
+      <Tooltip title="Display timezone">
+        <Button
+          color="inherit"
+          startIcon={<ClockIcon />}
+          onClick={(e) => setAnchor(e.currentTarget)}
+          sx={{ textTransform: 'none', maxWidth: 220, minWidth: 0 }}
+        >
+          <Box component="span" sx={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>
+            {label}
+          </Box>
+        </Button>
+      </Tooltip>
+      <Popover
+        open={Boolean(anchor)}
+        anchorEl={anchor}
+        onClose={() => setAnchor(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+        transformOrigin={{ vertical: 'top', horizontal: 'right' }}
+        slotProps={{ paper: { sx: { p: 2, width: 340 } } }}
+      >
+        <Typography variant="subtitle2" gutterBottom>
+          Display timezone
+        </Typography>
+        <TimezoneSelector localZone={localZone} autoFocus size="small" />
+        <Divider sx={{ my: 1.5 }} />
+        <Typography variant="caption" color="text.secondary">
+          Applies to all timestamps in this browser. More in{' '}
+          <Link href="/preferences" onClick={() => setAnchor(null)} style={{ color: 'inherit' }}>
+            Preferences
+          </Link>
+          .
+        </Typography>
+      </Popover>
+    </>
+  );
+}

--- a/web/components/TimezoneSelector.tsx
+++ b/web/components/TimezoneSelector.tsx
@@ -1,0 +1,67 @@
+'use client';
+
+import { Autocomplete, Button, Stack, TextField } from '@mui/material';
+import { MyLocation as LocalIcon, Public as UtcIcon } from '@mui/icons-material';
+import { useMemo } from 'react';
+import { usePreferences } from './PreferencesProvider';
+import { LOCAL_TIME_ZONE, listTimeZones } from '@/lib/preferences';
+
+interface Props {
+  // The visitor's resolved browser zone, shown alongside the "Local time"
+  // option/button so they know what it maps to.
+  localZone?: string | null;
+  autoFocus?: boolean;
+  size?: 'small' | 'medium';
+}
+
+// One-click presets (Local time / UTC) plus a searchable picker over every IANA
+// timezone. Writes the selection straight through to the shared preference.
+export default function TimezoneSelector({ localZone, autoFocus, size = 'medium' }: Props) {
+  const { preferences, setTimeZone } = usePreferences();
+  const current = preferences.timeZone;
+
+  const options = useMemo(() => {
+    const zones = [LOCAL_TIME_ZONE, ...listTimeZones()];
+    // Keep a persisted-but-unlisted zone selectable so Autocomplete can match it.
+    if (!zones.includes(current)) zones.push(current);
+    return zones;
+  }, [current]);
+
+  return (
+    <Stack spacing={1.5}>
+      <Stack direction="row" spacing={1} flexWrap="wrap" useFlexGap>
+        <Button
+          size="small"
+          startIcon={<LocalIcon />}
+          variant={current === LOCAL_TIME_ZONE ? 'contained' : 'outlined'}
+          onClick={() => setTimeZone(LOCAL_TIME_ZONE)}
+        >
+          Local time
+        </Button>
+        <Button
+          size="small"
+          startIcon={<UtcIcon />}
+          variant={current === 'UTC' ? 'contained' : 'outlined'}
+          onClick={() => setTimeZone('UTC')}
+        >
+          UTC
+        </Button>
+      </Stack>
+      <Autocomplete
+        options={options}
+        value={current}
+        onChange={(_, v) => v && setTimeZone(v)}
+        getOptionLabel={(z) =>
+          z === LOCAL_TIME_ZONE ? `Local time${localZone ? ` — ${localZone}` : ''}` : z
+        }
+        disableClearable
+        autoHighlight
+        fullWidth
+        size={size}
+        renderInput={(params) => (
+          <TextField {...params} label="Or pick a specific timezone" autoFocus={autoFocus} />
+        )}
+      />
+    </Stack>
+  );
+}

--- a/web/lib/format-time.test.ts
+++ b/web/lib/format-time.test.ts
@@ -1,0 +1,35 @@
+import { describe, expect, it } from 'vitest';
+import { formatTimestamp } from './format-time';
+
+describe('formatTimestamp', () => {
+  const iso = '2026-06-04T01:59:30Z';
+
+  it('returns null for empty or invalid input', () => {
+    expect(formatTimestamp('', 'UTC')).toBeNull();
+    expect(formatTimestamp(null, 'UTC')).toBeNull();
+    expect(formatTimestamp(undefined)).toBeNull();
+    expect(formatTimestamp('not-a-date', 'UTC')).toBeNull();
+  });
+
+  it('formats an explicit UTC zone', () => {
+    const out = formatTimestamp(iso, 'UTC');
+    expect(out).not.toBeNull();
+    expect(out!.text).toBe('2026-06-04 01:59:30 UTC');
+    // The title uses the long zone name and strips all commas.
+    expect(out!.title).toContain('Coordinated Universal Time');
+    expect(out!.title).not.toContain(',');
+  });
+
+  it('honours an explicit IANA timezone', () => {
+    const out = formatTimestamp(iso, 'Asia/Seoul');
+    expect(out).not.toBeNull();
+    // Seoul is UTC+9, so 01:59:30Z is 10:59:30 local.
+    expect(out!.text).toBe('2026-06-04 10:59:30 GMT+9');
+  });
+
+  it('formats a different zone correctly', () => {
+    const out = formatTimestamp(iso, 'America/New_York');
+    // EDT is UTC-4 in June, so 01:59:30Z is the previous day 21:59:30.
+    expect(out!.text).toBe('2026-06-03 21:59:30 EDT');
+  });
+});

--- a/web/lib/format-time.ts
+++ b/web/lib/format-time.ts
@@ -1,0 +1,67 @@
+// Pure timestamp formatting shared by the <TimeDisplay> component. Kept free of
+// React so it can be unit-tested directly.
+
+export interface FormattedTime {
+  // Short form shown inline, e.g. "2026-06-04 01:59:00 UTC".
+  text: string;
+  // Long form for a tooltip / title attribute, includes the full zone name.
+  title: string;
+}
+
+const SHORT_OPTIONS: Intl.DateTimeFormatOptions = {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit',
+  hour: '2-digit',
+  minute: '2-digit',
+  second: '2-digit',
+  hour12: false,
+  timeZoneName: 'short',
+};
+
+const LONG_OPTIONS: Intl.DateTimeFormatOptions = {
+  ...SHORT_OPTIONS,
+  weekday: 'short',
+  timeZoneName: 'long',
+};
+
+// Format an ISO-8601 timestamp for display. `timeZone` is an IANA zone name
+// (e.g. 'UTC', 'Asia/Seoul'); pass undefined to use the runtime's local zone
+// (the visitor's browser zone on the client). Returns null for empty/invalid
+// input so callers can render their own placeholder.
+export function formatTimestamp(
+  value: string | null | undefined,
+  timeZone?: string,
+): FormattedTime | null {
+  if (!value) return null;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return null;
+
+  // `undefined` timeZone means "host zone", stable within a session.
+  const zoneKey = timeZone ?? 'local';
+
+  return {
+    text: format(date, { ...SHORT_OPTIONS, timeZone }, `short:${zoneKey}`),
+    title: format(date, { ...LONG_OPTIONS, timeZone }, `long:${zoneKey}`),
+  };
+}
+
+// Constructing an Intl.DateTimeFormat is the expensive part (`.format()` is
+// cheap), and a single table can render hundreds of timestamps per pass — so
+// cache one formatter per distinct options set keyed by timezone.
+const formatterCache = new Map<string, Intl.DateTimeFormat>();
+
+function getFormatter(options: Intl.DateTimeFormatOptions, cacheKey: string): Intl.DateTimeFormat {
+  let fmt = formatterCache.get(cacheKey);
+  if (!fmt) {
+    fmt = new Intl.DateTimeFormat('en-CA', options);
+    formatterCache.set(cacheKey, fmt);
+  }
+  return fmt;
+}
+
+// Intl renders "2026-06-04, 01:59:00 UTC"; drop the commas so the output reads
+// as a single clean timestamp.
+function format(date: Date, options: Intl.DateTimeFormatOptions, cacheKey: string): string {
+  return getFormatter(options, cacheKey).format(date).replaceAll(',', '');
+}

--- a/web/lib/preferences.test.ts
+++ b/web/lib/preferences.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { LOCAL_TIME_ZONE, isValidTimeZone, listTimeZones } from './preferences';
+
+describe('isValidTimeZone', () => {
+  it('accepts the local sentinel and real IANA zones', () => {
+    expect(isValidTimeZone(LOCAL_TIME_ZONE)).toBe(true);
+    expect(isValidTimeZone('UTC')).toBe(true);
+    expect(isValidTimeZone('Asia/Seoul')).toBe(true);
+    expect(isValidTimeZone('America/New_York')).toBe(true);
+  });
+
+  it('rejects unknown zones and non-strings', () => {
+    expect(isValidTimeZone('Mars/Olympus')).toBe(false);
+    expect(isValidTimeZone('')).toBe(false);
+    expect(isValidTimeZone(undefined)).toBe(false);
+    expect(isValidTimeZone(42)).toBe(false);
+  });
+});
+
+describe('listTimeZones', () => {
+  it('returns a non-empty list that includes UTC', () => {
+    const zones = listTimeZones();
+    expect(zones.length).toBeGreaterThan(0);
+    expect(zones).toContain('UTC');
+  });
+});

--- a/web/lib/preferences.ts
+++ b/web/lib/preferences.ts
@@ -1,0 +1,110 @@
+// Client-side, frontend-only user preferences (timezone display, and later
+// theme / dark mode and other UI toggles). Persisted to localStorage so the
+// choice survives reloads. These are purely presentational and never sent to
+// the server, so localStorage (not a cookie/session) is the right home.
+
+// The sentinel for "use the visitor's browser timezone". Any other value is an
+// IANA timezone name (e.g. 'UTC', 'Asia/Seoul', 'America/New_York').
+export const LOCAL_TIME_ZONE = 'local';
+
+export interface Preferences {
+  // 'local' (browser zone) or an IANA timezone name.
+  timeZone: string;
+}
+
+export const DEFAULT_PREFERENCES: Preferences = {
+  timeZone: LOCAL_TIME_ZONE,
+};
+
+const STORAGE_KEY = 'opamp.preferences';
+
+// localStorage access throws in private browsing, when storage is disabled, or
+// over quota. Preferences are best-effort UI state, so every access degrades
+// to the defaults rather than throwing.
+export function readPreferences(): Preferences {
+  if (typeof window === 'undefined') return DEFAULT_PREFERENCES;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return DEFAULT_PREFERENCES;
+    const parsed = JSON.parse(raw) as Partial<Preferences>;
+    return normalize(parsed);
+  } catch {
+    return DEFAULT_PREFERENCES;
+  }
+}
+
+export function writePreferences(prefs: Preferences): void {
+  if (typeof window === 'undefined') return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(prefs));
+  } catch {
+    // Best-effort: the preference just won't persist across reloads.
+  }
+}
+
+// True for 'local' and any IANA zone the runtime recognises. Used both to
+// sanitise persisted values and to validate user selections.
+export function isValidTimeZone(tz: unknown): tz is string {
+  if (typeof tz !== 'string') return false;
+  if (tz === LOCAL_TIME_ZONE) return true;
+  try {
+    new Intl.DateTimeFormat('en-CA', { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Return the canonical IANA spelling of a zone (Intl is case-insensitive, so
+// 'utc' resolves to 'UTC'). Unknown values collapse to the local sentinel.
+// This also migrates the legacy lowercase 'utc' preference to 'UTC'.
+export function canonicalTimeZone(tz: unknown): string {
+  if (typeof tz !== 'string' || tz === LOCAL_TIME_ZONE) return LOCAL_TIME_ZONE;
+  try {
+    return new Intl.DateTimeFormat('en-CA', { timeZone: tz }).resolvedOptions().timeZone;
+  } catch {
+    return LOCAL_TIME_ZONE;
+  }
+}
+
+// The list of selectable IANA timezones. Modern browsers/Node expose the full
+// IANA set via Intl.supportedValuesOf; fall back to a small curated list when
+// it is unavailable so the picker is never empty.
+export function listTimeZones(): string[] {
+  let zones = FALLBACK_ZONES;
+  try {
+    const supported = (
+      Intl as typeof Intl & { supportedValuesOf?: (key: string) => string[] }
+    ).supportedValuesOf;
+    if (typeof supported === 'function') {
+      zones = supported('timeZone');
+    }
+  } catch {
+    // Keep the curated list.
+  }
+  // Intl.supportedValuesOf omits 'UTC'; surface it at the top so it's always
+  // an easy choice.
+  return zones.includes('UTC') ? zones : ['UTC', ...zones];
+}
+
+const FALLBACK_ZONES = [
+  'UTC',
+  'America/Los_Angeles',
+  'America/New_York',
+  'America/Sao_Paulo',
+  'Europe/London',
+  'Europe/Berlin',
+  'Europe/Moscow',
+  'Asia/Dubai',
+  'Asia/Kolkata',
+  'Asia/Shanghai',
+  'Asia/Seoul',
+  'Asia/Tokyo',
+  'Australia/Sydney',
+];
+
+// Coerce an untrusted parsed object into a valid Preferences, canonicalising
+// the zone spelling and dropping unknown values back to their defaults.
+function normalize(parsed: Partial<Preferences>): Preferences {
+  return { timeZone: canonicalTimeZone(parsed.timeZone) };
+}

--- a/web/lib/preferences.ts
+++ b/web/lib/preferences.ts
@@ -73,9 +73,8 @@ export function canonicalTimeZone(tz: unknown): string {
 export function listTimeZones(): string[] {
   let zones = FALLBACK_ZONES;
   try {
-    const supported = (
-      Intl as typeof Intl & { supportedValuesOf?: (key: string) => string[] }
-    ).supportedValuesOf;
+    const supported = (Intl as typeof Intl & { supportedValuesOf?: (key: string) => string[] })
+      .supportedValuesOf;
     if (typeof supported === 'function') {
       zones = supported('timeZone');
     }


### PR DESCRIPTION
## Summary
Timestamps across the web UI now render in the **visitor's browser timezone** by default, with a way to switch to **UTC** or **any specific IANA timezone**. Adds a `/preferences` page (the future home for frontend-only settings like dark mode) and a top-bar timezone control.

## What changed
- **`lib/preferences.ts`** — frontend-only prefs persisted to `localStorage`. `timeZone` is a single string: `'local'` (browser zone) or an IANA name (`'UTC'`, `'Asia/Seoul'`, …). UTC is just one of the zones, not a special mode.
  - `canonicalTimeZone()` migrates the legacy lowercase `'utc'` → `'UTC'` (Intl is case-insensitive).
  - `listTimeZones()` prepends `'UTC'` because `Intl.supportedValuesOf('timeZone')` omits it.
- **`lib/format-time.ts`** — pure, testable formatter with a per-zone `Intl.DateTimeFormat` cache (a single table renders hundreds of timestamps per render pass).
- **`PreferencesProvider`** — mounted in `layout.tsx` *above* `ThemeRegistry` so a future dark-mode toggle can share the same context. Hydration-safe (`hydrated` flag).
- **`TimeDisplay`** — renders all timestamps; UTC pre-hydration (server == first client render) then the chosen zone after mount, `suppressHydrationWarning` as backstop.
- **`TimezoneSelector`** — shared one-click **Local time** / **UTC** presets + searchable Autocomplete. Used by both the `/preferences` page and the new top-bar **`TimezoneButton`** (shows the active zone, opens a quick picker).
- Replaced every raw timestamp render (agents, connections, servers, namespaces, agent groups, packages, remote configs, certificates, users, role bindings, profile) with `<TimeDisplay>`.

## Tests
- `lib/format-time.test.ts`, `lib/preferences.test.ts`
- `tsc` ✓ · `eslint` ✓ · `vitest` 26 passed ✓ · `next build` ✓

## Manual verification (Chrome, against alpha API)
- Default **Local time** auto-detected as `Asia/Seoul`; timestamps show `… GMT+9`.
- **UTC** preset → `… GMT+9` shifts −9h to `… UTC`; displayed uppercase.
- **America/New_York** via select → Agents table shifts to `… EDT` (−13h from KST), correct.
- Top-bar popover and `/preferences` share state; switching in one updates everything live.

## Notes
- Display-only; nothing is sent to the server.
- The `/preferences` page is intended to host future frontend settings (theme / dark mode).

🤖 Generated with [Claude Code](https://claude.com/claude-code)