### PR TITLE
feat(agent): delete disconnected agents (API, opampctl, web)

### DIFF
--- a/internal/adapter/in/http/v1/agent/controller.go
+++ b/internal/adapter/in/http/v1/agent/controller.go
@@ -2,12 +2,14 @@
 package agent
 
 import (
+	"errors"
 	"log/slog"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 
 	v1 "github.com/minuk-dev/opampcommander/api/v1"
+	applicationport "github.com/minuk-dev/opampcommander/internal/application/port"
 	"github.com/minuk-dev/opampcommander/internal/domain/model"
 	"github.com/minuk-dev/opampcommander/pkg/ginutil"
 )
@@ -59,6 +61,12 @@ func (c *Controller) RoutesInfo() gin.RoutesInfo {
 			Path:        "/api/v1/namespaces/:namespace/agents/:id",
 			Handler:     "http.v1.agent.Update",
 			HandlerFunc: c.Update,
+		},
+		{
+			Method:      http.MethodDelete,
+			Path:        "/api/v1/namespaces/:namespace/agents/:id",
+			Handler:     "http.v1.agent.Delete",
+			HandlerFunc: c.Delete,
 		},
 	}
 }
@@ -194,8 +202,7 @@ func (c *Controller) Get(ctx *gin.Context) {
 
 	agent, err := c.agentUsecase.GetAgent(ctx.Request.Context(), namespace, instanceUID)
 	if err != nil {
-		c.logger.Error("failed to get agent", "error", err.Error())
-		ginutil.HandleDomainError(ctx, err, "An error occurred while retrieving the agent.")
+		c.handleAgentError(ctx, err, "An error occurred while retrieving the agent.")
 
 		return
 	}
@@ -244,11 +251,68 @@ func (c *Controller) Update(ctx *gin.Context) {
 
 	updatedAgent, err := c.agentUsecase.UpdateAgent(ctx.Request.Context(), namespace, instanceUID, &req)
 	if err != nil {
-		c.logger.Error("failed to update agent", "error", err.Error())
-		ginutil.HandleDomainError(ctx, err, "An error occurred while updating the agent.")
+		c.handleAgentError(ctx, err, "An error occurred while updating the agent.")
 
 		return
 	}
 
 	ctx.JSON(http.StatusOK, updatedAgent)
+}
+
+// Delete permanently removes a disconnected agent.
+//
+// @Summary  Delete Agent
+// @Tags agent
+// @Description Permanently delete a disconnected agent by its instance UID in a namespace.
+// @Description Connected agents cannot be deleted and return 409 Conflict.
+// @Accept  json
+// @Produce  json
+// @Param  namespace path string true "Namespace"
+// @Param  id path string true "Instance UID of the agent"
+// @Success  204 "No Content"
+// @Failure  400 {object} ErrorModel
+// @Failure  404 {object} ErrorModel
+// @Failure  409 {object} ErrorModel
+// @Failure  500 {object} ErrorModel
+// @Router  /api/v1/namespaces/{namespace}/agents/{id} [delete].
+func (c *Controller) Delete(ctx *gin.Context) {
+	namespace, err := ginutil.ParseString(ctx, "namespace", true)
+	if err != nil {
+		ginutil.HandleValidationError(ctx, "namespace", ctx.Param("namespace"), err, true)
+
+		return
+	}
+
+	instanceUID, err := ginutil.ParseUUID(ctx, "id")
+	if err != nil {
+		ginutil.HandleValidationError(ctx, "id", ctx.Param("id"), err, true)
+
+		return
+	}
+
+	err = c.agentUsecase.DeleteAgent(ctx.Request.Context(), namespace, instanceUID)
+	if err != nil {
+		c.handleAgentError(ctx, err, "An error occurred while deleting the agent.")
+
+		return
+	}
+
+	ctx.Status(http.StatusNoContent)
+}
+
+// handleAgentError maps agent management errors to HTTP responses, centralising the
+// status mapping shared by Get/Update/Delete:
+//   - ErrAgentNamespaceMismatch -> 404 (the agent exists, but not in this namespace)
+//   - ErrAgentConnected          -> 409 (a connected agent cannot be deleted)
+//   - everything else            -> delegated to ginutil.HandleDomainError (404/500)
+func (c *Controller) handleAgentError(ctx *gin.Context, err error, fallbackMessage string) {
+	switch {
+	case errors.Is(err, applicationport.ErrAgentNamespaceMismatch):
+		ginutil.ResourceNotFoundError(ctx, "agent", ctx.Param("id"))
+	case errors.Is(err, applicationport.ErrAgentConnected):
+		ginutil.ConflictError(ctx, err, "The agent is still connected and cannot be deleted.")
+	default:
+		c.logger.Error(fallbackMessage, "error", err.Error())
+		ginutil.HandleDomainError(ctx, err, fallbackMessage)
+	}
 }

--- a/internal/adapter/in/http/v1/agent/controller_test.go
+++ b/internal/adapter/in/http/v1/agent/controller_test.go
@@ -15,6 +15,7 @@ import (
 	v1 "github.com/minuk-dev/opampcommander/api/v1"
 	"github.com/minuk-dev/opampcommander/internal/adapter/in/http/v1/agent"
 	"github.com/minuk-dev/opampcommander/internal/adapter/in/http/v1/agent/usecasemock"
+	applicationport "github.com/minuk-dev/opampcommander/internal/application/port"
 	"github.com/minuk-dev/opampcommander/internal/domain/port"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/module/helper"
 	"github.com/minuk-dev/opampcommander/pkg/testutil"
@@ -309,6 +310,143 @@ func TestAgentControllerGetAgent(t *testing.T) {
 		// then
 		router.ServeHTTP(recorder, req)
 		assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+	})
+}
+
+func TestAgentControllerDeleteAgent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("Delete Agent - happycase returns 204", func(t *testing.T) {
+		t.Parallel()
+
+		ctrlBase := testutil.NewBase(t).ForController()
+		agentUsecase := usecasemock.NewMockManageUsecase(t)
+		controller := agent.NewController(agentUsecase, ctrlBase.Logger)
+		ctrlBase.SetupRouter(controller)
+		router := ctrlBase.Router
+
+		// given
+		instanceUID := uuid.New()
+
+		agentUsecase.EXPECT().
+			DeleteAgent(mock.Anything, "default", mock.Anything).
+			Return(nil)
+		// when
+		recorder := httptest.NewRecorder()
+		req, err := http.NewRequestWithContext(
+			t.Context(), http.MethodDelete,
+			"/api/v1/namespaces/default/agents/"+instanceUID.String(), nil,
+		)
+		require.NoError(t, err)
+		// then
+		router.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusNoContent, recorder.Code)
+		assert.Empty(t, recorder.Body.String())
+	})
+
+	t.Run("Delete Agent - connected agent returns 409", func(t *testing.T) {
+		t.Parallel()
+
+		ctrlBase := testutil.NewBase(t).ForController()
+		agentUsecase := usecasemock.NewMockManageUsecase(t)
+		controller := agent.NewController(agentUsecase, ctrlBase.Logger)
+		ctrlBase.SetupRouter(controller)
+		router := ctrlBase.Router
+
+		// given
+		instanceUID := uuid.New()
+
+		agentUsecase.EXPECT().
+			DeleteAgent(mock.Anything, "default", mock.Anything).
+			Return(applicationport.ErrAgentConnected)
+		// when
+		recorder := httptest.NewRecorder()
+		req, err := http.NewRequestWithContext(
+			t.Context(), http.MethodDelete,
+			"/api/v1/namespaces/default/agents/"+instanceUID.String(), nil,
+		)
+		require.NoError(t, err)
+		// then
+		router.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusConflict, recorder.Code)
+
+		body := recorder.Body.String()
+		assert.Contains(t, body, "Conflict")
+	})
+
+	t.Run("Delete Agent - namespace mismatch returns 404", func(t *testing.T) {
+		t.Parallel()
+
+		ctrlBase := testutil.NewBase(t).ForController()
+		agentUsecase := usecasemock.NewMockManageUsecase(t)
+		controller := agent.NewController(agentUsecase, ctrlBase.Logger)
+		ctrlBase.SetupRouter(controller)
+		router := ctrlBase.Router
+
+		// given
+		instanceUID := uuid.New()
+
+		agentUsecase.EXPECT().
+			DeleteAgent(mock.Anything, "default", mock.Anything).
+			Return(applicationport.ErrAgentNamespaceMismatch)
+		// when
+		recorder := httptest.NewRecorder()
+		req, err := http.NewRequestWithContext(
+			t.Context(), http.MethodDelete,
+			"/api/v1/namespaces/default/agents/"+instanceUID.String(), nil,
+		)
+		require.NoError(t, err)
+		// then
+		router.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusNotFound, recorder.Code)
+	})
+
+	t.Run("Delete Agent - not found returns 404", func(t *testing.T) {
+		t.Parallel()
+
+		ctrlBase := testutil.NewBase(t).ForController()
+		agentUsecase := usecasemock.NewMockManageUsecase(t)
+		controller := agent.NewController(agentUsecase, ctrlBase.Logger)
+		ctrlBase.SetupRouter(controller)
+		router := ctrlBase.Router
+
+		// given
+		instanceUID := uuid.New()
+
+		agentUsecase.EXPECT().
+			DeleteAgent(mock.Anything, "default", mock.Anything).
+			Return(port.ErrResourceNotExist)
+		// when
+		recorder := httptest.NewRecorder()
+		req, err := http.NewRequestWithContext(
+			t.Context(), http.MethodDelete,
+			"/api/v1/namespaces/default/agents/"+instanceUID.String(), nil,
+		)
+		require.NoError(t, err)
+		// then
+		router.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusNotFound, recorder.Code)
+	})
+
+	t.Run("Delete Agent - invalid uuid returns 400", func(t *testing.T) {
+		t.Parallel()
+
+		ctrlBase := testutil.NewBase(t).ForController()
+		agentUsecase := usecasemock.NewMockManageUsecase(t)
+		controller := agent.NewController(agentUsecase, ctrlBase.Logger)
+		ctrlBase.SetupRouter(controller)
+		router := ctrlBase.Router
+
+		// when
+		recorder := httptest.NewRecorder()
+		req, err := http.NewRequestWithContext(
+			t.Context(), http.MethodDelete,
+			"/api/v1/namespaces/default/agents/not-a-uuid", nil,
+		)
+		require.NoError(t, err)
+		// then
+		router.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
 	})
 }
 

