### PR TITLE
feat(web): relative time display with absolute-time tooltip + preference

### DIFF
--- a/web/app/preferences/page.tsx
+++ b/web/app/preferences/page.tsx
@@ -4,6 +4,7 @@ import { Alert, Box, Card, CardContent, Typography } from '@mui/material';
 import { useEffect, useState } from 'react';
 import PageHeader from '@/components/PageHeader';
 import TimeDisplay from '@/components/TimeDisplay';
+import TimeFormatSelector from '@/components/TimeFormatSelector';
 import TimezoneSelector from '@/components/TimezoneSelector';
 import { usePreferences } from '@/components/PreferencesProvider';
 
@@ -34,6 +35,20 @@ export default function PreferencesPage() {
         title="Preferences"
         subtitle="Display settings stored in this browser. They apply only to you and are never sent to the server."
       />
+
+      <Card variant="outlined" sx={{ mb: 3, maxWidth: 640 }}>
+        <CardContent>
+          <Typography variant="h6" gutterBottom>
+            Time format
+          </Typography>
+          <Typography variant="body2" color="text.secondary" sx={{ mb: 2 }}>
+            Show timestamps as a relative time (&ldquo;5 minutes ago&rdquo;) with the absolute time
+            on hover, or always as the full absolute timestamp.
+          </Typography>
+
+          <TimeFormatSelector />
+        </CardContent>
+      </Card>
 
       <Card variant="outlined" sx={{ mb: 3, maxWidth: 640 }}>
         <CardContent>

--- a/web/components/PreferencesProvider.tsx
+++ b/web/components/PreferencesProvider.tsx
@@ -12,6 +12,7 @@ import {
 import {
   DEFAULT_PREFERENCES,
   type Preferences,
+  type TimeFormat,
   readPreferences,
   writePreferences,
 } from '@/lib/preferences';
@@ -20,6 +21,8 @@ interface PreferencesContextValue {
   preferences: Preferences;
   // Set the display timezone: 'local' (browser zone) or an IANA zone name.
   setTimeZone: (timeZone: string) => void;
+  // Set how timestamps render: 'relative' or 'absolute'.
+  setTimeFormat: (timeFormat: TimeFormat) => void;
   // True once the persisted preferences have been read from localStorage on the
   // client. Components that render timezone-dependent output (which differs
   // between the server and the visitor's browser) gate on this to stay
@@ -51,9 +54,17 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
     });
   }, []);
 
+  const setTimeFormat = useCallback((timeFormat: TimeFormat) => {
+    setPreferences((prev) => {
+      const next = { ...prev, timeFormat };
+      writePreferences(next);
+      return next;
+    });
+  }, []);
+
   const value = useMemo<PreferencesContextValue>(
-    () => ({ preferences, setTimeZone, hydrated }),
-    [preferences, setTimeZone, hydrated],
+    () => ({ preferences, setTimeZone, setTimeFormat, hydrated }),
+    [preferences, setTimeZone, setTimeFormat, hydrated],
   );
 
   return <PreferencesContext.Provider value={value}>{children}</PreferencesContext.Provider>;

