### PR TITLE
feat(web): expose full build/version info like the apiserver

### DIFF
--- a/.github/workflows/web-release.yaml
+++ b/.github/workflows/web-release.yaml
@@ -34,6 +34,16 @@ jobs:
           fi
           echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
           echo "Computed version: ${VERSION}"
+          # Build metadata mirroring the apiserver's version payload. The web
+          # Docker build context is ./web (no .git), so compute here and pass
+          # as build-args.
+          echo "GIT_COMMIT=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
+          if [[ -z "$(git status --porcelain)" ]]; then
+            echo "GIT_TREE_STATE=clean" >> "$GITHUB_ENV"
+          else
+            echo "GIT_TREE_STATE=dirty" >> "$GITHUB_ENV"
+          fi
+          echo "BUILD_DATE=$(date -u +'%Y-%m-%dT%H:%M:%SZ')" >> "$GITHUB_ENV"
       - name: Login to GHCR
         uses: docker/login-action@v3
         with:
@@ -52,6 +62,9 @@ jobs:
           tags: ghcr.io/minuk-dev/opampcommander-web:${{ env.VERSION }}
           build-args: |
             VERSION=${{ env.VERSION }}
+            GIT_COMMIT=${{ env.GIT_COMMIT }}
+            GIT_TREE_STATE=${{ env.GIT_TREE_STATE }}
+            BUILD_DATE=${{ env.BUILD_DATE }}
           provenance: false
           cache-from: type=gha,scope=opampcommander-web
           cache-to: type=gha,mode=max,scope=opampcommander-web

--- a/web/Dockerfile
+++ b/web/Dockerfile
@@ -22,9 +22,20 @@ WORKDIR /app
 # without a separate runtime lookup. Required — fail the build rather
 # than silently shipping the stale package.json fallback when CI forgets
 # to pass it. For local builds, pass e.g. `--build-arg VERSION=dev`.
+#
+# GIT_COMMIT/GIT_TREE_STATE/BUILD_DATE mirror the apiserver's version payload
+# (api/v1/version). Git isn't available in this build context (only ./web is
+# copied), so CI computes them and passes them in; they're optional and
+# default to empty for local builds.
 ARG VERSION
+ARG GIT_COMMIT=""
+ARG GIT_TREE_STATE=""
+ARG BUILD_DATE=""
 ENV NEXT_TELEMETRY_DISABLED=1 \
-    NEXT_PUBLIC_WEB_VERSION=${VERSION}
+    NEXT_PUBLIC_WEB_VERSION=${VERSION} \
+    NEXT_PUBLIC_WEB_GIT_COMMIT=${GIT_COMMIT} \
+    NEXT_PUBLIC_WEB_GIT_TREE_STATE=${GIT_TREE_STATE} \
+    NEXT_PUBLIC_WEB_BUILD_DATE=${BUILD_DATE}
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
 RUN test -n "${VERSION}" || (echo "ERROR: VERSION build-arg is required (pass --build-arg VERSION=...)" >&2 && exit 1) \

--- a/web/app/version/page.tsx
+++ b/web/app/version/page.tsx
@@ -2,7 +2,7 @@ import { Alert, Box, Card, CardContent, Stack, Typography } from '@mui/material'
 import PageHeader from '@/components/PageHeader';
 import JsonBlock from '@/components/JsonBlock';
 import { serverGet } from '@/lib/server-api';