--- a/internal/adapter/in/http/v1/agent/usecasemock/mocks.go
+++ b/internal/adapter/in/http/v1/agent/usecasemock/mocks.go
@@ -40,6 +40,69 @@ func (_m *MockManageUsecase) EXPECT() *MockManageUsecase_Expecter {
 	return &MockManageUsecase_Expecter{mock: &_m.Mock}
 }
 
+// DeleteAgent provides a mock function for the type MockManageUsecase
+func (_mock *MockManageUsecase) DeleteAgent(ctx context.Context, namespace string, instanceUID uuid.UUID) error {
+	ret := _mock.Called(ctx, namespace, instanceUID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteAgent")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, uuid.UUID) error); ok {
+		r0 = returnFunc(ctx, namespace, instanceUID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockManageUsecase_DeleteAgent_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DeleteAgent'
+type MockManageUsecase_DeleteAgent_Call struct {
+	*mock.Call
+}
+
+// DeleteAgent is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespace string
+//   - instanceUID uuid.UUID
+func (_e *MockManageUsecase_Expecter) DeleteAgent(ctx interface{}, namespace interface{}, instanceUID interface{}) *MockManageUsecase_DeleteAgent_Call {
+	return &MockManageUsecase_DeleteAgent_Call{Call: _e.mock.On("DeleteAgent", ctx, namespace, instanceUID)}
+}
+
+func (_c *MockManageUsecase_DeleteAgent_Call) Run(run func(ctx context.Context, namespace string, instanceUID uuid.UUID)) *MockManageUsecase_DeleteAgent_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 uuid.UUID
+		if args[2] != nil {
+			arg2 = args[2].(uuid.UUID)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockManageUsecase_DeleteAgent_Call) Return(err error) *MockManageUsecase_DeleteAgent_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockManageUsecase_DeleteAgent_Call) RunAndReturn(run func(ctx context.Context, namespace string, instanceUID uuid.UUID) error) *MockManageUsecase_DeleteAgent_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetAgent provides a mock function for the type MockManageUsecase
 func (_mock *MockManageUsecase) GetAgent(ctx context.Context, namespace string, instanceUID uuid.UUID) (*v1.Agent, error) {
 	ret := _mock.Called(ctx, namespace, instanceUID)

--- a/internal/adapter/out/persistence/mongodb/agent.go
+++ b/internal/adapter/out/persistence/mongodb/agent.go
@@ -115,6 +115,16 @@ func (a *AgentRepository) PutAgent(ctx context.Context, agent *agentmodel.Agent)
 	return nil
 }
 
+// DeleteAgent implements agentport.AgentPersistencePort.
+func (a *AgentRepository) DeleteAgent(ctx context.Context, instanceUID uuid.UUID) error {
+	err := a.common.deleteOne(ctx, instanceUID)
+	if err != nil {
+		return fmt.Errorf("failed to delete agent from persistence: %w", err)
+	}
+
+	return nil
+}
+
 // ListAgentsBySelector implements agentport.AgentPersistencePort.
 //
 //nolint:funlen // Reason: unavoidable.

--- a/internal/adapter/out/persistence/mongodb/agent_test.go
+++ b/internal/adapter/out/persistence/mongodb/agent_test.go
@@ -299,6 +299,77 @@ func TestAgentMongoAdapter_PutAgent(t *testing.T) {
 	})
 }
 