--- a/web/components/TimeDisplay.tsx
+++ b/web/components/TimeDisplay.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import { usePreferences } from './PreferencesProvider';
-import { formatTimestamp } from '@/lib/format-time';
-import { LOCAL_TIME_ZONE } from '@/lib/preferences';
+import { formatRelativeTime, formatTimestamp } from '@/lib/format-time';
+import { LOCAL_TIME_ZONE, RELATIVE_TIME_FORMAT } from '@/lib/preferences';
+import { useNow } from '@/lib/use-now';
 
 interface Props {
   // ISO-8601 timestamp. Empty/undefined renders `emptyText`.
@@ -11,11 +12,16 @@ interface Props {
   emptyText?: string;
 }
 
-// Renders a timestamp formatted per the user's timezone preference. Until the
-// preferences have hydrated on the client we render in UTC, which is identical
-// on the server and the browser — so switching to the chosen zone happens after
-// hydration without a mismatch. suppressHydrationWarning guards against any
-// residual Intl differences between the Node and browser runtimes.
+// Renders a timestamp per the user's preferences. By default it shows a live
+// relative time ("5 minutes ago") with the absolute timestamp in the hover
+// tooltip; the 'absolute' time-format preference shows the full timestamp
+// inline instead. Both honour the chosen timezone.
+//
+// Until preferences have hydrated on the client we render the absolute time in
+// UTC, which is identical on the server and the browser — so switching to the
+// relative phrasing / chosen zone happens after hydration without a mismatch.
+// suppressHydrationWarning guards against any residual Intl differences between
+// the Node and browser runtimes.
 export default function TimeDisplay({ value, emptyText = '-' }: Props) {
   const { preferences, hydrated } = usePreferences();
 
@@ -34,9 +40,22 @@ export default function TimeDisplay({ value, emptyText = '-' }: Props) {
     return <span title={value}>{value}</span>;
   }
 
+  // Relative phrasing depends on the client clock, so only after hydration and
+  // only when the user hasn't opted into absolute display. The tooltip always
+  // carries the full absolute timestamp.
+  const showRelative = hydrated && preferences.timeFormat === RELATIVE_TIME_FORMAT;
+
   return (
     <time dateTime={value} title={formatted.title} suppressHydrationWarning>
-      {formatted.text}
+      {showRelative ? <RelativeText value={value} fallback={formatted.text} /> : formatted.text}
     </time>
   );
+}
+
+// The live relative phrase, isolated so the 30s ticker subscription exists only
+// when relative display is actually shown — in absolute mode (or pre-hydration)
+// no TimeDisplay subscribes, so nothing re-renders on tick.
+function RelativeText({ value, fallback }: { value: string; fallback: string }) {
+  const now = useNow();
+  return <>{formatRelativeTime(value, now) ?? fallback}</>;
 }

--- a/web/components/TimeFormatSelector.tsx
+++ b/web/components/TimeFormatSelector.tsx
@@ -3,11 +3,7 @@
 import { ToggleButton, ToggleButtonGroup } from '@mui/material';
 import { Schedule as RelativeIcon, Event as AbsoluteIcon } from '@mui/icons-material';
 import { usePreferences } from './PreferencesProvider';
-import {
-  ABSOLUTE_TIME_FORMAT,
-  RELATIVE_TIME_FORMAT,
-  type TimeFormat,
-} from '@/lib/preferences';
+import { ABSOLUTE_TIME_FORMAT, RELATIVE_TIME_FORMAT, type TimeFormat } from '@/lib/preferences';
 
 // Toggle between relative ("5 minutes ago") and absolute timestamp display.
 // Writes the selection straight through to the shared preference.

--- a/web/components/TimeFormatSelector.tsx
+++ b/web/components/TimeFormatSelector.tsx
@@ -1,0 +1,40 @@
+'use client';
+
+import { ToggleButton, ToggleButtonGroup } from '@mui/material';
+import { Schedule as RelativeIcon, Event as AbsoluteIcon } from '@mui/icons-material';
+import { usePreferences } from './PreferencesProvider';
+import {
+  ABSOLUTE_TIME_FORMAT,
+  RELATIVE_TIME_FORMAT,
+  type TimeFormat,
+} from '@/lib/preferences';
+
+// Toggle between relative ("5 minutes ago") and absolute timestamp display.
+// Writes the selection straight through to the shared preference.
+export default function TimeFormatSelector() {
+  const { preferences, setTimeFormat } = usePreferences();
+
+  return (
+    <ToggleButtonGroup
+      exclusive
+      color="primary"
+      size="small"
+      value={preferences.timeFormat}
+      onChange={(_, next: TimeFormat | null) => {
+        // null arrives when the active button is clicked again — ignore it so a
+        // format is always selected.
+        if (next) setTimeFormat(next);
+      }}
+      aria-label="Timestamp format"
+    >
+      <ToggleButton value={RELATIVE_TIME_FORMAT}>
+        <RelativeIcon fontSize="small" sx={{ mr: 1 }} />
+        Relative
+      </ToggleButton>
+      <ToggleButton value={ABSOLUTE_TIME_FORMAT}>
+        <AbsoluteIcon fontSize="small" sx={{ mr: 1 }} />
+        Absolute
+      </ToggleButton>
+    </ToggleButtonGroup>
+  );
+}

--- a/web/lib/format-time.test.ts
+++ b/web/lib/format-time.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { formatTimestamp } from './format-time';
+import { formatRelativeTime, formatTimestamp } from './format-time';
 
 describe('formatTimestamp', () => {
   const iso = '2026-06-04T01:59:30Z';
@@ -31,5 +31,55 @@ describe('formatTimestamp', () => {
     const out = formatTimestamp(iso, 'America/New_York');
     // EDT is UTC-4 in June, so 01:59:30Z is the previous day 21:59:30.
     expect(out!.text).toBe('2026-06-03 21:59:30 EDT');
+  });
+});
+
+describe('formatRelativeTime', () => {
+  const now = Date.parse('2026-06-04T12:00:00Z');
+  const at = (offsetMs: number) => new Date(now + offsetMs).toISOString();
+  const SEC = 1000;
+  const MIN = 60 * SEC;
+  const HOUR = 60 * MIN;
+  const DAY = 24 * HOUR;
+
+  it('returns null for empty or invalid input', () => {
+    expect(formatRelativeTime('', now)).toBeNull();
+    expect(formatRelativeTime(null, now)).toBeNull();
+    expect(formatRelativeTime(undefined, now)).toBeNull();
+    expect(formatRelativeTime('not-a-date', now)).toBeNull();
+  });
+
+  it('renders the present moment as "now"', () => {
+    expect(formatRelativeTime(at(0), now)).toBe('now');
+  });
+
+  it('treats small future skew as "now" but keeps genuine future times', () => {
+    // Within the clock-skew tolerance → "now" rather than "in 3 seconds".
+    expect(formatRelativeTime(at(3 * SEC), now)).toBe('now');
+    // Beyond the tolerance → still a real future phrase.
+    expect(formatRelativeTime(at(20 * SEC), now)).toBe('in 20 seconds');
+  });
+
+  it('rolls a near-boundary value up to the next unit', () => {
+    // 59.6s must read "1 minute ago", not "60 seconds ago".
+    expect(formatRelativeTime(at(-59_600), now)).toBe('1 minute ago');
+  });
+
+  it('renders recent past times', () => {
+    expect(formatRelativeTime(at(-30 * SEC), now)).toBe('30 seconds ago');
+    expect(formatRelativeTime(at(-5 * MIN), now)).toBe('5 minutes ago');
+    expect(formatRelativeTime(at(-3 * HOUR), now)).toBe('3 hours ago');
+    expect(formatRelativeTime(at(-1 * DAY), now)).toBe('yesterday');
+    expect(formatRelativeTime(at(-4 * DAY), now)).toBe('4 days ago');
+  });
+
+  it('renders future times', () => {
+    expect(formatRelativeTime(at(2 * MIN), now)).toBe('in 2 minutes');
+    expect(formatRelativeTime(at(1 * DAY), now)).toBe('tomorrow');
+  });
+
+  it('escalates to larger units', () => {
+    expect(formatRelativeTime(at(-90 * DAY), now)).toBe('3 months ago');
+    expect(formatRelativeTime(at(-800 * DAY), now)).toBe('2 years ago');
   });
 });

--- a/web/lib/format-time.test.ts
+++ b/web/lib/format-time.test.ts
@@ -75,7 +75,7 @@ describe('formatRelativeTime', () => {
 
   it('renders future times', () => {
     expect(formatRelativeTime(at(2 * MIN), now)).toBe('in 2 minutes');
-    expect(formatRelativeTime(at(1 * DAY), now)).toBe('tomorrow');
+    expect(formatRelativeTime(at(DAY), now)).toBe('tomorrow');
   });
 
   it('escalates to larger units', () => {

--- a/web/lib/format-time.ts
+++ b/web/lib/format-time.ts
@@ -65,3 +65,57 @@ function getFormatter(options: Intl.DateTimeFormatOptions, cacheKey: string): In
 function format(date: Date, options: Intl.DateTimeFormatOptions, cacheKey: string): string {
   return getFormatter(options, cacheKey).format(date).replaceAll(',', '');
 }
+
+// Largest-to-smallest cascade of units and how many of the smaller unit make up
+// one of this one. The walk divides the elapsed seconds by each `amount` until
+// the magnitude fits inside the next unit, then formats with that unit.
+const RELATIVE_DIVISIONS: { amount: number; unit: Intl.RelativeTimeFormatUnit }[] = [
+  { amount: 60, unit: 'second' },
+  { amount: 60, unit: 'minute' },
+  { amount: 24, unit: 'hour' },
+  { amount: 7, unit: 'day' },
+  { amount: 4.34524, unit: 'week' },
+  { amount: 12, unit: 'month' },
+  { amount: Number.POSITIVE_INFINITY, unit: 'year' },
+];
+
+// `numeric: 'auto'` yields friendly phrasings ("now", "yesterday") instead of
+// always-numeric ("0 seconds ago", "1 day ago").
+const relativeFormatter = new Intl.RelativeTimeFormat('en', { numeric: 'auto' });
+
+// Future timestamps within this window render as "now". Server/client clock
+// skew routinely puts a just-created resource a few seconds ahead of the
+// browser clock, and "in 3 seconds" reads as a glitch. Genuinely future times
+// (e.g. certificate expiries) sit far beyond this and still render as "in …".
+const FUTURE_SKEW_TOLERANCE_SECONDS = 10;
+
+// Format an ISO-8601 timestamp as a relative phrase ("5 minutes ago", "in 3
+// hours", "now"). `nowMs` is the reference epoch-ms — pass a shared, ticking
+// value so many timestamps advance in lockstep; defaults to Date.now(). Returns
+// null for empty/invalid input so callers can render their own placeholder.
+export function formatRelativeTime(
+  value: string | null | undefined,
+  nowMs?: number,
+): string | null {
+  if (!value) return null;
+  const time = new Date(value).getTime();
+  if (Number.isNaN(time)) return null;
+
+  // Signed seconds: negative is in the past, positive is in the future.
+  let duration = (time - (nowMs ?? Date.now())) / 1000;
+  if (duration > 0 && duration < FUTURE_SKEW_TOLERANCE_SECONDS) duration = 0;
+
+  for (const { amount, unit } of RELATIVE_DIVISIONS) {
+    // Round before the threshold check (not just for output): a value like
+    // 59.6s would otherwise print "60 seconds ago" instead of rolling over to
+    // "1 minute ago". The unrounded `duration` still feeds the next division so
+    // precision is preserved across units.
+    const rounded = Math.round(duration);
+    if (Math.abs(rounded) < amount) {
+      return relativeFormatter.format(rounded, unit);
+    }
+    duration /= amount;
+  }
+  // Unreachable: the last division has an infinite amount.
+  return null;
+}

--- a/web/lib/preferences.test.ts
+++ b/web/lib/preferences.test.ts
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest';
-import { LOCAL_TIME_ZONE, isValidTimeZone, listTimeZones } from './preferences';
+import {
+  ABSOLUTE_TIME_FORMAT,
+  LOCAL_TIME_ZONE,
+  RELATIVE_TIME_FORMAT,
+  canonicalTimeFormat,
+  isValidTimeZone,
+  listTimeZones,
+} from './preferences';
 
 describe('isValidTimeZone', () => {
   it('accepts the local sentinel and real IANA zones', () => {
@@ -22,5 +29,18 @@ describe('listTimeZones', () => {
     const zones = listTimeZones();
     expect(zones.length).toBeGreaterThan(0);
     expect(zones).toContain('UTC');
+  });
+});
+
+describe('canonicalTimeFormat', () => {
+  it('keeps the explicit absolute opt-in', () => {
+    expect(canonicalTimeFormat(ABSOLUTE_TIME_FORMAT)).toBe(ABSOLUTE_TIME_FORMAT);
+  });
+
+  it('defaults anything else to relative', () => {
+    expect(canonicalTimeFormat(RELATIVE_TIME_FORMAT)).toBe(RELATIVE_TIME_FORMAT);
+    expect(canonicalTimeFormat(undefined)).toBe(RELATIVE_TIME_FORMAT);
+    expect(canonicalTimeFormat('bogus')).toBe(RELATIVE_TIME_FORMAT);
+    expect(canonicalTimeFormat(42)).toBe(RELATIVE_TIME_FORMAT);
   });
 });

--- a/web/lib/preferences.ts
+++ b/web/lib/preferences.ts
@@ -7,13 +7,22 @@
 // IANA timezone name (e.g. 'UTC', 'Asia/Seoul', 'America/New_York').
 export const LOCAL_TIME_ZONE = 'local';
 
+// How timestamps are rendered: 'relative' shows "5 minutes ago" with the
+// absolute time in a tooltip; 'absolute' always shows the full timestamp.
+export const RELATIVE_TIME_FORMAT = 'relative';
+export const ABSOLUTE_TIME_FORMAT = 'absolute';
+export type TimeFormat = typeof RELATIVE_TIME_FORMAT | typeof ABSOLUTE_TIME_FORMAT;
+
 export interface Preferences {
   // 'local' (browser zone) or an IANA timezone name.
   timeZone: string;
+  // 'relative' (default) or 'absolute'.
+  timeFormat: TimeFormat;
 }
 
 export const DEFAULT_PREFERENCES: Preferences = {
   timeZone: LOCAL_TIME_ZONE,
+  timeFormat: RELATIVE_TIME_FORMAT,
 };
 
 const STORAGE_KEY = 'opamp.preferences';
@@ -102,8 +111,17 @@ const FALLBACK_ZONES = [
   'Australia/Sydney',
 ];
 
+// Coerce an unknown value into a valid TimeFormat, defaulting anything other
+// than the explicit 'absolute' opt-in back to 'relative'.
+export function canonicalTimeFormat(value: unknown): TimeFormat {
+  return value === ABSOLUTE_TIME_FORMAT ? ABSOLUTE_TIME_FORMAT : RELATIVE_TIME_FORMAT;
+}
+
 // Coerce an untrusted parsed object into a valid Preferences, canonicalising
 // the zone spelling and dropping unknown values back to their defaults.
 function normalize(parsed: Partial<Preferences>): Preferences {
-  return { timeZone: canonicalTimeZone(parsed.timeZone) };
+  return {
+    timeZone: canonicalTimeZone(parsed.timeZone),
+    timeFormat: canonicalTimeFormat(parsed.timeFormat),
+  };
 }

--- a/web/lib/use-now.ts
+++ b/web/lib/use-now.ts
@@ -1,0 +1,55 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+
+// A single shared "current time" that ticks on one interval for the whole page.
+// Relative timestamps ("5 minutes ago") need a periodically-refreshed reference
+// time, but a list can render hundreds of them — so instead of each component
+// owning a timer, they all subscribe to this one store via useSyncExternalStore.
+// The interval only runs while there is at least one subscriber.
+
+// 30s is fine-grained enough for minute/hour/day relative phrasings without
+// re-rendering every second.
+const REFRESH_MS = 30_000;
+
+let now = Date.now();
+const listeners = new Set<() => void>();
+let timer: ReturnType<typeof setInterval> | null = null;
+
+function subscribe(onChange: () => void): () => void {
+  listeners.add(onChange);
+  if (!timer) {
+    // The interval is the only thing that advances `now`, so while no one was
+    // subscribed the clock sat frozen at the last tick. Refresh it as the timer
+    // (re)starts — otherwise the first render after a remount would format
+    // against a stale time and could even read a past event as a future one.
+    now = Date.now();
+    timer = setInterval(() => {
+      now = Date.now();
+      listeners.forEach((listener) => listener());
+    }, REFRESH_MS);
+  }
+  return () => {
+    listeners.delete(onChange);
+    if (listeners.size === 0 && timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+  };
+}
+
+function getSnapshot(): number {
+  return now;
+}
+
+// Deterministic on the server so the markup matches the first client render;
+// the real clock takes over after hydration. Relative output is only shown
+// post-hydration anyway, so this value is never formatted.
+function getServerSnapshot(): number {
+  return 0;
+}
+
+// Current epoch-ms, refreshed every REFRESH_MS. Re-renders subscribers on tick.
+export function useNow(): number {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}


### PR DESCRIPTION
## What

Timestamps across the web UI now render as a **live relative time** ("5 minutes ago") by default, with the **absolute timestamp shown on hover** (tooltip). A new **Time format** preference lets users switch to always showing the absolute timestamp instead. Both modes continue to honour the existing per-visitor timezone preference.

This is implemented in the shared `TimeDisplay` component, so every page that already uses it (agents, connections, certificates, profile, servers, …) picks up the behaviour automatically.

## Changes

- **`lib/format-time.ts`** — new pure `formatRelativeTime()` built on `Intl.RelativeTimeFormat` over a second→minute→hour→day→week→month→year cascade.
- **`lib/use-now.ts`** — a single shared, subscriber-counted 30s ticker via `useSyncExternalStore`. A list of hundreds of timestamps drives **one** interval instead of one timer each; the interval only runs while something is subscribed.
- **`components/TimeDisplay.tsx`** — shows relative text with the absolute value in the `title` tooltip. Relative phrasing is gated on hydration + relative mode, and the ticker subscription is isolated to an inner component so **absolute mode does no periodic re-rendering**.
- **`lib/preferences.ts` / `PreferencesProvider`** — persisted `timeFormat` (`relative` default / `absolute`) with canonicalisation and a `setTimeFormat` setter.
- **`components/TimeFormatSelector.tsx`** + **preferences page** — a Relative/Absolute toggle with a live preview.

## Review fixes folded in

A self-review (high-effort) surfaced four issues, all addressed here:

1. **Stale shared clock** — `use-now` now refreshes the clock when the ticker (re)starts, so a remount after an idle gap can't read a past event as a future one.
2. **Future clock skew** — `formatRelativeTime` clamps small future deltas (≤10s) to "now" so a just-created, slightly-ahead server timestamp doesn't read "in 3 seconds"; genuine future times (e.g. expiries) are unaffected.
3. **Wasted re-renders** — the 30s ticker subscription is isolated so absolute mode and pre-hydration render do no periodic work.
4. **Boundary rounding** — rounding is applied before the unit-threshold check, so 59.6s reads "1 minute ago" instead of "60 seconds ago".

## Tests

- New unit tests for `formatRelativeTime` (past/future/units, skew clamp, boundary rollover) and `canonicalTimeFormat`.
- Full web suite: **44 passing**. `tsc --noEmit`, `eslint`, and `next build` all clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)