### PR TITLE
feat(web): paginated list views with total count ("1–50 of N")

### DIFF
--- a/web/app/agentgroups/page.tsx
+++ b/web/app/agentgroups/page.tsx
@@ -28,12 +28,13 @@ import { Tooltip } from '@mui/material';
 import { useState } from 'react';
 import PageHeader from '@/components/PageHeader';
 import ConfirmDialog from '@/components/ConfirmDialog';
+import PaginationFooter from '@/components/PaginationFooter';
 import RowActionsMenu from '@/components/RowActionsMenu';
 import TimeDisplay from '@/components/TimeDisplay';
 import { useNamespace } from '@/components/NamespaceProvider';
 import { api } from '@/lib/api-client';
-import { useApi } from '@/lib/swr';
-import type { AgentGroup, ListResponse } from '@/lib/types';
+import { useCursorPagination } from '@/lib/pagination';
+import type { AgentGroup } from '@/lib/types';
 import AgentGroupEditDialog from './AgentGroupEditDialog';
 
 export default function AgentGroupsPage() {
@@ -43,17 +44,8 @@ export default function AgentGroupsPage() {
   const [deleting, setDeleting] = useState<AgentGroup | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
 
-  const {
-    data,
-    error: fetchError,
-    isLoading,
-    mutate,
-  } = useApi<ListResponse<AgentGroup>>([
-    `/api/v1/namespaces/${namespace}/agentgroups`,
-    { limit: 200 },
-  ]);
-  const groups = data?.items ?? [];
-  const loading = isLoading;
+  const pagination = useCursorPagination<AgentGroup>(`/api/v1/namespaces/${namespace}/agentgroups`);
+  const { items: groups, isLoading: loading, error: fetchError, refresh } = pagination;
   const error =
     actionError ??
     (fetchError instanceof Error
@@ -62,7 +54,7 @@ export default function AgentGroupsPage() {
         ? 'Failed to fetch groups'
         : null);
 
-  const fetchGroups = () => mutate();
+  const fetchGroups = () => refresh();
 
   const onDelete = async () => {
     if (!deleting) return;
@@ -70,7 +62,7 @@ export default function AgentGroupsPage() {
       await api.delete(`/api/v1/namespaces/${namespace}/agentgroups/${deleting.metadata.name}`);
       setDeleting(null);
       setActionError(null);
-      await mutate();
+      refresh();
     } catch (err) {
       setActionError(err instanceof Error ? err.message : 'Failed to delete');
     }
@@ -203,6 +195,8 @@ export default function AgentGroupsPage() {
           </TableBody>
         </Table>
       </TableContainer>
+
+      <PaginationFooter pagination={pagination} />
 
       <AgentGroupEditDialog
         open={createOpen}

--- a/web/app/agents/page.tsx
+++ b/web/app/agents/page.tsx
@@ -33,16 +33,15 @@ import {
 } from '@mui/icons-material';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
-import { Suspense, useCallback, useEffect, useState } from 'react';
+import { Suspense, useEffect, useState } from 'react';
 import PageHeader from '@/components/PageHeader';
+import PaginationFooter from '@/components/PaginationFooter';
 import RowActionsMenu from '@/components/RowActionsMenu';
 import TimeDisplay from '@/components/TimeDisplay';
 import { useNamespace } from '@/components/NamespaceProvider';
-import { api } from '@/lib/api-client';
+import { useCursorPagination } from '@/lib/pagination';
 import { useApi } from '@/lib/swr';
 import type { Agent, AgentGroup, ListResponse } from '@/lib/types';
-
-const PAGE_SIZE = 50;
 
 type SearchMode = 'uid' | 'group' | 'description';
 
@@ -71,13 +70,26 @@ function AgentsInner() {
     (search.get('mode') as SearchMode | null) ||
     (agentGroupParam ? 'group' : descParam ? 'description' : 'uid');
 
-  const [agents, setAgents] = useState<Agent[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
   const [mode, setMode] = useState<SearchMode>(modeParam);
   const [query, setQuery] = useState(qParam);
-  const [continueToken, setContinueToken] = useState<string | null>(null);
-  const [continueStack, setContinueStack] = useState<string[]>([]);
+
+  // The three search modes hit different endpoints; description mode reuses the
+  // plain list and filters client-side (see visibleAgents below).
+  let listPath: string;
+  const listQuery: Record<string, string> = {};
+  if (agentGroupParam) {
+    listPath = `/api/v1/namespaces/${namespace}/agentgroups/${agentGroupParam}/agents`;
+  } else if (qParam) {
+    listPath = `/api/v1/namespaces/${namespace}/agents/search`;
+    listQuery.q = qParam;
+  } else {
+    listPath = `/api/v1/namespaces/${namespace}/agents`;
+  }
+
+  const pagination = useCursorPagination<Agent>(listPath, { query: listQuery });
+  const { items: agents, isLoading: loading, error: fetchError } = pagination;
+  const error =
+    fetchError instanceof Error ? fetchError.message : fetchError ? 'Failed to fetch agents' : null;
 
   // Group list for the "Group" autocomplete + chip cross-reference. SWR dedupes
   // this with the same fetch on other pages and silently no-ops on RBAC denial.
@@ -98,44 +110,6 @@ function AgentsInner() {
   useEffect(() => {
     setMode(modeParam);
   }, [modeParam]);
-
-  const fetchAgents = useCallback(
-    async (token?: string) => {
-      setLoading(true);
-      setError(null);
-      try {
-        let path: string;
-        const q: Record<string, string | number | undefined> = {
-          limit: PAGE_SIZE,
-          continue: token,
-        };
-
-        if (agentGroupParam) {
-          path = `/api/v1/namespaces/${namespace}/agentgroups/${agentGroupParam}/agents`;
-        } else if (qParam) {
-          path = `/api/v1/namespaces/${namespace}/agents/search`;
-          q.q = qParam;
-        } else {
-          // Description search filters client-side over the unsearched list.
-          path = `/api/v1/namespaces/${namespace}/agents`;
-        }
-
-        const data = await api.get<ListResponse<Agent>>(path, { query: q });
-        setAgents(data.items ?? []);
-        setContinueToken(data.metadata?.continue || null);
-      } catch (err) {
-        setError(err instanceof Error ? err.message : 'Failed to fetch agents');
-      } finally {
-        setLoading(false);
-      }
-    },
-    [namespace, qParam, agentGroupParam],
-  );
-
-  useEffect(() => {
-    setContinueStack([]);
-    void fetchAgents();
-  }, [fetchAgents]);
 
   const updateUrl = (next: {
     q?: string;
@@ -180,12 +154,6 @@ function AgentsInner() {
     updateUrl({ q: '' });
   };
 
-  const next = () => {
-    if (!continueToken) return;
-    setContinueStack((s) => [...s, continueToken]);
-    void fetchAgents(continueToken);
-  };
-
   const filterActive = Boolean(agentGroupParam || qParam || descParam);
   const lcDesc = descParam.toLowerCase();
   const visibleAgents = descParam
@@ -198,7 +166,7 @@ function AgentsInner() {
         title="Agents"
         subtitle={`Namespace: ${namespace}`}
         actions={
-          <IconButton color="primary" onClick={() => fetchAgents()}>
+          <IconButton color="primary" onClick={() => pagination.refresh()}>
             <RefreshIcon />
           </IconButton>
         }
@@ -425,21 +393,7 @@ function AgentsInner() {
         </Table>
       </TableContainer>
 
-      <Stack direction="row" justifyContent="flex-end" mt={2} gap={1}>
-        <Button
-          disabled={continueStack.length === 0 || loading}
-          onClick={() => {
-            const prev = continueStack[continueStack.length - 2] || undefined;
-            setContinueStack((s) => s.slice(0, -1));
-            void fetchAgents(prev);
-          }}
-        >
-          Prev
-        </Button>
-        <Button disabled={!continueToken || loading} onClick={next}>
-          Next
-        </Button>
-      </Stack>
+      <PaginationFooter pagination={pagination} />
     </Box>
   );
 }

--- a/web/app/connections/page.tsx
+++ b/web/app/connections/page.tsx
@@ -16,38 +16,19 @@ import {
 } from '@mui/material';
 import { Refresh as RefreshIcon } from '@mui/icons-material';
 import Link from 'next/link';
-import { useCallback, useEffect, useState } from 'react';
 import PageHeader from '@/components/PageHeader';
+import PaginationFooter from '@/components/PaginationFooter';
 import { useNamespace } from '@/components/NamespaceProvider';
 import TimeDisplay from '@/components/TimeDisplay';
-import { api } from '@/lib/api-client';
-import type { Connection, ListResponse } from '@/lib/types';
+import { useCursorPagination } from '@/lib/pagination';
+import type { Connection } from '@/lib/types';
 
 export default function ConnectionsPage() {
   const { namespace } = useNamespace();
-  const [items, setItems] = useState<Connection[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  const fetchItems = useCallback(async () => {
-    setLoading(true);
-    setError(null);
-    try {
-      const res = await api.get<ListResponse<Connection>>(
-        `/api/v1/namespaces/${namespace}/connections`,
-        { query: { limit: 200 } },
-      );
-      setItems(res.items ?? []);
-    } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to fetch');
-    } finally {
-      setLoading(false);
-    }
-  }, [namespace]);
-
-  useEffect(() => {
-    void fetchItems();
-  }, [fetchItems]);
+  const pagination = useCursorPagination<Connection>(`/api/v1/namespaces/${namespace}/connections`);
+  const { items, isLoading: loading, error: fetchError, refresh } = pagination;
+  const error =
+    fetchError instanceof Error ? fetchError.message : fetchError ? 'Failed to fetch' : null;
 
   return (
     <Box>
@@ -55,7 +36,7 @@ export default function ConnectionsPage() {
         title="Connections"
         subtitle={`Namespace: ${namespace}`}
         actions={
-          <IconButton color="primary" onClick={fetchItems}>
+          <IconButton color="primary" onClick={() => refresh()}>
             <RefreshIcon />
           </IconButton>
         }
@@ -113,6 +94,8 @@ export default function ConnectionsPage() {
           </TableBody>
         </Table>
       </TableContainer>
+
+      <PaginationFooter pagination={pagination} />
     </Box>
   );
 }

--- a/web/components/PaginationFooter.tsx
+++ b/web/components/PaginationFooter.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { TablePagination } from '@mui/material';
+import type { CursorPagination } from '@/lib/pagination';
+
+interface Props {
+  // Accepts the object returned by useCursorPagination (only the fields used
+  // here are required, so any element type works).
+  pagination: Pick<
+    CursorPagination<unknown>,
+    | 'page'
+    | 'pageSize'
+    | 'range'
+    | 'canPrev'
+    | 'canNext'
+    | 'next'
+    | 'prev'
+    | 'setPageSize'
+    | 'isLoading'
+  >;
+  rowsPerPageOptions?: number[];
+}
+
+const DEFAULT_OPTIONS = [25, 50, 100, 200];
+
+// Footer that renders MUI's "start–end of total" label with prev/next arrows
+// and a rows-per-page selector, driven by cursor pagination. The arrows step
+// one page at a time (cursor pagination can't jump to an arbitrary page), so
+// we map MUI's page delta onto next()/prev() and disable each side using our
+// own canNext/canPrev rather than MUI's count-derived bounds.
+export default function PaginationFooter({
+  pagination,
+  rowsPerPageOptions = DEFAULT_OPTIONS,
+}: Props) {
+  const { page, pageSize, range, canPrev, canNext, next, prev, setPageSize, isLoading } =
+    pagination;
+
+  // While a fresh page is loading `range` is derived from an empty result, so
+  // its numbers are meaningless — show an ellipsis instead. `count` is clamped
+  // so `page` is never out of MUI's range (which would log a dev warning); the
+  // visible "of N" comes from `range.total`, not this value.
+  const count = Math.max(range.total, (page + 1) * pageSize);
+
+  return (
+    <TablePagination
+      component="div"
+      count={count}
+      page={page}
+      rowsPerPage={pageSize}
+      rowsPerPageOptions={rowsPerPageOptions}
+      labelDisplayedRows={() =>
+        isLoading
+          ? '…'
+          : range.total === 0
+            ? '0 of 0'
+            : `${range.start}–${range.end} of ${range.total}`
+      }
+      onPageChange={(_, newPage) => {
+        if (newPage > page) next();
+        else prev();
+      }}
+      onRowsPerPageChange={(e) => setPageSize(parseInt(e.target.value, 10))}
+      slotProps={{
+        actions: {
+          previousButton: { disabled: !canPrev },
+          nextButton: { disabled: !canNext },
+        },
+      }}
+    />
+  );
+}

--- a/web/components/ResourceListPage.tsx
+++ b/web/components/ResourceListPage.tsx
@@ -24,10 +24,10 @@ import {
 import { type ReactNode, useState } from 'react';
 import PageHeader from './PageHeader';
 import ConfirmDialog from './ConfirmDialog';
+import PaginationFooter from './PaginationFooter';
 import RowActionsMenu, { type RowAction } from './RowActionsMenu';
 import { api } from '@/lib/api-client';
-import { useApi } from '@/lib/swr';
-import type { ListResponse } from '@/lib/types';
+import { useCursorPagination } from '@/lib/pagination';
 
 export interface Column<T> {
   header: string;
@@ -84,15 +84,8 @@ export default function ResourceListPage<T>({
   const [deleting, setDeleting] = useState<T | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
 
-  const {
-    data,
-    error: fetchError,
-    isLoading,
-    isValidating,
-    mutate,
-  } = useApi<ListResponse<T>>([listPath, { limit: 200, ...query }]);
-
-  const items = data?.items ?? [];
+  const pagination = useCursorPagination<T>(listPath, { query });
+  const { items, isLoading, isValidating, error: fetchError, refresh } = pagination;
   const loading = isLoading;
   const error =
     actionError ??
@@ -104,7 +97,7 @@ export default function ResourceListPage<T>({
       await api.delete(itemPath(deleting));
       setDeleting(null);
       setActionError(null);
-      await mutate();
+      refresh();
     } catch (err) {
       setActionError(err instanceof Error ? err.message : 'Failed to delete');
     }
@@ -151,7 +144,7 @@ export default function ResourceListPage<T>({
         subtitle={subtitle}
         actions={
           <>
-            <IconButton color="primary" onClick={() => mutate()} disabled={isValidating}>
+            <IconButton color="primary" onClick={() => refresh()} disabled={isValidating}>
               <RefreshIcon />
             </IconButton>
             {renderCreate && (
@@ -216,12 +209,14 @@ export default function ResourceListPage<T>({
         </Table>
       </TableContainer>
 
+      <PaginationFooter pagination={pagination} />
+
       {renderCreate?.({
         open: createOpen,
         onClose: () => setCreateOpen(false),
         onSaved: () => {
           setCreateOpen(false);
-          void mutate();
+          refresh();
         },
       })}
       {editing &&
@@ -231,7 +226,7 @@ export default function ResourceListPage<T>({
           onClose: () => setEditing(null),
           onSaved: () => {
             setEditing(null);
-            void mutate();
+            refresh();
           },
         })}
       <ConfirmDialog

--- a/web/lib/pagination.test.ts
+++ b/web/lib/pagination.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { pageRange } from './pagination';
+
+describe('pageRange', () => {
+  it('computes the range and total on the first page', () => {
+    // 50 shown, 150 still to come → 200 total, showing 1–50.
+    expect(pageRange(0, 50, 50, 150)).toEqual({ start: 1, end: 50, total: 200 });
+  });
+
+  it('offsets the range on later pages', () => {
+    // Page 2 (0-based), 50 shown, 50 remaining → 200 total, showing 101–150.
+    expect(pageRange(2, 50, 50, 50)).toEqual({ start: 101, end: 150, total: 200 });
+  });
+
+  it('handles a short final page', () => {
+    // Last page with 30 items and nothing remaining.
+    expect(pageRange(3, 50, 30, 0)).toEqual({ start: 151, end: 180, total: 180 });
+  });
+
+  it('reports a zero range for an empty result', () => {
+    expect(pageRange(0, 50, 0, 0)).toEqual({ start: 0, end: 0, total: 0 });
+  });
+
+  it('treats a negative remaining count as zero', () => {
+    expect(pageRange(0, 50, 10, -1)).toEqual({ start: 1, end: 10, total: 10 });
+  });
+});

--- a/web/lib/pagination.ts
+++ b/web/lib/pagination.ts
@@ -1,0 +1,173 @@
+'use client';
+
+// Cursor pagination shared across list pages.
+//
+// The backend pages with a `continue` token (the _id of the last item on the
+// page) plus a `remainingItemCount` (how many matching docs come *after* the
+// current page). It does NOT return an absolute total, so we derive one:
+//
+//   total = (items on previous pages) + (items on this page) + remainingItemCount
+//
+// Previous pages are always full because the backend only hands back a usable
+// `continue` token / non-zero remaining when more docs exist, so we can treat
+// the items-before count as `page * pageSize`. That makes `total` exact on
+// every page, which is what lets the footer say "1–50 of 200".
+
+import { useCallback, useMemo, useState } from 'react';
+import { useApi, type SWRKey } from './swr';
+import type { ListResponse } from './types';
+
+type Query = Record<string, string | number | boolean | undefined | null>;
+
+export interface PageRange {
+  // 1-based index of the first item shown (0 when the page is empty).
+  start: number;
+  // 1-based index of the last item shown.
+  end: number;
+  // Exact count of all matching items across every page.
+  total: number;
+}
+
+// Pure range/total math, split out so it can be unit-tested without React.
+export function pageRange(
+  page: number,
+  pageSize: number,
+  itemCount: number,
+  remainingItemCount: number,
+): PageRange {
+  const offset = page * pageSize;
+  const remaining = Math.max(remainingItemCount, 0);
+  const total = offset + itemCount + remaining;
+  return {
+    start: itemCount === 0 ? 0 : offset + 1,
+    end: offset + itemCount,
+    total,
+  };
+}
+
+export interface CursorPagination<T> {
+  items: T[];
+  isLoading: boolean;
+  isValidating: boolean;
+  error: unknown;
+  page: number;
+  pageSize: number;
+  range: PageRange;
+  canPrev: boolean;
+  canNext: boolean;
+  next: () => void;
+  prev: () => void;
+  setPageSize: (size: number) => void;
+  /** Revalidate the current page (used by the Refresh button). */
+  refresh: () => void;
+  /** Revalidate the current page and reset to page 0 (used after mutations). */
+  reset: () => void;
+}
+
+export interface CursorPaginationOptions {
+  query?: Query;
+  initialPageSize?: number;
+  /** Disable fetching entirely (e.g. while a dependency isn't ready). */
+  enabled?: boolean;
+}
+
+const DEFAULT_PAGE_SIZE = 50;
+
+export function useCursorPagination<T>(
+  path: string,
+  options: CursorPaginationOptions = {},
+): CursorPagination<T> {
+  const { query, initialPageSize = DEFAULT_PAGE_SIZE, enabled = true } = options;
+
+  const [pageSize, setPageSizeState] = useState(initialPageSize);
+  // tokens[i] is the `continue` token used to fetch page i. tokens[0] is
+  // undefined (the first page has no cursor).
+  const [tokens, setTokens] = useState<(string | undefined)[]>([undefined]);
+  const [page, setPage] = useState(0);
+
+  // Serialised identity of everything that should send us back to page 0:
+  // the path, the caller's filters, and the page size (the total math assumes
+  // a consistent page size across the visited pages). When it changes we reset
+  // during render — React's "adjust state when a prop changes" pattern — rather
+  // than in an effect, so the new page-0 cursor is used on this same render.
+  const queryKey = JSON.stringify(query ?? {});
+  const resetKey = `${path}|${queryKey}|${pageSize}`;
+  const [prevResetKey, setPrevResetKey] = useState(resetKey);
+
+  let activeTokens = tokens;
+  let activePage = page;
+  if (resetKey !== prevResetKey) {
+    setPrevResetKey(resetKey);
+    setTokens([undefined]);
+    setPage(0);
+    activeTokens = [undefined];
+    activePage = 0;
+  }
+
+  const token = activeTokens[activePage];
+  const key: SWRKey | null = enabled
+    ? [path, { limit: pageSize, continue: token, ...query }]
+    : null;
+
+  // We deliberately do NOT keep the previous page's data while a new page
+  // loads. With cursor pagination `data` must always match the requested page:
+  // if it lagged, the "X–Y of N" range (derived from `activePage`) would not
+  // match the rows on screen, and Next would stay clickable on a stale cursor.
+  // While a fresh page loads `data` is undefined → empty items, remaining 0,
+  // canNext false — so the footer/table stay consistent (callers show a
+  // spinner on `isLoading`).
+  const { data, error, isLoading, isValidating, mutate } = useApi<ListResponse<T>>(key);
+
+  const items = useMemo(() => data?.items ?? [], [data]);
+  const remaining = data?.metadata?.remainingItemCount ?? 0;
+  const continueToken = data?.metadata?.continue || '';
+
+  const range = pageRange(activePage, pageSize, items.length, remaining);
+  const canPrev = activePage > 0 && !isLoading;
+  const canNext = remaining > 0 && continueToken !== '';
+
+  const next = useCallback(() => {
+    if (remaining <= 0 || continueToken === '') return;
+    setTokens((prev) => {
+      const copy = prev.slice(0, activePage + 1);
+      copy[activePage + 1] = continueToken;
+      return copy;
+    });
+    setPage((p) => p + 1);
+  }, [remaining, continueToken, activePage]);
+
+  const prev = useCallback(() => {
+    setPage((p) => Math.max(0, p - 1));
+  }, []);
+
+  const setPageSize = useCallback((size: number) => {
+    setPageSizeState(size);
+  }, []);
+
+  const refresh = useCallback(() => {
+    void mutate();
+  }, [mutate]);
+
+  const reset = useCallback(() => {
+    setTokens([undefined]);
+    setPage(0);
+    void mutate();
+  }, [mutate]);
+
+  return {
+    items,
+    isLoading,
+    isValidating,
+    error,
+    page: activePage,
+    pageSize,
+    range,
+    canPrev,
+    canNext,
+    next,
+    prev,
+    setPageSize,
+    refresh,
+    reset,
+  };
+}


### PR DESCRIPTION
## What

Adds real pagination with a total count to the web list views. Lists now show **"1–50 of 200"** with prev/next arrows and a rows-per-page selector, instead of either silently capping at 200 items or showing bare Prev/Next with no totals.

Originated from the request: *"agent랑 agentgroup 등등 list가 pagination 되게 — 단순 next/prev가 아니라 몇 개 중 몇 개인지."*

## How

The backend already pages with a `continue` token + `remainingItemCount` but doesn't return an absolute total. We derive an exact one:

```
total = page * pageSize  +  items on this page  +  remainingItemCount
```

Previous pages are always full whenever `remainingItemCount > 0` (the backend only yields a usable cursor when more docs exist), so `page * pageSize` is exact on every page — which is what lets the footer show a real total.

- **`web/lib/pagination.ts`** — `pageRange()` pure helper (unit-tested) + `useCursorPagination()` SWR hook. Tracks the continue-token stack and resets to page 0 when the path / filters / page size change (React's render-time "adjust state" pattern, not an effect).
- **`web/components/PaginationFooter.tsx`** — wraps MUI `TablePagination` (`component="div"`) to render `start–end of total` with prev/next + rows-per-page.
- Wired into the shared **`ResourceListPage`** (covers roles, rolebindings, certificates, users, agentpackages, agentremoteconfigs) and the custom **agents**, **agentgroups**, and **connections** pages.

`namespaces` (context-seeded, small) and `servers` (cluster members) are intentionally left unpaginated.

## Correctness note

Data is intentionally **not** kept across page changes: with cursor pagination `data` must always match the requested page, otherwise the `start–end of N` range (derived from the page index) would drift from the rows on screen and Next could fire on a stale cursor. While a fresh page loads, `data` is empty → `canNext` is false and the footer shows `…`; callers already render a spinner on `isLoading`. Backward/cached navigation is instant.

## Testing

- `tsc --noEmit` ✅
- `eslint` (all changed files) ✅
- `vitest run` — 7 files, 31 tests ✅ (includes 5 new `pageRange` cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)