+func TestAgentMongoAdapter_DeleteAgent(t *testing.T) {
+	testcontainers.SkipIfProviderIsNotHealthy(t)
+	t.Parallel()
+	base := testutil.NewBase(t)
+
+	t.Run("deletes an existing agent", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		mongoDBContainer, err := mongoTestContainer.Run(
+			ctx,
+			testMongoDBImage,
+		)
+		require.NoError(t, err)
+
+		mongoDBURI, err := mongoDBContainer.ConnectionString(ctx)
+		require.NoError(t, err)
+
+		client, err := mongo.Connect(options.Client().ApplyURI(mongoDBURI))
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err := client.Disconnect(ctx)
+			require.NoError(t, err)
+		})
+
+		database := client.Database("testdb")
+		agentRepository := mongodb.NewAgentRepository(database, base.Logger)
+
+		instanceUID := uuid.New()
+		agent := agentmodel.NewAgent(instanceUID)
+		require.NoError(t, agentRepository.PutAgent(ctx, agent))
+
+		// when
+		err = agentRepository.DeleteAgent(ctx, instanceUID)
+
+		// then
+		require.NoError(t, err)
+
+		_, err = agentRepository.GetAgent(ctx, instanceUID)
+		require.ErrorIs(t, err, port.ErrResourceNotExist)
+	})
+
+	t.Run("returns ErrResourceNotExist for a missing agent", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		mongoDBContainer, err := mongoTestContainer.Run(
+			ctx,
+			testMongoDBImage,
+		)
+		require.NoError(t, err)
+
+		mongoDBURI, err := mongoDBContainer.ConnectionString(ctx)
+		require.NoError(t, err)
+
+		client, err := mongo.Connect(options.Client().ApplyURI(mongoDBURI))
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			err := client.Disconnect(ctx)
+			require.NoError(t, err)
+		})
+
+		database := client.Database("testdb")
+		agentRepository := mongodb.NewAgentRepository(database, base.Logger)
+
+		// when
+		err = agentRepository.DeleteAgent(ctx, uuid.New())
+
+		// then
+		require.ErrorIs(t, err, port.ErrResourceNotExist)
+	})
+}
+
 func TestAgentMongoAdapter_ConfigShouldBeSameAfterSaveAndLoad(t *testing.T) {
 	testcontainers.SkipIfProviderIsNotHealthy(t)
 	t.Parallel()

--- a/internal/adapter/out/persistence/mongodb/common.go
+++ b/internal/adapter/out/persistence/mongodb/common.go
@@ -203,6 +203,28 @@ func (a *commonEntityAdapter[Entity, KeyType]) put(ctx context.Context, entity *
 	return nil
 }
 
+// deleteOne permanently removes the document identified by key. It returns
+// port.ErrResourceNotExist when no matching document is found.
+//
+// WARNING: this is a HARD delete — it issues a real DeleteOne and does NOT apply
+// the soft-delete filter (excludeDeletedFilter) that get/list use. Most resources
+// in this codebase soft-delete by stamping metadata.deletedAt and rely on the
+// tombstone surviving (audit, IncludeDeleted reads, login flow). Only use this for
+// resource types that have no deletedAt field / no soft-delete semantics (today:
+// agents). Wiring it for a soft-deleted resource will silently purge tombstones.
+func (a *commonEntityAdapter[Entity, KeyType]) deleteOne(ctx context.Context, key KeyType) error {
+	result, err := a.collection.DeleteOne(ctx, a.filterByKey(key))
+	if err != nil {
+		return fmt.Errorf("failed to delete resource from mongodb: %w", err)
+	}
+
+	if result.DeletedCount == 0 {
+		return port.ErrResourceNotExist
+	}
+
+	return nil
+}
+
 func (a *commonEntityAdapter[Entity, KeyType]) listWithContinueTokenAndLimit(
 	ctx context.Context,
 	continueTokenObjectID bson.ObjectID,

--- a/internal/application/port/in.go
+++ b/internal/application/port/in.go
@@ -3,6 +3,7 @@ package port
 
 import (
 	"context"
+	"errors"
 
 	"github.com/google/uuid"
 	"github.com/open-telemetry/opamp-go/protobufs"
@@ -10,8 +11,19 @@ import (
 
 	v1 "github.com/minuk-dev/opampcommander/api/v1"
 	agentmodel "github.com/minuk-dev/opampcommander/internal/domain/agent/model"
+	agentport "github.com/minuk-dev/opampcommander/internal/domain/agent/port"
 	"github.com/minuk-dev/opampcommander/internal/domain/model"
 )
+
+// ErrAgentConnected is returned when attempting to delete an agent that is still connected.
+// Only disconnected agents can be deleted. It aliases the domain sentinel (the guard is
+// enforced in the domain layer) so the HTTP layer can match it without importing the domain.
+var ErrAgentConnected = agentport.ErrAgentConnected
+
+// ErrAgentNamespaceMismatch is returned when an agent exists but does not belong to the
+// requested namespace. From that namespace's perspective the agent does not exist, so
+// callers should map this to a 404.
+var ErrAgentNamespaceMismatch = errors.New("agent does not belong to the specified namespace")
 
 // OpAMPUsecase is a use case that handles OpAMP protocol operations.
 // Please see [github.com/open-telemetry/opamp-go/server/types/ConnectionCallbacks].
@@ -63,6 +75,7 @@ type AgentManageUsecase interface {
 		options *model.ListOptions) (*v1.ListResponse[v1.Agent], error)
 	UpdateAgent(ctx context.Context, namespace string, instanceUID uuid.UUID,
 		agent *v1.Agent) (*v1.Agent, error)
+	DeleteAgent(ctx context.Context, namespace string, instanceUID uuid.UUID) error
 }
 
 // AgentGroupManageUsecase is a use case that handles agent group management operations.

--- a/internal/application/service/agent/agent.go
+++ b/internal/application/service/agent/agent.go
@@ -23,7 +23,9 @@ var (
 	// ErrRestartCapabilityNotSupported is returned when agent doesn't support restart capability.
 	ErrRestartCapabilityNotSupported = errors.New("agent does not support restart capability")
 	// ErrAgentNamespaceMismatch is returned when the agent does not belong to the specified namespace.
-	ErrAgentNamespaceMismatch = errors.New("agent does not belong to the specified namespace")
+	// It aliases the application port sentinel so the HTTP layer can map it to a 404 while existing
+	// references to this package-level name keep working.
+	ErrAgentNamespaceMismatch = applicationport.ErrAgentNamespaceMismatch
 )
 
 var _ applicationport.AgentManageUsecase = (*Service)(nil)
@@ -37,7 +39,6 @@ type Service struct {
 	// mapper
 	mapper *helper.Mapper
 	logger *slog.Logger
-	clock  clock.Clock
 }
 
 // New creates a new instance of the Service struct.
@@ -54,7 +55,6 @@ func New(
 
 		mapper: helper.NewMapper(realClock, agentmodel.DefaultConnectionStaleness),
 		logger: logger,
-		clock:  realClock,
 	}
 }
 
@@ -64,13 +64,9 @@ func (s *Service) GetAgent(
 	namespace string,
 	instanceUID uuid.UUID,
 ) (*v1.Agent, error) {
-	agent, err := s.agentUsecase.GetAgent(ctx, instanceUID)
+	agent, err := s.getAgentInNamespace(ctx, namespace, instanceUID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get agent: %w", err)
-	}
-
-	if agent.Metadata.Namespace != namespace {
-		return nil, fmt.Errorf("failed to get agent: %w", ErrAgentNamespaceMismatch)
+		return nil, err
 	}
 
 	return s.mapper.MapAgentToAPI(agent), nil
@@ -125,6 +121,30 @@ func (s *Service) SearchAgents(
 	}, nil
 }
 
+// DeleteAgent implements [port.AgentManageUsecase].
+//
+// Only disconnected agents may be deleted. The connection guard is enforced by the
+// domain DeleteAgent (against a fresh read), so a still-connected agent is rejected
+// with [applicationport.ErrAgentConnected]; this method just scopes the delete to the
+// requested namespace.
+func (s *Service) DeleteAgent(
+	ctx context.Context,
+	namespace string,
+	instanceUID uuid.UUID,
+) error {
+	_, err := s.getAgentInNamespace(ctx, namespace, instanceUID)
+	if err != nil {
+		return err
+	}
+
+	err = s.agentUsecase.DeleteAgent(ctx, instanceUID)
+	if err != nil {
+		return fmt.Errorf("failed to delete agent: %w", err)
+	}
+
+	return nil
+}
+
 // UpdateAgent implements [port.AgentManageUsecase].
 func (s *Service) UpdateAgent(
 	ctx context.Context,
@@ -132,13 +152,9 @@ func (s *Service) UpdateAgent(
 	instanceUID uuid.UUID,
 	api *v1.Agent,
 ) (*v1.Agent, error) {
-	existing, err := s.agentUsecase.GetAgent(ctx, instanceUID)
+	existing, err := s.getAgentInNamespace(ctx, namespace, instanceUID)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get agent: %w", err)
-	}
-
-	if existing.Metadata.Namespace != namespace {
-		return nil, fmt.Errorf("failed to update agent: %w", ErrAgentNamespaceMismatch)
+		return nil, err
 	}
 
 	agent := s.mapper.MapAPIToAgent(api)
@@ -172,4 +188,25 @@ func (s *Service) UpdateAgent(
 	}
 
 	return s.mapper.MapAgentToAPI(existing), nil
+}
+
+// getAgentInNamespace fetches an agent by UID and verifies it belongs to the given
+// namespace. It returns ErrAgentNamespaceMismatch when the agent exists but in a
+// different namespace, so the HTTP layer can map that to a 404. Centralising this
+// keeps the namespace-scoping invariant in one place for Get/Update/Delete.
+func (s *Service) getAgentInNamespace(
+	ctx context.Context,
+	namespace string,
+	instanceUID uuid.UUID,
+) (*agentmodel.Agent, error) {
+	agent, err := s.agentUsecase.GetAgent(ctx, instanceUID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get agent: %w", err)
+	}
+
+	if agent.Metadata.Namespace != namespace {
+		return nil, fmt.Errorf("failed to get agent: %w", ErrAgentNamespaceMismatch)
+	}
+
+	return agent, nil
 }

--- a/internal/application/service/agent/agent_test.go
+++ b/internal/application/service/agent/agent_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/mock"
 	"github.com/stretchr/testify/require"
 
+	applicationport "github.com/minuk-dev/opampcommander/internal/application/port"
 	"github.com/minuk-dev/opampcommander/internal/application/service/agent"
 	agentmodel "github.com/minuk-dev/opampcommander/internal/domain/agent/model"
 	"github.com/minuk-dev/opampcommander/internal/domain/model"
@@ -70,6 +71,12 @@ func (m *MockAgentUsecase) ListAgentsBySelector(
 
 func (m *MockAgentUsecase) SaveAgent(ctx context.Context, agnt *agentmodel.Agent) error {
 	args := m.Called(ctx, agnt)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+func (m *MockAgentUsecase) DeleteAgent(ctx context.Context, instanceUID uuid.UUID) error {
+	args := m.Called(ctx, instanceUID)
 
 	return args.Error(0) //nolint:wrapcheck // mock error
 }
@@ -204,6 +211,104 @@ func TestService_SearchAgents(t *testing.T) {
 		assert.Len(t, response.Items, 2)
 		assert.Equal(t, "next-token", response.Metadata.Continue)
 		assert.Equal(t, int64(10), response.Metadata.RemainingItemCount)
+		mockAgentUsecase.AssertExpectations(t)
+	})
+}
+
+func TestService_DeleteAgent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("deletes a disconnected agent", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		ctx := t.Context()
+		mockAgentUsecase := new(MockAgentUsecase)
+		mockNotificationUsecase := new(MockAgentNotificationUsecase)
+		service := agent.New(mockAgentUsecase, mockNotificationUsecase, slog.Default())
+
+		instanceUID := uuid.New()
+		domainAgent := agentmodel.NewAgent(instanceUID) // Status.Connected defaults to false
+
+		mockAgentUsecase.On("GetAgent", ctx, instanceUID).Return(domainAgent, nil)
+		mockAgentUsecase.On("DeleteAgent", ctx, instanceUID).Return(nil)
+
+		// when
+		err := service.DeleteAgent(ctx, "default", instanceUID)
+
+		// then
+		require.NoError(t, err)
+		mockAgentUsecase.AssertExpectations(t)
+	})
+
+	t.Run("propagates the domain connection guard (ErrAgentConnected)", func(t *testing.T) {
+		t.Parallel()
+
+		// given: the connection guard now lives in the domain DeleteAgent, so the
+		// application service just surfaces ErrAgentConnected to the caller.
+		ctx := t.Context()
+		mockAgentUsecase := new(MockAgentUsecase)
+		mockNotificationUsecase := new(MockAgentNotificationUsecase)
+		service := agent.New(mockAgentUsecase, mockNotificationUsecase, slog.Default())
+
+		instanceUID := uuid.New()
+		domainAgent := agentmodel.NewAgent(instanceUID) // namespace "default"
+
+		mockAgentUsecase.On("GetAgent", ctx, instanceUID).Return(domainAgent, nil)
+		mockAgentUsecase.On("DeleteAgent", ctx, instanceUID).Return(applicationport.ErrAgentConnected)
+
+		// when
+		err := service.DeleteAgent(ctx, "default", instanceUID)
+
+		// then
+		require.ErrorIs(t, err, applicationport.ErrAgentConnected)
+		mockAgentUsecase.AssertExpectations(t)
+	})
+
+	t.Run("rejects deletion when namespace mismatches", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		ctx := t.Context()
+		mockAgentUsecase := new(MockAgentUsecase)
+		mockNotificationUsecase := new(MockAgentNotificationUsecase)
+		service := agent.New(mockAgentUsecase, mockNotificationUsecase, slog.Default())
+
+		instanceUID := uuid.New()
+		domainAgent := agentmodel.NewAgent(instanceUID) // namespace defaults to "default"
+
+		mockAgentUsecase.On("GetAgent", ctx, instanceUID).Return(domainAgent, nil)
+
+		// when
+		err := service.DeleteAgent(ctx, "other", instanceUID)
+
+		// then
+		require.ErrorIs(t, err, agent.ErrAgentNamespaceMismatch)
+		mockAgentUsecase.AssertNotCalled(t, "DeleteAgent", mock.Anything, mock.Anything)
+		mockAgentUsecase.AssertExpectations(t)
+	})
+
+	t.Run("returns error on usecase failure", func(t *testing.T) {
+		t.Parallel()
+
+		// given
+		ctx := t.Context()
+		mockAgentUsecase := new(MockAgentUsecase)
+		mockNotificationUsecase := new(MockAgentNotificationUsecase)
+		service := agent.New(mockAgentUsecase, mockNotificationUsecase, slog.Default())
+
+		instanceUID := uuid.New()
+		domainAgent := agentmodel.NewAgent(instanceUID)
+
+		mockAgentUsecase.On("GetAgent", ctx, instanceUID).Return(domainAgent, nil)
+		mockAgentUsecase.On("DeleteAgent", ctx, instanceUID).Return(errMockError)
+
+		// when
+		err := service.DeleteAgent(ctx, "default", instanceUID)
+
+		// then
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to delete agent")
 		mockAgentUsecase.AssertExpectations(t)
 	})
 }

