### PR TITLE
fix(web): proxy 204/205/304 with null body to avoid Response throw

### DIFF
--- a/web/app/api/proxy/[...path]/route.test.ts
+++ b/web/app/api/proxy/[...path]/route.test.ts
@@ -1,0 +1,50 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+import { DELETE, GET } from './route';
+
+function ctx(path: string[]) {
+  return { params: Promise.resolve({ path }) };
+}
+
+describe('proxy route', () => {
+  const fetchSpy = vi.fn();
+
+  beforeEach(() => {
+    fetchSpy.mockReset();
+    vi.stubGlobal('fetch', fetchSpy);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  // Regression: 204/205/304 are null-body status codes. Forwarding the upstream
+  // body (even an empty ArrayBuffer) into the Response constructor throws
+  // "Invalid response status code 204". This surfaced when deleting an agent.
+  it.each([204, 205, 304])('forwards %i without a body and does not throw', async (status) => {
+    fetchSpy.mockResolvedValueOnce(new Response(null, { status }));
+
+    const req = new NextRequest('http://localhost/api/proxy/api/v1/namespaces/default/agents/abc', {
+      method: 'DELETE',
+    });
+    const res = await DELETE(req, ctx(['api', 'v1', 'namespaces', 'default', 'agents', 'abc']));
+
+    expect(res.status).toBe(status);
+    expect(res.body).toBeNull();
+  });
+
+  it('forwards a normal 200 JSON body through', async () => {
+    fetchSpy.mockResolvedValueOnce(
+      new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    const req = new NextRequest('http://localhost/api/proxy/api/v1/agents', { method: 'GET' });
+    const res = await GET(req, ctx(['api', 'v1', 'agents']));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+  });
+});

--- a/web/app/api/proxy/[...path]/route.ts
+++ b/web/app/api/proxy/[...path]/route.ts
@@ -15,6 +15,10 @@ const HOP_BY_HOP = new Set([
   'host',
 ]);
 
+// "null body status" codes: the Response constructor throws ("Invalid response
+// status code 204") if given any body, even an empty one.
+const NULL_BODY_STATUS = new Set([204, 205, 304]);
+
 async function forward(request: NextRequest, segments: string[]): Promise<NextResponse> {
   const targetPath = `/${segments.map((s) => encodeURIComponent(s)).join('/')}`;
   const search = request.nextUrl.search;
@@ -80,9 +84,6 @@ async function forward(request: NextRequest, segments: string[]): Promise<NextRe
     }
   }
 
-  // 204/205/304 are "null body status" codes: the Response constructor throws
-  // ("Invalid response status code 204") if given any body, even an empty one.
-  const NULL_BODY_STATUS = new Set([204, 205, 304]);
   const body = NULL_BODY_STATUS.has(upstream.status) ? null : await upstream.arrayBuffer();
   return new NextResponse(body, {
     status: upstream.status,

--- a/web/app/api/proxy/[...path]/route.ts
+++ b/web/app/api/proxy/[...path]/route.ts
@@ -80,7 +80,10 @@ async function forward(request: NextRequest, segments: string[]): Promise<NextRe
     }
   }
 
-  const body = await upstream.arrayBuffer();
+  // 204/205/304 are "null body status" codes: the Response constructor throws
+  // ("Invalid response status code 204") if given any body, even an empty one.
+  const NULL_BODY_STATUS = new Set([204, 205, 304]);
+  const body = NULL_BODY_STATUS.has(upstream.status) ? null : await upstream.arrayBuffer();
   return new NextResponse(body, {
     status: upstream.status,
     statusText: upstream.statusText,


### PR DESCRIPTION
## Problem

Deleting an agent in the web UI failed with:

```
TypeError: Response constructor: Invalid response status code 204
```

The agent delete endpoint returns `204 No Content` from the Go backend. The Next.js proxy route (`web/app/api/proxy/[...path]/route.ts`) reconstructs upstream responses by reading the body into an `ArrayBuffer` and passing it to `new NextResponse(body, { status })`. Per the Fetch spec, **204/205/304 are null-body status codes** — the `Response`/`NextResponse` constructor throws if given *any* body, even an empty `ArrayBuffer`.

## Fix

Pass `null` as the body for null-body statuses (204/205/304). This fixes agent delete and makes the proxy correct for any endpoint returning those statuses.

## Test

- `npx tsc --noEmit` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)