-import { WEB_VERSION } from '@/lib/web-version';
+import { getWebVersionInfo } from '@/lib/web-version';
 
 function InfoRows({ entries }: { entries: Array<[string, unknown]> }) {
   return (
@@ -25,7 +25,7 @@ function InfoRows({ entries }: { entries: Array<[string, unknown]> }) {
 // token from the httpOnly session cookie (see lib/server-api). No client-side
 // effect/loading state needed — the page streams in already populated.
 export default async function VersionPage() {
-  const webInfo = { version: WEB_VERSION };
+  const webInfo = getWebVersionInfo();
 
   let apiInfo: Record<string, unknown> | null = null;
   let error: string | null = null;

--- a/web/components/VersionFooter.tsx
+++ b/web/components/VersionFooter.tsx
@@ -3,7 +3,7 @@
 import { Box, Stack, Tooltip, Typography } from '@mui/material';
 import Link from 'next/link';
 import { fetcher, useSWRImmutable } from '@/lib/swr';
-import { WEB_VERSION } from '@/lib/web-version';
+import { WEB_BUILD, WEB_VERSION } from '@/lib/web-version';
 
 interface VersionInfo {
   gitVersion?: string;
@@ -28,6 +28,8 @@ export default function VersionFooter() {
           <div>
             <strong>web</strong>: {WEB_VERSION}
           </div>
+          {WEB_BUILD.gitCommit && <div>commit: {WEB_BUILD.gitCommit.slice(0, 12)}</div>}
+          {WEB_BUILD.buildDate && <div>built: {WEB_BUILD.buildDate}</div>}
           {info ? (
             <>
               {info.gitVersion && (

--- a/web/lib/web-version.test.ts
+++ b/web/lib/web-version.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { getWebVersionInfo, parseMajorMinor } from './web-version';
+
+describe('parseMajorMinor', () => {
+  it('parses a snapshot version', () => {
+    expect(parseMajorMinor('0.1.41-SNAPSHOT-14bc29e')).toEqual({ major: '0', minor: '1' });
+  });
+
+  it('parses a plain semver', () => {
+    expect(parseMajorMinor('1.20.3')).toEqual({ major: '1', minor: '20' });
+  });
+
+  it('tolerates a leading v', () => {
+    expect(parseMajorMinor('v2.5.0')).toEqual({ major: '2', minor: '5' });
+  });
+
+  it('returns empty parts for an unrecognized version', () => {
+    expect(parseMajorMinor('unknown')).toEqual({ major: '', minor: '' });
+  });
+});
+
+describe('getWebVersionInfo', () => {
+  it('reports Node runtime fields', () => {
+    const info = getWebVersionInfo();
+    expect(info.nodeVersion).toBe(process.version);
+    expect(info.platform).toBe(`${process.platform}/${process.arch}`);
+    expect(info.nextVersion).toMatch(/\d+\.\d+/);
+  });
+});

--- a/web/lib/web-version.ts
+++ b/web/lib/web-version.ts
@@ -1,7 +1,63 @@
-// Web app version. In release/container builds, NEXT_PUBLIC_WEB_VERSION is
-// injected at `next build` time from scripts/version.sh — the same source
-// that tags the image — so the footer matches the deployed image tag. In
-// local dev (no env var), fall back to package.json's version.
+// Web app version & build metadata, the web-side analog of the apiserver's
+// /api/v1/version payload (see api/v1/version/version.go).
+//
+// Two sources feed it:
+//   - Build-time fields (gitVersion/gitCommit/gitTreeState/buildDate) are
+//     baked at `next build` from NEXT_PUBLIC_* env vars injected by
+//     web/Dockerfile, which CI fills from git — the same source that tags the
+//     image, so the page matches the deployed image. NEXT_PUBLIC_* vars are
+//     inlined into both the server and client bundles. In local dev (no env
+//     vars) they fall back to package.json / placeholders so the page still
+//     renders.
+//   - Runtime fields (nodeVersion/platform) come from `process` and are only
+//     meaningful server-side, so getWebVersionInfo() must be called from a
+//     Server Component / route handler, never the browser.
 import pkg from '../package.json';
 
-export const WEB_VERSION: string = process.env.NEXT_PUBLIC_WEB_VERSION || pkg.version;
+const gitVersion = process.env.NEXT_PUBLIC_WEB_VERSION || pkg.version;
+const gitCommit = process.env.NEXT_PUBLIC_WEB_GIT_COMMIT || '';
+const gitTreeState = process.env.NEXT_PUBLIC_WEB_GIT_TREE_STATE || '';
+const buildDate = process.env.NEXT_PUBLIC_WEB_BUILD_DATE || '';
+
+// Backward-compatible single-string export; safe in client components.
+export const WEB_VERSION: string = gitVersion;
+
+// Build-time metadata, safe in client components (NEXT_PUBLIC_* is inlined).
+// Excludes the Node runtime fields, which only exist server-side.
+export const WEB_BUILD = { gitVersion, gitCommit, gitTreeState, buildDate };
+
+export interface WebVersionInfo {
+  major: string;
+  minor: string;
+  gitVersion: string;
+  gitCommit: string;
+  gitTreeState: string;
+  buildDate: string;
+  nodeVersion: string;
+  nextVersion: string;
+  platform: string;
+}
+
+// Pulls "0" / "1" out of versions like "0.1.41-SNAPSHOT-14bc29e" or "v0.1.0".
+// Returns empty strings when the version isn't in a recognizable form.
+export function parseMajorMinor(version: string): { major: string; minor: string } {
+  const m = version.match(/^v?(\d+)\.(\d+)/);
+  return { major: m?.[1] ?? '', minor: m?.[2] ?? '' };
+}
+
+// Server-only: reads Node runtime fields (process.version/platform) that are
+// undefined in the browser bundle. Call from RSC / route handlers only.
+export function getWebVersionInfo(): WebVersionInfo {
+  const { major, minor } = parseMajorMinor(gitVersion);
+  return {
+    major,
+    minor,
+    gitVersion,
+    gitCommit,
+    gitTreeState,
+    buildDate,
+    nodeVersion: process.version,
+    nextVersion: pkg.dependencies.next,
+    platform: `${process.platform}/${process.arch}`,
+  };
+}


### PR DESCRIPTION
## What

The web version page only showed a single version string, while the apiserver's `/api/v1/version` exposes the full payload (`major`, `minor`, `gitCommit`, `gitTreeState`, `buildDate`, `goVersion`, `platform`, …). This makes the web side report the same kind of info.

Before, the **Web** card showed only `version: 0.1.x`. Now it mirrors the **API server** card.

## Changes

- **`web/lib/web-version.ts`** — `getWebVersionInfo()` builds a `WebVersionInfo`:
  - build-time fields (`gitVersion`/`gitCommit`/`gitTreeState`/`buildDate`) from `NEXT_PUBLIC_*` env vars (baked at `next build`, fall back to `package.json`/empty in local dev),
  - runtime fields (`nodeVersion` = `process.version`, `platform` = `process.platform/arch`) — the analog of Go's `runtime.Version()`/`GOOS/GOARCH`,
  - `major`/`minor` parsed from the version, `nextVersion` standing in for the apiserver's `compiler`.
  - Client-safe `WEB_BUILD` export for the footer.
- **`web/app/version/page.tsx`** — renders the full web info, symmetric with the API card.
- **`web/components/VersionFooter.tsx`** — footer tooltip's `web` line gains `commit` + `built`.
- **`web/Dockerfile`** — accepts `GIT_COMMIT`/`GIT_TREE_STATE`/`BUILD_DATE` build-args and bakes them as `NEXT_PUBLIC_*` (git isn't available in the `./web` build context).
- **`.github/workflows/web-release.yaml`** — computes those from git and passes them through.

## Notes

- In local `next dev`/non-CI builds, `gitCommit`/`buildDate` show empty; `nodeVersion`/`platform`/`major`/`minor` are always populated. Full info appears in CI-built images.

## Testing

- `web/lib/web-version.test.ts` added (parseMajorMinor + runtime fields).
- `vitest`, `eslint`, `tsc --noEmit`, `prettier --check`, and a production `next build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)