--- a/internal/domain/agent/port/in.go
+++ b/internal/domain/agent/port/in.go
@@ -18,6 +18,10 @@ var (
 	ErrConnectionAlreadyExists = errors.New("connection already exists")
 	// ErrConnectionNotFound is an error that indicates that the connection was not found.
 	ErrConnectionNotFound = errors.New("connection not found")
+	// ErrAgentConnected indicates that a delete was attempted on a still-connected agent.
+	// The connection guard is enforced here in the domain so it cannot be bypassed by
+	// callers that hold an AgentUsecase directly.
+	ErrAgentConnected = errors.New("agent is still connected; only disconnected agents can be deleted")
 )
 
 // AgentUsecase is an interface that defines the methods for agent use cases.
@@ -34,6 +38,10 @@ type AgentUsecase interface {
 	) (*model.ListResponse[*agentmodel.Agent], error)
 	// SaveAgent saves the agent.
 	SaveAgent(ctx context.Context, agent *agentmodel.Agent) error
+	// DeleteAgent permanently (hard) removes a disconnected agent by its instance UID.
+	// It enforces the "only disconnected agents may be deleted" policy and returns
+	// ErrAgentConnected for a still-connected agent, so the guard cannot be bypassed.
+	DeleteAgent(ctx context.Context, instanceUID uuid.UUID) error
 	// ListAgents lists agents filtered by namespace.
 	ListAgents(ctx context.Context, namespace string,
 		options *model.ListOptions) (*model.ListResponse[*agentmodel.Agent], error)

--- a/internal/domain/agent/port/out.go
+++ b/internal/domain/agent/port/out.go
@@ -19,6 +19,8 @@ type AgentPersistencePort interface {
 	GetAgent(ctx context.Context, instanceUID uuid.UUID) (*agentmodel.Agent, error)
 	// PutAgent saves or updates an agent.
 	PutAgent(ctx context.Context, agent *agentmodel.Agent) error
+	// DeleteAgent permanently removes an agent by its instance UID.
+	DeleteAgent(ctx context.Context, instanceUID uuid.UUID) error
 	// ListAgents retrieves a list of agents filtered by namespace with pagination options.
 	ListAgents(ctx context.Context, namespace string,
 		options *model.ListOptions) (*model.ListResponse[*agentmodel.Agent], error)

--- a/internal/domain/agent/service/agent.go
+++ b/internal/domain/agent/service/agent.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/jellydator/ttlcache/v3"
+	"k8s.io/utils/clock"
 
 	agentmodel "github.com/minuk-dev/opampcommander/internal/domain/agent/model"
 	agentport "github.com/minuk-dev/opampcommander/internal/domain/agent/port"
@@ -38,6 +39,8 @@ type AgentService struct {
 	logger               *slog.Logger
 	agentCache           *ttlcache.Cache[uuid.UUID, *agentmodel.Agent]
 	cacheEnabled         bool
+	// clock is consulted only for the delete connection-guard (staleness evaluation).
+	clock clock.PassiveClock
 }
 
 // NewAgentService creates a new instance of AgentService with default cache configuration.
@@ -66,6 +69,7 @@ func NewAgentServiceWithConfig(
 			logger:               logger,
 			agentCache:           nil,
 			cacheEnabled:         false,
+			clock:                clock.RealClock{},
 		}
 	}
 
@@ -94,6 +98,7 @@ func NewAgentServiceWithConfig(
 		logger:               logger,
 		agentCache:           agentCache,
 		cacheEnabled:         true,
+		clock:                clock.RealClock{},
 	}
 }
 
@@ -168,6 +173,35 @@ func (s *AgentService) SaveAgent(ctx context.Context, agent *agentmodel.Agent) e
 	if s.cacheEnabled {
 		s.agentCache.Set(agent.Metadata.InstanceUID, agent.Clone(), ttlcache.DefaultTTL)
 	}
+
+	return nil
+}
+
+// DeleteAgent permanently (hard) removes a disconnected agent by its instance UID
+// and invalidates the cache.
+//
+// The "only disconnected agents may be deleted" policy is enforced here so it
+// cannot be bypassed by callers that hold an AgentUsecase directly. The agent is
+// read fresh from persistence (not the cache) so the decision reflects the agent's
+// real current state — important right after a disconnect, where another server's
+// write may not be visible in this process's cache yet. A still-connected agent is
+// rejected with [agentport.ErrAgentConnected].
+func (s *AgentService) DeleteAgent(ctx context.Context, instanceUID uuid.UUID) error {
+	agent, err := s.agentPersistencePort.GetAgent(ctx, instanceUID)
+	if err != nil {
+		return fmt.Errorf("failed to get agent for deletion: %w", err)
+	}
+
+	if agent.IsConnectedAt(s.clock.Now(), agentmodel.DefaultConnectionStaleness) {
+		return fmt.Errorf("failed to delete agent: %w", agentport.ErrAgentConnected)
+	}
+
+	err = s.agentPersistencePort.DeleteAgent(ctx, instanceUID)
+	if err != nil {
+		return fmt.Errorf("failed to delete agent from persistence: %w", err)
+	}
+
+	s.InvalidateCache(instanceUID)
 
 	return nil
 }

--- a/internal/domain/agent/service/agent_test.go
+++ b/internal/domain/agent/service/agent_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -14,6 +15,7 @@ import (
 	agentmodel "github.com/minuk-dev/opampcommander/internal/domain/agent/model"
 	"github.com/minuk-dev/opampcommander/internal/domain/agent/model/agent"
 	"github.com/minuk-dev/opampcommander/internal/domain/agent/model/serverevent"
+	agentport "github.com/minuk-dev/opampcommander/internal/domain/agent/port"
 	agentservice "github.com/minuk-dev/opampcommander/internal/domain/agent/service"
 	"github.com/minuk-dev/opampcommander/internal/domain/model"
 )
@@ -43,6 +45,12 @@ func (m *MockAgentPersistencePort) GetAgent(ctx context.Context, instanceUID uui
 
 func (m *MockAgentPersistencePort) PutAgent(ctx context.Context, agnt *agentmodel.Agent) error {
 	args := m.Called(ctx, agnt)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+func (m *MockAgentPersistencePort) DeleteAgent(ctx context.Context, instanceUID uuid.UUID) error {
+	args := m.Called(ctx, instanceUID)
 
 	return args.Error(0) //nolint:wrapcheck // mock error
 }
@@ -674,6 +682,82 @@ func TestAgentService_InvalidateCache(t *testing.T) {
 
 	mockPersistence.AssertExpectations(t)
 	mockPersistence.AssertNumberOfCalls(t, "GetAgent", 2)
+}
+
+func TestAgentService_DeleteAgent_InvalidatesCache(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	instanceUID := uuid.New()
+
+	mockAgent := agentmodel.NewAgent(instanceUID)
+
+	mockPersistence := new(MockAgentPersistencePort)
+	mockPersistence.On("PutAgent", ctx, mockAgent).Return(nil)
+	mockPersistence.On("DeleteAgent", ctx, instanceUID).Return(nil)
+	// DeleteAgent reads fresh for the connection guard (call #1), and the post-delete
+	// GetAgent misses the (invalidated) cache and hits persistence again (call #2).
+	mockPersistence.On("GetAgent", ctx, instanceUID).Return(mockAgent, nil).Times(2)
+
+	svc := agentservice.NewAgentService(mockPersistence, slog.Default())
+
+	// Prime the cache.
+	err := svc.SaveAgent(ctx, mockAgent)
+	require.NoError(t, err)
+
+	// Delete should remove from persistence and invalidate the cache.
+	err = svc.DeleteAgent(ctx, instanceUID)
+	require.NoError(t, err)
+
+	// Subsequent get falls through to persistence.
+	_, err = svc.GetAgent(ctx, instanceUID)
+	require.NoError(t, err)
+
+	mockPersistence.AssertExpectations(t)
+	mockPersistence.AssertNumberOfCalls(t, "GetAgent", 2)
+}
+
+func TestAgentService_DeleteAgent_RejectsConnected(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	instanceUID := uuid.New()
+
+	connectedAgent := agentmodel.NewAgent(instanceUID)
+	connectedAgent.Status.Connected = true
+	connectedAgent.Status.LastReportedAt = time.Now() // recent heartbeat => connected
+
+	mockPersistence := new(MockAgentPersistencePort)
+	mockPersistence.On("GetAgent", ctx, instanceUID).Return(connectedAgent, nil)
+
+	svc := agentservice.NewAgentService(mockPersistence, slog.Default())
+
+	err := svc.DeleteAgent(ctx, instanceUID)
+
+	require.ErrorIs(t, err, agentport.ErrAgentConnected)
+	// A connected agent must never be removed from persistence.
+	mockPersistence.AssertNotCalled(t, "DeleteAgent", mock.Anything, mock.Anything)
+	mockPersistence.AssertExpectations(t)
+}
+
+func TestAgentService_DeleteAgent_PersistenceError(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	instanceUID := uuid.New()
+
+	mockAgent := agentmodel.NewAgent(instanceUID) // disconnected => passes the guard
+
+	mockPersistence := new(MockAgentPersistencePort)
+	mockPersistence.On("GetAgent", ctx, instanceUID).Return(mockAgent, nil)
+	mockPersistence.On("DeleteAgent", ctx, instanceUID).Return(errDatabaseConnection)
+
+	svc := agentservice.NewAgentService(mockPersistence, slog.Default())
+
+	err := svc.DeleteAgent(ctx, instanceUID)
+
+	require.Error(t, err)
+	mockPersistence.AssertExpectations(t)
 }
 
 func TestAgentService_Shutdown(t *testing.T) {

--- a/internal/domain/agent/service/agentgroup_internal_test.go
+++ b/internal/domain/agent/service/agentgroup_internal_test.go
@@ -136,6 +136,12 @@ func (m *mockAgentUsecase) SaveAgent(ctx context.Context, a *agentmodel.Agent) e
 	return args.Error(0) //nolint:wrapcheck
 }
 
+func (m *mockAgentUsecase) DeleteAgent(ctx context.Context, instanceUID uuid.UUID) error {
+	args := m.Called(ctx, instanceUID)
+
+	return args.Error(0) //nolint:wrapcheck
+}
+
 func (m *mockAgentUsecase) ListAgents(
 	ctx context.Context,
 	namespace string,

--- a/internal/domain/agent/service/agentgroup_test.go
+++ b/internal/domain/agent/service/agentgroup_test.go
@@ -145,6 +145,12 @@ func (m *MockAgentUsecaseForGroup) SaveAgent(ctx context.Context, agnt *agentmod
 	return args.Error(0) //nolint:wrapcheck // mock error
 }
 
+func (m *MockAgentUsecaseForGroup) DeleteAgent(ctx context.Context, instanceUID uuid.UUID) error {
+	args := m.Called(ctx, instanceUID)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
 func (m *MockAgentUsecaseForGroup) ListAgents(
 	ctx context.Context,
 	namespace string,

--- a/internal/domain/agent/service/server_test.go
+++ b/internal/domain/agent/service/server_test.go
@@ -294,6 +294,12 @@ func (m *MockAgentUsecase) SaveAgent(ctx context.Context, agent *agentmodel.Agen
 	return args.Error(0) //nolint:wrapcheck // mock error
 }
 
+func (m *MockAgentUsecase) DeleteAgent(ctx context.Context, instanceUID uuid.UUID) error {
+	args := m.Called(ctx, instanceUID)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
 func (m *MockAgentUsecase) ListAgents(
 	ctx context.Context,
 	namespace string,

--- a/pkg/apiserver/docs/docs.go
+++ b/pkg/apiserver/docs/docs.go
@@ -1088,6 +1088,64 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "delete": {
+                "description": "Permanently delete a disconnected agent by its instance UID in a namespace.\nConnected agents cannot be deleted and return 409 Conflict.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "agent"
+                ],
+                "summary": "Delete Agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Namespace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Instance UID of the agent",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorModel"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorModel"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorModel"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorModel"
+                        }
+                    }
+                }
             }
         },
         "/api/v1/namespaces/{namespace}/certificates": {

--- a/pkg/apiserver/docs/swagger.json
+++ b/pkg/apiserver/docs/swagger.json
@@ -1080,6 +1080,64 @@
                         }
                     }
                 }
+            },
+            "delete": {
+                "description": "Permanently delete a disconnected agent by its instance UID in a namespace.\nConnected agents cannot be deleted and return 409 Conflict.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "agent"
+                ],
+                "summary": "Delete Agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Namespace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Instance UID of the agent",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorModel"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorModel"
+                        }
+                    },
+                    "409": {
+                        "description": "Conflict",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorModel"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorModel"
+                        }
+                    }
+                }
             }
         },
         "/api/v1/namespaces/{namespace}/certificates": {

--- a/pkg/apiserver/docs/swagger.yaml
+++ b/pkg/apiserver/docs/swagger.yaml
@@ -1741,6 +1741,47 @@ paths:
       tags:
       - agent
   /api/v1/namespaces/{namespace}/agents/{id}:
+    delete:
+      consumes:
+      - application/json
+      description: |-
+        Permanently delete a disconnected agent by its instance UID in a namespace.
+        Connected agents cannot be deleted and return 409 Conflict.
+      parameters:
+      - description: Namespace
+        in: path
+        name: namespace
+        required: true
+        type: string
+      - description: Instance UID of the agent
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/ErrorModel'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/ErrorModel'
+        "409":
+          description: Conflict
+          schema:
+            $ref: '#/definitions/ErrorModel'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/ErrorModel'
+      summary: Delete Agent
+      tags:
+      - agent
     get:
       consumes:
       - application/json

--- a/pkg/client/agent.go
+++ b/pkg/client/agent.go
@@ -10,15 +10,22 @@ import (
 	v1 "github.com/minuk-dev/opampcommander/api/v1"
 )
 
+// agentByIDURL is the single source of truth for the per-agent path. The
+// Get/Update/Delete URL constants below alias it so a route rename only happens
+// in one place, while the exported names stay stable for client consumers.
+const agentByIDURL = "/api/v1/namespaces/{namespace}/agents/{id}"
+
 const (
 	// ListAgentURL is the path to list all agents in a namespace.
 	ListAgentURL = "/api/v1/namespaces/{namespace}/agents"
 	// SearchAgentURL is the path to search agents in a namespace.
 	SearchAgentURL = "/api/v1/namespaces/{namespace}/agents/search"
 	// GetAgentURL is the path to get an agent by ID in a namespace.
-	GetAgentURL = "/api/v1/namespaces/{namespace}/agents/{id}"
+	GetAgentURL = agentByIDURL
 	// UpdateAgentURL is the path to update an agent in a namespace.
-	UpdateAgentURL = "/api/v1/namespaces/{namespace}/agents/{id}"
+	UpdateAgentURL = agentByIDURL
+	// DeleteAgentURL is the path to delete an agent by ID in a namespace.
+	DeleteAgentURL = agentByIDURL
 )
 
 // AgentService provides methods to interact with agents.
@@ -126,6 +133,32 @@ func (s *AgentService) SearchAgents(
 	}
 
 	return &result, nil
+}
+
+// DeleteAgent deletes a disconnected agent by its namespace and ID.
+// The server rejects deletion of connected agents with a 409 Conflict.
+func (s *AgentService) DeleteAgent(
+	ctx context.Context,
+	namespace string,
+	id uuid.UUID,
+) error {
+	res, err := s.service.Resty.R().
+		SetContext(ctx).
+		SetPathParam("namespace", namespace).
+		SetPathParam("id", id.String()).
+		Delete(DeleteAgentURL)
+	if err != nil {
+		return fmt.Errorf("failed to delete agent: %w", err)
+	}
+
+	if res.IsError() {
+		return fmt.Errorf("failed to delete agent: %w", &ResponseError{
+			StatusCode:   res.StatusCode(),
+			ErrorMessage: res.String(),
+		})
+	}
+
+	return nil
 }
 
 // SetNewInstanceUIDRequest is a struct that represents the request to set a new instance UID for the agent.

--- a/pkg/cmd/opampctl/deletecmd/agent/agent.go
+++ b/pkg/cmd/opampctl/deletecmd/agent/agent.go
@@ -1,0 +1,117 @@
+// Package agent implements the 'opampctl delete agent' command.
+package agent
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/samber/lo"
+	"github.com/spf13/cobra"
+
+	v1 "github.com/minuk-dev/opampcommander/api/v1"
+	"github.com/minuk-dev/opampcommander/pkg/client"
+	"github.com/minuk-dev/opampcommander/pkg/clientutil"
+	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/deletecmd/internal/deleteutil"
+	"github.com/minuk-dev/opampcommander/pkg/opampctl/config"
+)
+
+const (
+	// MaxCompletionResults is the maximum number of completion results to return.
+	MaxCompletionResults = 20
+)
+
+var (
+	// ErrAgentInstanceUIDRequired is returned when the target agent instance UID is not provided.
+	ErrAgentInstanceUIDRequired = errors.New("agent instance UID is required")
+)
+
+// CommandOptions contains the options for the 'opampctl delete agent' command.
+type CommandOptions struct {
+	*config.GlobalConfig
+
+	// flags
+	namespace string
+
+	// internal
+	client *client.Client
+}
+
+// NewCommand creates a new 'opampctl delete agent' command.
+func NewCommand(options CommandOptions) *cobra.Command {
+	//exhaustruct:ignore
+	cmd := &cobra.Command{
+		Use:               "agent [instance-uid...]",
+		Short:             "Delete disconnected agent(s)",
+		Long:              "Delete one or more disconnected agents by instance UID. Connected agents cannot be deleted.",
+		ValidArgsFunction: options.ValidArgsFunction,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := options.Prepare(cmd, args)
+			if err != nil {
+				return err
+			}
+
+			return options.Run(cmd, args)
+		},
+	}
+	cmd.Flags().StringVarP(&options.namespace, "namespace", "n", "default", "Namespace of the agent")
+
+	return cmd
+}
+
+// Prepare prepares the internal state before running the command.
+func (o *CommandOptions) Prepare(_ *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return ErrAgentInstanceUIDRequired
+	}
+
+	cli, err := clientutil.NewClient(o.GlobalConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create authenticated client: %w", err)
+	}
+
+	o.client = cli
+
+	return nil
+}
+
+// Run runs the command.
+func (o *CommandOptions) Run(cmd *cobra.Command, ids []string) error {
+	deleteutil.Run(cmd, "agent", ids, func(id string) error {
+		instanceUID, parseErr := uuid.Parse(id)
+		if parseErr != nil {
+			return fmt.Errorf("invalid instance UID %q: %w", id, parseErr)
+		}
+
+		return o.client.AgentService.DeleteAgent(cmd.Context(), o.namespace, instanceUID)
+	})
+
+	return nil
+}
+
+// ValidArgsFunction provides dynamic completion for agent instance UIDs.
+func (o *CommandOptions) ValidArgsFunction(
+	cmd *cobra.Command, _ []string, toComplete string,
+) ([]string, cobra.ShellCompDirective) {
+	// unfortunately, we don't use o.client because this function is called without Prepare.
+	cli, err := clientutil.NewClient(o.GlobalConfig)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	resp, err := cli.AgentService.SearchAgents(
+		cmd.Context(),
+		o.namespace,
+		toComplete,
+		client.WithLimit(MaxCompletionResults),
+	)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	instanceUIDs := lo.Map(resp.Items, func(agent v1.Agent, _ int) string {
+		return agent.Metadata.InstanceUID.String()
+	})
+
+	return instanceUIDs, cobra.ShellCompDirectiveNoFileComp
+}

--- a/pkg/cmd/opampctl/deletecmd/agentgroup/agentgroup.go
+++ b/pkg/cmd/opampctl/deletecmd/agentgroup/agentgroup.go
@@ -12,6 +12,7 @@ import (
 	v1 "github.com/minuk-dev/opampcommander/api/v1"
 	"github.com/minuk-dev/opampcommander/pkg/client"
 	"github.com/minuk-dev/opampcommander/pkg/clientutil"
+	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/deletecmd/internal/deleteutil"
 	"github.com/minuk-dev/opampcommander/pkg/opampctl/config"
 )
 
@@ -80,31 +81,9 @@ func (o *CommandOptions) Prepare(_ *cobra.Command, args []string) error {
 
 // Run runs the command.
 func (o *CommandOptions) Run(cmd *cobra.Command, names []string) error {
-	type deleteResult struct {
-		name string
-		err  error
-	}
-
-	results := lo.Map(names, func(name string, _ int) deleteResult {
-		return deleteResult{
-			name: name,
-			err:  o.client.AgentGroupService.DeleteAgentGroup(cmd.Context(), o.namespace, name),
-		}
+	deleteutil.Run(cmd, "agentgroup", names, func(name string) error {
+		return o.client.AgentGroupService.DeleteAgentGroup(cmd.Context(), o.namespace, name)
 	})
-
-	successfullyDeleted := lo.FilterMap(results, func(r deleteResult, _ int) (string, bool) {
-		return r.name, r.err == nil
-	})
-	failedToDelete := lo.FilterMap(results, func(r deleteResult, _ int) (string, bool) {
-		return r.name, r.err != nil
-	})
-
-	cmd.Printf("Successfully deleted %d agentgroup(s): %s\n",
-		len(successfullyDeleted), strings.Join(successfullyDeleted, ", "))
-
-	if len(failedToDelete) > 0 {
-		cmd.PrintErrf("Failed to delete %d agentgroup(s): %s\n", len(failedToDelete), strings.Join(failedToDelete, ", "))
-	}
 
 	return nil
 }

--- a/pkg/cmd/opampctl/deletecmd/delete.go
+++ b/pkg/cmd/opampctl/deletecmd/delete.go
@@ -5,6 +5,7 @@ package deletecmd
 import (
 	"github.com/spf13/cobra"
 
+	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/deletecmd/agent"
 	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/deletecmd/agentgroup"
 	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/deletecmd/agentpackage"
 	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/deletecmd/agentremoteconfig"
@@ -29,6 +30,9 @@ func NewCommand(options CommandOptions) *cobra.Command {
 		Short: "delete",
 	}
 
+	cmd.AddCommand(agent.NewCommand(agent.CommandOptions{
+		GlobalConfig: options.GlobalConfig,
+	}))
 	cmd.AddCommand(agentgroup.NewCommand(agentgroup.CommandOptions{
 		GlobalConfig: options.GlobalConfig,
 	}))

--- a/pkg/cmd/opampctl/deletecmd/internal/deleteutil/deleteutil.go
+++ b/pkg/cmd/opampctl/deletecmd/internal/deleteutil/deleteutil.go
@@ -1,0 +1,43 @@
+// Package deleteutil provides shared helpers for the 'opampctl delete' subcommands,
+// so each resource command only supplies its per-identifier delete call and shares
+// one consistent success/failure summary.
+package deleteutil
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/samber/lo"
+	"github.com/spf13/cobra"
+)
+
+// Run deletes each identifier via del and prints a standard summary. kind is the
+// singular resource noun used in messages (e.g. "agent", "agentgroup"). It never
+// returns an error itself: per-identifier failures are reported on stderr so a
+// partial batch still deletes what it can.
+func Run(cmd *cobra.Command, kind string, ids []string, del func(id string) error) {
+	type result struct {
+		id  string
+		err error
+	}
+
+	results := lo.Map(ids, func(id string, _ int) result {
+		return result{id: id, err: del(id)}
+	})
+
+	deleted := lo.FilterMap(results, func(r result, _ int) (string, bool) {
+		return r.id, r.err == nil
+	})
+
+	cmd.Printf("Successfully deleted %d %s(s): %s\n", len(deleted), kind, strings.Join(deleted, ", "))
+
+	failed := lo.Filter(results, func(r result, _ int) bool {
+		return r.err != nil
+	})
+	if len(failed) > 0 {
+		messages := lo.Map(failed, func(r result, _ int) string {
+			return fmt.Sprintf("%s: %v", r.id, r.err)
+		})
+		cmd.PrintErrf("Failed to delete %d %s(s): %s\n", len(failed), kind, strings.Join(messages, "; "))
+	}
+}

--- a/pkg/ginutil/errormiddleware.go
+++ b/pkg/ginutil/errormiddleware.go
@@ -145,6 +145,26 @@ func InternalServerError(ctx *gin.Context, err error, detail string) {
 	})
 }
 
+// ConflictError creates a standardized 409 Conflict error response.
+func ConflictError(ctx *gin.Context, err error, detail string) {
+	baseURL := GetErrorTypeURI(ctx)
+
+	ctx.JSON(http.StatusConflict, &api.ErrorModel{
+		Type:     baseURL,
+		Title:    "Conflict",
+		Status:   http.StatusConflict,
+		Detail:   detail,
+		Instance: ctx.Request.URL.String(),
+		Errors: []*api.ErrorDetail{
+			{
+				Message:  err.Error(),
+				Location: "server",
+				Value:    nil,
+			},
+		},
+	})
+}
+
 // ResourceNotFoundError creates a standardized 404 error response.
 func ResourceNotFoundError(ctx *gin.Context, resourceType, identifier string) {
 	baseURL := GetErrorTypeURI(ctx)

--- a/test/e2e/apiserver/agent_delete_e2e_test.go
+++ b/test/e2e/apiserver/agent_delete_e2e_test.go
@@ -1,0 +1,138 @@
+//go:build e2e
+
+package apiserver_test
+
+import (
+	"context"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"go.mongodb.org/mongo-driver/v2/bson"
+
+	"github.com/minuk-dev/opampcommander/pkg/client"
+	"github.com/minuk-dev/opampcommander/pkg/testutil"
+)
+
+// TestE2E_APIServer_DeleteAgent exercises the agent delete flow end-to-end through
+// the same client library that opampctl uses against a live API server:
+//   - a disconnected agent can be deleted (and is gone afterwards)
+//   - a connected agent is rejected with 409 Conflict (and survives)
+//   - deleting a non-existent agent returns 404 Not Found
+func TestE2E_APIServer_DeleteAgent(t *testing.T) {
+	t.Parallel()
+	testcontainers.SkipIfProviderIsNotHealthy(t)
+
+	if testing.Short() {
+		t.Skip("Skipping E2E test in short mode")
+	}
+
+	ctx, cancel := context.WithTimeout(t.Context(), 3*time.Minute)
+	defer cancel()
+
+	base := testutil.NewBase(t)
+
+	// Given: Infrastructure is set up (MongoDB + API Server)
+	dbName := "opampcommander_e2e_delete_agent_test"
+	mongoServer := base.StartMongoDB()
+	apiServer := base.StartAPIServer(mongoServer.URI, dbName)
+	defer apiServer.Stop()
+
+	apiServer.WaitForReady()
+
+	opampClient := apiServer.Client()
+	namespace := "default"
+
+	// Given: One disconnected and one connected agent inserted directly into MongoDB.
+	mongoClient, err := setupMongoDBClient(t, mongoServer.URI)
+	require.NoError(t, err)
+
+	defer func() { _ = mongoClient.Disconnect(ctx) }()
+
+	disconnectedUID := uuid.New()
+	connectedUID := uuid.New()
+
+	collection := mongoClient.Database(dbName).Collection("agents")
+
+	_, err = collection.InsertMany(ctx, []interface{}{
+		bson.M{
+			"metadata": bson.M{
+				"instanceUid":       bson.Binary{Subtype: 0x04, Data: disconnectedUID[:]},
+				"instanceUidString": disconnectedUID.String(),
+				"namespace":         namespace,
+			},
+			"status": bson.M{
+				"connected": false,
+			},
+			"spec": bson.M{},
+		},
+		bson.M{
+			"metadata": bson.M{
+				"instanceUid":       bson.Binary{Subtype: 0x04, Data: connectedUID[:]},
+				"instanceUidString": connectedUID.String(),
+				"namespace":         namespace,
+			},
+			"status": bson.M{
+				"connected": true,
+				// Recent heartbeat so the server considers it effectively connected.
+				"lastCommunicatedAt": bson.NewDateTimeFromTime(time.Now()),
+			},
+			"spec": bson.M{},
+		},
+	})
+	require.NoError(t, err)
+
+	// Sanity check: both agents are visible through the API before deletion.
+	_, err = opampClient.AgentService.GetAgent(ctx, namespace, disconnectedUID)
+	require.NoError(t, err, "disconnected agent should exist before delete")
+	_, err = opampClient.AgentService.GetAgent(ctx, namespace, connectedUID)
+	require.NoError(t, err, "connected agent should exist before delete")
+
+	t.Run("deletes a disconnected agent", func(t *testing.T) {
+		// When: deleting the disconnected agent.
+		err := opampClient.AgentService.DeleteAgent(ctx, namespace, disconnectedUID)
+
+		// Then: it succeeds and the agent is gone.
+		require.NoError(t, err)
+
+		_, getErr := opampClient.AgentService.GetAgent(ctx, namespace, disconnectedUID)
+		require.Error(t, getErr, "disconnected agent should be gone after delete")
+		assert.Equal(t, http.StatusNotFound, responseStatusCode(t, getErr))
+	})
+
+	t.Run("rejects deleting a connected agent with 409", func(t *testing.T) {
+		// When: deleting the connected agent.
+		err := opampClient.AgentService.DeleteAgent(ctx, namespace, connectedUID)
+
+		// Then: it is rejected with 409 Conflict and the agent survives.
+		require.Error(t, err)
+		assert.Equal(t, http.StatusConflict, responseStatusCode(t, err))
+
+		_, getErr := opampClient.AgentService.GetAgent(ctx, namespace, connectedUID)
+		require.NoError(t, getErr, "connected agent should still exist after rejected delete")
+	})
+
+	t.Run("returns 404 for a non-existent agent", func(t *testing.T) {
+		// When: deleting an agent that does not exist.
+		err := opampClient.AgentService.DeleteAgent(ctx, namespace, uuid.New())
+
+		// Then: it returns 404 Not Found.
+		require.Error(t, err)
+		assert.Equal(t, http.StatusNotFound, responseStatusCode(t, err))
+	})
+}
+
+// responseStatusCode extracts the HTTP status code from a client.ResponseError.
+func responseStatusCode(t *testing.T, err error) int {
+	t.Helper()
+
+	var respErr *client.ResponseError
+
+	require.ErrorAs(t, err, &respErr, "expected a client.ResponseError")
+
+	return respErr.StatusCode
+}

--- a/test/integration/restart_test.go
+++ b/test/integration/restart_test.go
@@ -163,6 +163,12 @@ func (m *mockAgentUsecase) SaveAgent(_ context.Context, agent *agentmodel.Agent)
 	return nil
 }
 
+func (m *mockAgentUsecase) DeleteAgent(_ context.Context, instanceUID uuid.UUID) error {
+	delete(m.agents, instanceUID)
+
+	return nil
+}
+
 func (m *mockAgentUsecase) ListAgents(
 	_ context.Context,
 	_ string,

--- a/web/app/agents/[id]/page.tsx
+++ b/web/app/agents/[id]/page.tsx
@@ -20,14 +20,17 @@ import {
   ArrowBack as ArrowBackIcon,
   Refresh as RefreshIcon,
   RestartAlt as RestartIcon,
+  Delete as DeleteIcon,
 } from '@mui/icons-material';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import PageHeader from '@/components/PageHeader';
+import ConfirmDialog from '@/components/ConfirmDialog';
 import JsonBlock from '@/components/JsonBlock';
 import TimeDisplay from '@/components/TimeDisplay';
 import { useNamespace } from '@/components/NamespaceProvider';
 import { api } from '@/lib/api-client';
+import { agentDeleteConfirmMessage, deleteAgent } from '@/lib/agents';
 import { useApi } from '@/lib/swr';
 import type { Agent } from '@/lib/types';
 import AgentEditDialog from './AgentEditDialog';
@@ -64,6 +67,7 @@ function AgentDetailInner() {
   const [restartBusy, setRestartBusy] = useState(false);
   const [actionHandled, setActionHandled] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
+  const [deleteOpen, setDeleteOpen] = useState(false);
 
   const {
     data: agent,
@@ -103,6 +107,12 @@ function AgentDetailInner() {
       setRestartBusy(false);
     }
   }, [agent, namespace, params.id, mutate]);
+
+  const onDeleteAgent = useCallback(async () => {
+    await deleteAgent(namespace, params.id);
+    setDeleteOpen(false);
+    router.push('/agents');
+  }, [namespace, params.id, router]);
 
   // Honor ?action= once after the agent loads.
   useEffect(() => {
@@ -158,6 +168,15 @@ function AgentDetailInner() {
             <Button startIcon={<RestartIcon />} onClick={requestRestart} disabled={restartBusy}>
               Request restart
             </Button>
+            {!agent.status.connected && (
+              <Button
+                startIcon={<DeleteIcon />}
+                color="error"
+                onClick={() => setDeleteOpen(true)}
+              >
+                Delete
+              </Button>
+            )}
             <Button startIcon={<EditIcon />} variant="contained" onClick={() => setEditOpen(true)}>
               Edit spec
             </Button>
@@ -296,6 +315,16 @@ function AgentDetailInner() {
           void mutate(saved, { revalidate: false });
           setEditOpen(false);
         }}
+      />
+
+      <ConfirmDialog
+        open={deleteOpen}
+        title="Delete agent"
+        message={agentDeleteConfirmMessage(agent.metadata.instanceUid)}
+        confirmLabel="Delete"
+        destructive
+        onClose={() => setDeleteOpen(false)}
+        onConfirm={onDeleteAgent}
       />
     </Box>
   );

--- a/web/app/agents/[id]/page.tsx
+++ b/web/app/agents/[id]/page.tsx
@@ -169,11 +169,7 @@ function AgentDetailInner() {
               Request restart
             </Button>
             {!agent.status.connected && (
-              <Button
-                startIcon={<DeleteIcon />}
-                color="error"
-                onClick={() => setDeleteOpen(true)}
-              >
+              <Button startIcon={<DeleteIcon />} color="error" onClick={() => setDeleteOpen(true)}>
                 Delete
               </Button>
             )}

--- a/web/app/agents/page.tsx
+++ b/web/app/agents/page.tsx
@@ -30,15 +30,18 @@ import {
   Visibility as ViewIcon,
   Edit as EditIcon,
   RestartAlt as RestartIcon,
+  Delete as DeleteIcon,
 } from '@mui/icons-material';
 import Link from 'next/link';
 import { useRouter, useSearchParams } from 'next/navigation';
 import { Suspense, useEffect, useState } from 'react';
 import PageHeader from '@/components/PageHeader';
 import PaginationFooter from '@/components/PaginationFooter';
-import RowActionsMenu from '@/components/RowActionsMenu';
+import RowActionsMenu, { type RowAction } from '@/components/RowActionsMenu';
+import ConfirmDialog from '@/components/ConfirmDialog';
 import TimeDisplay from '@/components/TimeDisplay';
 import { useNamespace } from '@/components/NamespaceProvider';
+import { agentDeleteConfirmMessage, deleteAgent } from '@/lib/agents';
 import { useCursorPagination } from '@/lib/pagination';
 import { useApi } from '@/lib/swr';
 import type { Agent, AgentGroup, ListResponse } from '@/lib/types';
@@ -72,6 +75,7 @@ function AgentsInner() {
 
   const [mode, setMode] = useState<SearchMode>(modeParam);
   const [query, setQuery] = useState(qParam);
+  const [deleting, setDeleting] = useState<Agent | null>(null);
 
   // The three search modes hit different endpoints; description mode reuses the
   // plain list and filters client-side (see visibleAgents below).
@@ -152,6 +156,17 @@ function AgentsInner() {
   const clearSearch = () => {
     setQuery('');
     updateUrl({ q: '' });
+  };
+
+  // Only disconnected agents can be deleted; a connected one would just be
+  // recreated on its next report (the server enforces this with a 409 too).
+  // reset() (not refresh()) revalidates from page 0 so deleting the last row on a
+  // later page doesn't strand the user on a now-empty cursor page.
+  const onDelete = async () => {
+    if (!deleting) return;
+    await deleteAgent(namespace, deleting.metadata.instanceUid);
+    setDeleting(null);
+    pagination.reset();
   };
 
   const filterActive = Boolean(agentGroupParam || qParam || descParam);
@@ -383,6 +398,19 @@ function AgentsInner() {
                           icon: <RestartIcon fontSize="small" />,
                           href: `/agents/${agent.metadata.instanceUid}?action=restart`,
                         },
+                        // Deleting a connected agent is pointless (it reappears),
+                        // so only surface it for disconnected ones.
+                        ...(!agent.status.connected
+                          ? [
+                              {
+                                label: 'Delete agent',
+                                icon: <DeleteIcon fontSize="small" />,
+                                onClick: () => setDeleting(agent),
+                                destructive: true,
+                                divider: true,
+                              } satisfies RowAction,
+                            ]
+                          : []),
                       ]}
                     />
                   </TableCell>
@@ -394,6 +422,16 @@ function AgentsInner() {
       </TableContainer>
 
       <PaginationFooter pagination={pagination} />
+
+      <ConfirmDialog
+        open={deleting !== null}
+        title="Delete agent"
+        message={deleting ? agentDeleteConfirmMessage(deleting.metadata.instanceUid) : ''}
+        confirmLabel="Delete"
+        destructive
+        onClose={() => setDeleting(null)}
+        onConfirm={onDelete}
+      />
     </Box>
   );
 }

--- a/web/lib/agents.ts
+++ b/web/lib/agents.ts
@@ -1,0 +1,12 @@
+import { api } from './api-client';
+
+// Shared agent-deletion helpers, used by both the agents list and detail pages so
+// the confirmation copy and the API path stay in one place.
+
+export function agentDeleteConfirmMessage(instanceUid: string): string {
+  return `Permanently delete agent "${instanceUid}"? This removes its stored record; if the agent reconnects it will reappear.`;
+}
+
+export function deleteAgent(namespace: string, instanceUid: string): Promise<void> {
+  return api.delete(`/api/v1/namespaces/${namespace}/agents/${instanceUid}`);
+}


### PR DESCRIPTION
## What

Adds end-to-end deletion of **disconnected** OpAMP agents — there was previously no way to remove an agent record.

## Backend (hexagonal)
- `DeleteAgent` on the domain `AgentUsecase` / `AgentPersistencePort`, plus a MongoDB **hard delete** (`deleteOne` helper). Agents have no soft-delete field, so a hard delete is the correct semantics; the helper is documented as bypassing the soft-delete filter so it isn't misused for tombstoned resources.
- **Connection guard enforced in the domain** against a *fresh* persistence read (not the cache): a still-connected agent is rejected with `ErrAgentConnected`. Putting it in the domain means callers holding an `AgentUsecase` can't bypass it, and the fresh read avoids a stale-cache false 409.
- Application `AgentManageUsecase.DeleteAgent` scopes the delete to the namespace.
- `DELETE /api/v1/namespaces/{namespace}/agents/{id}` → **204 / 404 / 409 / 400**, with a centralised agent error→status mapping (a wrong-namespace request now returns **404** instead of 500, fixed for Get/Update too).

## Client & CLI
- `client.AgentService.DeleteAgent`.
- `opampctl delete agent <uid...> [-n namespace]` (multi-arg, UID shell completion), using a shared `deleteutil` helper that `delete agentgroup` now also uses (unifies the previously divergent success/failure reporting).

## Web
- Delete action shown only for **disconnected** agents on both the agents list and the detail page, behind a confirm dialog. Shared confirm-message/delete helpers (`web/lib/agents.ts`) remove the duplicated copy + URL. The list uses `reset()` after delete so removing the last row on a later page doesn't strand the user on an empty page.

## Tests
- Unit: application service, HTTP controller (incl. 204/404/409/400 + namespace-mismatch), domain service (connection guard + cache invalidation), MongoDB repo.
- E2E (`test/e2e/apiserver`): drives the real API server via the client library — disconnected→deletable, connected→409, missing→404.
- Web vitest suite green; updated Go mocks.

## Follow-up (not in this PR)
- **Multi-server connection/Kafka propagation on delete:** deleting an agent does not actively close a connection held on another server or emit a delete CloudEvent. Both the dangling connection and the agent record self-heal (WS close clears the connection; a live agent is recreated on its next report), so this is a separate, optional enhancement rather than a correctness bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)