### PR TITLE
feat(web): add per-table column picker with persisted visibility

### DIFF
--- a/web/app/agentgroups/page.tsx
+++ b/web/app/agentgroups/page.tsx
@@ -32,12 +32,25 @@ import PageHeader from '@/components/PageHeader';
 import ConfirmDialog from '@/components/ConfirmDialog';
 import PaginationFooter from '@/components/PaginationFooter';
 import RowActionsMenu from '@/components/RowActionsMenu';
+import ColumnPicker from '@/components/ColumnPicker';
 import TimeDisplay from '@/components/TimeDisplay';
 import { useNamespace } from '@/components/NamespaceProvider';
 import { api } from '@/lib/api-client';
+import { type ColumnConfig, useColumnVisibility } from '@/lib/column-visibility';
 import { useCursorPagination } from '@/lib/pagination';
 import type { AgentGroup } from '@/lib/types';
 import AgentGroupEditDialog from './AgentGroupEditDialog';
+
+// Columns for the agent groups table. `name` is locked (the row identifier);
+// the rest are toggleable via the column picker and persisted per user.
+const AGENT_GROUP_COLUMNS: ColumnConfig[] = [
+  { id: 'name', label: 'Name', locked: true },
+  { id: 'priority', label: 'Priority' },
+  { id: 'agents', label: 'Agents' },
+  { id: 'connected', label: 'Connected' },
+  { id: 'healthy', label: 'Healthy' },
+  { id: 'created', label: 'Created' },
+];
 
 export default function AgentGroupsPage() {
   const { namespace } = useNamespace();
@@ -49,6 +62,10 @@ export default function AgentGroupsPage() {
   // the agents list (which also hides disconnected by default); the toggle
   // switches it to the full membership count.
   const [showDisconnected, setShowDisconnected] = useState(false);
+
+  const { visible, isVisible, toggle } = useColumnVisibility('agentgroups', AGENT_GROUP_COLUMNS);
+  // +1 for the always-present Actions column.
+  const colSpan = AGENT_GROUP_COLUMNS.filter((c) => isVisible(c.id)).length + 1;
 
   const pagination = useCursorPagination<AgentGroup>(`/api/v1/namespaces/${namespace}/agentgroups`);
   const { items: groups, isLoading: loading, error: fetchError, refresh } = pagination;
@@ -108,83 +125,99 @@ export default function AgentGroupsPage() {
         </Alert>
       )}
 
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 1 }}>
+        <ColumnPicker columns={AGENT_GROUP_COLUMNS} visible={visible} onToggle={toggle} />
+      </Box>
+
       <TableContainer component={Paper}>
         <Table>
           <TableHead>
             <TableRow>
-              <TableCell>Name</TableCell>
-              <TableCell>Priority</TableCell>
-              <TableCell>Agents</TableCell>
-              <TableCell>Connected</TableCell>
-              <TableCell>Healthy</TableCell>
-              <TableCell>Created</TableCell>
+              {isVisible('name') && <TableCell>Name</TableCell>}
+              {isVisible('priority') && <TableCell>Priority</TableCell>}
+              {isVisible('agents') && <TableCell>Agents</TableCell>}
+              {isVisible('connected') && <TableCell>Connected</TableCell>}
+              {isVisible('healthy') && <TableCell>Healthy</TableCell>}
+              {isVisible('created') && <TableCell>Created</TableCell>}
               <TableCell align="right">Actions</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
             {loading ? (
               <TableRow>
-                <TableCell colSpan={7} align="center">
+                <TableCell colSpan={colSpan} align="center">
                   <CircularProgress size={24} />
                 </TableCell>
               </TableRow>
             ) : groups.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={7} align="center">
+                <TableCell colSpan={colSpan} align="center">
                   No agent groups
                 </TableCell>
               </TableRow>
             ) : (
               groups.map((g) => (
                 <TableRow key={g.metadata.name} hover>
-                  <TableCell>
-                    <Tooltip title="View agents in this group" placement="right">
-                      <Link
-                        href={`/agents?agentGroup=${encodeURIComponent(g.metadata.name)}`}
-                        style={{ fontWeight: 500 }}
+                  {isVisible('name') && (
+                    <TableCell>
+                      <Tooltip title="View agents in this group" placement="right">
+                        <Link
+                          href={`/agents?agentGroup=${encodeURIComponent(g.metadata.name)}`}
+                          style={{ fontWeight: 500 }}
+                        >
+                          {g.metadata.name}
+                        </Link>
+                      </Tooltip>
+                    </TableCell>
+                  )}
+                  {isVisible('priority') && <TableCell>{g.spec.priority}</TableCell>}
+                  {isVisible('agents') && (
+                    <TableCell>
+                      <Tooltip
+                        title={
+                          showDisconnected
+                            ? 'All agents in this group (connected + disconnected)'
+                            : 'Connected agents in this group'
+                        }
+                        placement="top"
                       >
-                        {g.metadata.name}
-                      </Link>
-                    </Tooltip>
-                  </TableCell>
-                  <TableCell>{g.spec.priority}</TableCell>
-                  <TableCell>
-                    <Tooltip
-                      title={
-                        showDisconnected
-                          ? 'All agents in this group (connected + disconnected)'
-                          : 'Connected agents in this group'
-                      }
-                      placement="top"
-                    >
+                        <Chip
+                          component={Link}
+                          href={`/agents?agentGroup=${encodeURIComponent(g.metadata.name)}`}
+                          label={
+                            showDisconnected ? g.status.numAgents : g.status.numConnectedAgents
+                          }
+                          size="small"
+                          clickable
+                        />
+                      </Tooltip>
+                    </TableCell>
+                  )}
+                  {isVisible('connected') && (
+                    <TableCell>
                       <Chip
-                        component={Link}
-                        href={`/agents?agentGroup=${encodeURIComponent(g.metadata.name)}`}
-                        label={showDisconnected ? g.status.numAgents : g.status.numConnectedAgents}
+                        label={`${g.status.numConnectedAgents}/${g.status.numAgents}`}
+                        color="success"
                         size="small"
-                        clickable
+                        variant="outlined"
                       />
-                    </Tooltip>
-                  </TableCell>
-                  <TableCell>
-                    <Chip
-                      label={`${g.status.numConnectedAgents}/${g.status.numAgents}`}
-                      color="success"
-                      size="small"
-                      variant="outlined"
-                    />
-                  </TableCell>
-                  <TableCell>
-                    <Chip
-                      label={`${g.status.numHealthyAgents}/${g.status.numAgents}`}
-                      color={g.status.numUnhealthyAgents ? 'warning' : 'success'}
-                      size="small"
-                      variant="outlined"
-                    />
-                  </TableCell>
-                  <TableCell>
-                    <TimeDisplay value={g.metadata.createdAt} />
-                  </TableCell>
+                    </TableCell>
+                  )}
+                  {isVisible('healthy') && (
+                    <TableCell>
+                      <Chip
+                        label={`${g.status.numHealthyAgents}/${g.status.numAgents}`}
+                        color={g.status.numUnhealthyAgents ? 'warning' : 'success'}
+                        size="small"
+                        variant="outlined"
+                      />
+                    </TableCell>
+                  )}
+                  {isVisible('created') && (
+                    <TableCell>
+                      <TimeDisplay value={g.metadata.createdAt} />
+                    </TableCell>
+                  )}
                   <TableCell align="right">
                     <RowActionsMenu
                       actions={[

--- a/web/app/agents/[id]/page.tsx
+++ b/web/app/agents/[id]/page.tsx
@@ -30,32 +30,10 @@ import JsonBlock from '@/components/JsonBlock';
 import TimeDisplay from '@/components/TimeDisplay';
 import { useNamespace } from '@/components/NamespaceProvider';
 import { api } from '@/lib/api-client';
-import { agentDeleteConfirmMessage, deleteAgent } from '@/lib/agents';
+import { agentDeleteConfirmMessage, capabilityNames, deleteAgent } from '@/lib/agents';
 import { useApi } from '@/lib/swr';
 import type { Agent } from '@/lib/types';
 import AgentEditDialog from './AgentEditDialog';
-
-function capabilityNames(bitmask: number | undefined): string[] {
-  if (!bitmask) return [];
-  const table: Array<[number, string]> = [
-    [1, 'ReportsStatus'],
-    [2, 'AcceptsRemoteConfig'],
-    [4, 'ReportsEffectiveConfig'],
-    [8, 'AcceptsPackages'],
-    [16, 'ReportsPackageStatuses'],
-    [32, 'ReportsOwnTraces'],
-    [64, 'ReportsOwnMetrics'],
-    [128, 'ReportsOwnLogs'],
-    [256, 'AcceptsOpAMPConnectionSettings'],
-    [512, 'AcceptsOtherConnectionSettings'],
-    [1024, 'AcceptsRestartCommand'],
-    [2048, 'ReportsHealth'],
-    [4096, 'ReportsRemoteConfig'],
-    [8192, 'ReportsHeartbeat'],
-    [16384, 'ReportsAvailableComponents'],
-  ];
-  return table.filter(([b]) => (bitmask & b) !== 0).map(([, name]) => name);
-}
 
 function AgentDetailInner() {
   const params = useParams<{ id: string }>();

--- a/web/app/agents/page.tsx
+++ b/web/app/agents/page.tsx
@@ -41,9 +41,11 @@ import PageHeader from '@/components/PageHeader';
 import PaginationFooter from '@/components/PaginationFooter';
 import RowActionsMenu, { type RowAction } from '@/components/RowActionsMenu';
 import ConfirmDialog from '@/components/ConfirmDialog';
+import ColumnPicker from '@/components/ColumnPicker';
 import TimeDisplay from '@/components/TimeDisplay';
 import { useNamespace } from '@/components/NamespaceProvider';
-import { agentDeleteConfirmMessage, deleteAgent } from '@/lib/agents';
+import { agentDeleteConfirmMessage, capabilityNames, deleteAgent } from '@/lib/agents';
+import { type ColumnConfig, useColumnVisibility } from '@/lib/column-visibility';
 import { useCursorPagination } from '@/lib/pagination';
 import { useApi } from '@/lib/swr';
 import type { Agent, AgentGroup, ListResponse } from '@/lib/types';
@@ -60,6 +62,42 @@ function attrMatchesDescription(agent: Agent, lcNeedle: string): boolean {
   ];
   return collect.some(
     ([k, v]) => k.toLowerCase().includes(lcNeedle) || v.toLowerCase().includes(lcNeedle),
+  );
+}
+
+// Columns for the agents table. `instanceUid` is locked (the row identifier);
+// `sequence` and the verbose capability/attribute columns are off by default so
+// the table stays readable, and users opt into them via the column picker.
+const AGENT_COLUMNS: ColumnConfig[] = [
+  { id: 'instanceUid', label: 'Instance UID', locked: true },
+  { id: 'connected', label: 'Connected' },
+  { id: 'healthy', label: 'Healthy' },
+  { id: 'type', label: 'Type' },
+  { id: 'lastReported', label: 'Last Reported' },
+  { id: 'sequence', label: 'Sequence', defaultVisible: false },
+  { id: 'capabilities', label: 'Capabilities', defaultVisible: false },
+  {
+    id: 'identifyingAttributes',
+    label: 'Description (identifying attributes)',
+    defaultVisible: false,
+  },
+  {
+    id: 'nonIdentifyingAttributes',
+    label: 'Description (non-identifying attributes)',
+    defaultVisible: false,
+  },
+];
+
+// Render an attribute map as compact key=value chips for a table cell.
+function AttrChips({ attrs }: { attrs: Record<string, string> | undefined }) {
+  const entries = Object.entries(attrs ?? {});
+  if (entries.length === 0) return <>-</>;
+  return (
+    <Stack direction="row" gap={0.5} flexWrap="wrap" sx={{ maxWidth: 320 }}>
+      {entries.map(([k, v]) => (
+        <Chip key={k} label={`${k}=${v}`} size="small" variant="outlined" />
+      ))}
+    </Stack>
   );
 }
 
@@ -82,6 +120,10 @@ function AgentsInner() {
   // hidden we pass connected=true so the server filters them out (keeping the
   // paginated total accurate) rather than filtering the current page client-side.
   const [showDisconnected, setShowDisconnected] = useState(false);
+
+  const { visible, isVisible, toggle } = useColumnVisibility('agents', AGENT_COLUMNS);
+  // +1 for the always-present Actions column.
+  const colSpan = AGENT_COLUMNS.filter((c) => isVisible(c.id)).length + 1;
 
   // The three search modes hit different endpoints; description mode reuses the
   // plain list and filters client-side (see visibleAgents below).
@@ -338,29 +380,40 @@ function AgentsInner() {
         </Alert>
       )}
 
+      <Box sx={{ display: 'flex', justifyContent: 'flex-end', mb: 1 }}>
+        <ColumnPicker columns={AGENT_COLUMNS} visible={visible} onToggle={toggle} />
+      </Box>
+
       <TableContainer component={Paper}>
         <Table>
           <TableHead>
             <TableRow>
-              <TableCell>Instance UID</TableCell>
-              <TableCell>Connected</TableCell>
-              <TableCell>Healthy</TableCell>
-              <TableCell>Type</TableCell>
-              <TableCell>Last Reported</TableCell>
-              <TableCell>Sequence</TableCell>
+              {isVisible('instanceUid') && <TableCell>Instance UID</TableCell>}
+              {isVisible('connected') && <TableCell>Connected</TableCell>}
+              {isVisible('healthy') && <TableCell>Healthy</TableCell>}
+              {isVisible('type') && <TableCell>Type</TableCell>}
+              {isVisible('lastReported') && <TableCell>Last Reported</TableCell>}
+              {isVisible('sequence') && <TableCell>Sequence</TableCell>}
+              {isVisible('capabilities') && <TableCell>Capabilities</TableCell>}
+              {isVisible('identifyingAttributes') && (
+                <TableCell>Description (identifying attributes)</TableCell>
+              )}
+              {isVisible('nonIdentifyingAttributes') && (
+                <TableCell>Description (non-identifying attributes)</TableCell>
+              )}
               <TableCell align="right">Actions</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
             {loading ? (
               <TableRow>
-                <TableCell colSpan={7} align="center">
+                <TableCell colSpan={colSpan} align="center">
                   <CircularProgress size={24} />
                 </TableCell>
               </TableRow>
             ) : visibleAgents.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={7} align="center">
+                <TableCell colSpan={colSpan} align="center">
                   {descParam
                     ? `No agents on this page match description "${descParam}"`
                     : 'No agents found'}
@@ -379,28 +432,64 @@ function AgentsInner() {
                     '&:hover': { bgcolor: 'action.hover' },
                   }}
                 >
-                  <TableCell sx={{ fontFamily: 'monospace' }}>
-                    {agent.metadata.instanceUid}
-                  </TableCell>
-                  <TableCell>
-                    <Chip
-                      label={agent.status.connected ? 'Connected' : 'Disconnected'}
-                      color={agent.status.connected ? 'success' : 'default'}
-                      size="small"
-                    />
-                  </TableCell>
-                  <TableCell>
-                    <Chip
-                      label={agent.status.componentHealth?.healthy ? 'Healthy' : 'Unhealthy'}
-                      color={agent.status.componentHealth?.healthy ? 'success' : 'warning'}
-                      size="small"
-                    />
-                  </TableCell>
-                  <TableCell>{agent.status.connectionType || '-'}</TableCell>
-                  <TableCell>
-                    <TimeDisplay value={agent.status.lastReportedAt} />
-                  </TableCell>
-                  <TableCell>{agent.status.sequenceNum ?? '-'}</TableCell>
+                  {isVisible('instanceUid') && (
+                    <TableCell sx={{ fontFamily: 'monospace' }}>
+                      {agent.metadata.instanceUid}
+                    </TableCell>
+                  )}
+                  {isVisible('connected') && (
+                    <TableCell>
+                      <Chip
+                        label={agent.status.connected ? 'Connected' : 'Disconnected'}
+                        color={agent.status.connected ? 'success' : 'default'}
+                        size="small"
+                      />
+                    </TableCell>
+                  )}
+                  {isVisible('healthy') && (
+                    <TableCell>
+                      <Chip
+                        label={agent.status.componentHealth?.healthy ? 'Healthy' : 'Unhealthy'}
+                        color={agent.status.componentHealth?.healthy ? 'success' : 'warning'}
+                        size="small"
+                      />
+                    </TableCell>
+                  )}
+                  {isVisible('type') && <TableCell>{agent.status.connectionType || '-'}</TableCell>}
+                  {isVisible('lastReported') && (
+                    <TableCell>
+                      <TimeDisplay value={agent.status.lastReportedAt} />
+                    </TableCell>
+                  )}
+                  {isVisible('sequence') && (
+                    <TableCell>{agent.status.sequenceNum ?? '-'}</TableCell>
+                  )}
+                  {isVisible('capabilities') && (
+                    <TableCell>
+                      {(() => {
+                        const caps = capabilityNames(agent.metadata.capabilities);
+                        return caps.length === 0 ? (
+                          '-'
+                        ) : (
+                          <Stack direction="row" gap={0.5} flexWrap="wrap" sx={{ maxWidth: 320 }}>
+                            {caps.map((c) => (
+                              <Chip key={c} label={c} size="small" variant="outlined" />
+                            ))}
+                          </Stack>
+                        );
+                      })()}
+                    </TableCell>
+                  )}
+                  {isVisible('identifyingAttributes') && (
+                    <TableCell>
+                      <AttrChips attrs={agent.metadata.description?.identifyingAttributes} />
+                    </TableCell>
+                  )}
+                  {isVisible('nonIdentifyingAttributes') && (
+                    <TableCell>
+                      <AttrChips attrs={agent.metadata.description?.nonIdentifyingAttributes} />
+                    </TableCell>
+                  )}
                   <TableCell align="right">
                     <RowActionsMenu
                       actions={[

--- a/web/components/ColumnPicker.tsx
+++ b/web/components/ColumnPicker.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Checkbox,
+  IconButton,
+  ListItemIcon,
+  ListItemText,
+  Menu,
+  MenuItem,
+  Tooltip,
+} from '@mui/material';
+import { ViewColumn as ViewColumnIcon } from '@mui/icons-material';
+import type { ColumnConfig, ColumnVisibility } from '@/lib/column-visibility';
+
+interface Props {
+  columns: ColumnConfig[];
+  visible: ColumnVisibility;
+  onToggle: (id: string) => void;
+}
+
+// A button that opens a checklist of the table's columns, letting the user pick
+// which ones are shown. Locked columns appear checked and disabled so the full
+// set stays discoverable. Pair with `useColumnVisibility` to persist the choice.
+export default function ColumnPicker({ columns, visible, onToggle }: Props) {
+  const [anchor, setAnchor] = useState<HTMLElement | null>(null);
+
+  return (
+    <>
+      <Tooltip title="Choose columns">
+        <IconButton size="small" onClick={(e) => setAnchor(e.currentTarget)} aria-label="Columns">
+          <ViewColumnIcon />
+        </IconButton>
+      </Tooltip>
+      <Menu anchorEl={anchor} open={Boolean(anchor)} onClose={() => setAnchor(null)}>
+        {columns.map((c) => {
+          const checked = c.locked ? true : (visible[c.id] ?? true);
+          return (
+            <MenuItem key={c.id} dense disabled={c.locked} onClick={() => onToggle(c.id)}>
+              <ListItemIcon sx={{ minWidth: 0 }}>
+                <Checkbox edge="start" size="small" checked={checked} tabIndex={-1} disableRipple />
+              </ListItemIcon>
+              <ListItemText primary={c.label} />
+            </MenuItem>
+          );
+        })}
+      </Menu>
+    </>
+  );
+}

--- a/web/components/ThemeRegistry.tsx
+++ b/web/components/ThemeRegistry.tsx
@@ -14,6 +14,16 @@ const theme = createTheme({
       main: '#dc004e',
     },
   },
+  components: {
+    // Shrink the root font size so all rem-based typography scales down
+    // uniformly (16px → 14px). Layout spacing is px-based and stays put, so
+    // only the text gets smaller — a global, even reduction.
+    MuiCssBaseline: {
+      styleOverrides: {
+        html: { fontSize: '87.5%' },
+      },
+    },
+  },
 });
 
 export default function ThemeRegistry({ children }: { children: ReactNode }) {

--- a/web/lib/agents.ts
+++ b/web/lib/agents.ts
@@ -10,3 +10,28 @@ export function agentDeleteConfirmMessage(instanceUid: string): string {
 export function deleteAgent(namespace: string, instanceUid: string): Promise<void> {
   return api.delete(`/api/v1/namespaces/${namespace}/agents/${instanceUid}`);
 }
+
+// Decode an OpAMP AgentCapabilities bitmask into the individual capability
+// names. Shared by the agents list and detail pages so the bit table lives in
+// one place.
+export function capabilityNames(bitmask: number | undefined): string[] {
+  if (!bitmask) return [];
+  const table: Array<[number, string]> = [
+    [1, 'ReportsStatus'],
+    [2, 'AcceptsRemoteConfig'],
+    [4, 'ReportsEffectiveConfig'],
+    [8, 'AcceptsPackages'],
+    [16, 'ReportsPackageStatuses'],
+    [32, 'ReportsOwnTraces'],
+    [64, 'ReportsOwnMetrics'],
+    [128, 'ReportsOwnLogs'],
+    [256, 'AcceptsOpAMPConnectionSettings'],
+    [512, 'AcceptsOtherConnectionSettings'],
+    [1024, 'AcceptsRestartCommand'],
+    [2048, 'ReportsHealth'],
+    [4096, 'ReportsRemoteConfig'],
+    [8192, 'ReportsHeartbeat'],
+    [16384, 'ReportsAvailableComponents'],
+  ];
+  return table.filter(([b]) => (bitmask & b) !== 0).map(([, name]) => name);
+}

--- a/web/lib/column-visibility.test.ts
+++ b/web/lib/column-visibility.test.ts
@@ -1,0 +1,69 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { type ColumnConfig, useColumnVisibility } from './column-visibility';
+
+const COLUMNS: ColumnConfig[] = [
+  { id: 'a', label: 'A', locked: true },
+  { id: 'b', label: 'B' }, // defaultVisible omitted -> true
+  { id: 'c', label: 'C', defaultVisible: false },
+];
+
+const KEY = 'opamp.columns.t';
+
+afterEach(() => {
+  window.localStorage.clear();
+});
+
+describe('useColumnVisibility', () => {
+  it('uses defaults when nothing is stored', () => {
+    const { result } = renderHook(() => useColumnVisibility('t', COLUMNS));
+    expect(result.current.isVisible('a')).toBe(true);
+    expect(result.current.isVisible('b')).toBe(true);
+    expect(result.current.isVisible('c')).toBe(false);
+  });
+
+  it('persists a toggle and reloads it on remount', () => {
+    const first = renderHook(() => useColumnVisibility('t', COLUMNS));
+    act(() => first.result.current.toggle('c'));
+    expect(first.result.current.isVisible('c')).toBe(true);
+    first.unmount();
+
+    const second = renderHook(() => useColumnVisibility('t', COLUMNS));
+    expect(second.result.current.isVisible('c')).toBe(true);
+  });
+
+  it('falls back to defaults on corrupt JSON', () => {
+    window.localStorage.setItem(KEY, '{ not json');
+    const { result } = renderHook(() => useColumnVisibility('t', COLUMNS));
+    expect(result.current.isVisible('c')).toBe(false);
+  });
+
+  it('ignores an incompatible schema version', () => {
+    window.localStorage.setItem(KEY, JSON.stringify({ v: 999, columns: { c: true } }));
+    const { result } = renderHook(() => useColumnVisibility('t', COLUMNS));
+    // Stored override discarded -> 'c' keeps its default (hidden).
+    expect(result.current.isVisible('c')).toBe(false);
+  });
+
+  it('ignores a missing/legacy envelope (no version field)', () => {
+    window.localStorage.setItem(KEY, JSON.stringify({ c: true }));
+    const { result } = renderHook(() => useColumnVisibility('t', COLUMNS));
+    expect(result.current.isVisible('c')).toBe(false);
+  });
+
+  it('drops non-boolean fields but keeps valid overrides', () => {
+    window.localStorage.setItem(
+      KEY,
+      JSON.stringify({ v: 1, columns: { b: 'nope', c: true, unknown: true } }),
+    );
+    const { result } = renderHook(() => useColumnVisibility('t', COLUMNS));
+    expect(result.current.isVisible('b')).toBe(true); // bad value ignored -> default
+    expect(result.current.isVisible('c')).toBe(true); // valid override applied
+  });
+
+  it('never lets a stored value turn a locked column off', () => {
+    window.localStorage.setItem(KEY, JSON.stringify({ v: 1, columns: { a: false } }));
+    const { result } = renderHook(() => useColumnVisibility('t', COLUMNS));
+    expect(result.current.isVisible('a')).toBe(true);
+  });
+});

--- a/web/lib/column-visibility.ts
+++ b/web/lib/column-visibility.ts
@@ -1,0 +1,140 @@
+'use client';
+
+// Per-table column visibility, persisted to localStorage so each user's choice
+// of which columns to show survives reloads. Purely presentational UI state
+// (like the timezone preference in `preferences.ts`), so localStorage — keyed
+// per table — is the right home; nothing is ever sent to the server.
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+
+export interface ColumnConfig {
+  // Stable identifier used as the persistence key and React key. Renaming an id
+  // resets that column to its default for existing users.
+  id: string;
+  // Label shown in the column picker menu.
+  label: string;
+  // Shown when the user has no saved preference. Defaults to true.
+  defaultVisible?: boolean;
+  // Locked columns are always visible and cannot be toggled off (e.g. the
+  // primary identifier column). They still appear in the picker, checked and
+  // disabled, so the full column set is discoverable.
+  locked?: boolean;
+}
+
+export type ColumnVisibility = Record<string, boolean>;
+
+const KEY_PREFIX = 'opamp.columns.';
+
+// Persisted format version. Treat anything that doesn't match the current
+// schema (older/newer versions, hand-edited junk, an unrelated value that
+// happens to share the key) as incompatible and fall back to defaults. Bump
+// this whenever the stored shape changes incompatibly.
+const SCHEMA_VERSION = 1;
+
+// The on-disk shape. Kept deliberately small and explicit so we can validate it
+// field-by-field on read — localStorage is shared, user-writable, and may carry
+// values written by an older or newer build, so we never trust its contents.
+interface StoredVisibility {
+  v: number;
+  columns: Record<string, boolean>;
+}
+
+function storageKey(table: string): string {
+  return `${KEY_PREFIX}${table}`;
+}
+
+function computeDefaults(columns: ColumnConfig[]): ColumnVisibility {
+  const out: ColumnVisibility = {};
+  for (const c of columns) {
+    out[c.id] = c.locked ? true : (c.defaultVisible ?? true);
+  }
+  return out;
+}
+
+// Validate an untrusted parsed value against the current schema. Returns the
+// stored column map only when the whole envelope is well-formed and the version
+// matches; otherwise null so the caller can fall back to defaults.
+function parseStored(value: unknown): Record<string, boolean> | null {
+  if (typeof value !== 'object' || value === null) return null;
+  const obj = value as Record<string, unknown>;
+  if (obj.v !== SCHEMA_VERSION) return null;
+  const cols = obj.columns;
+  if (typeof cols !== 'object' || cols === null) return null;
+  const out: Record<string, boolean> = {};
+  for (const [k, v] of Object.entries(cols)) {
+    // Drop any non-boolean entry rather than rejecting the whole blob; a single
+    // bad field shouldn't wipe the user's other choices.
+    if (typeof v === 'boolean') out[k] = v;
+  }
+  return out;
+}
+
+// Merge persisted overrides onto the defaults. Unknown / removed column ids in
+// storage are ignored, and columns added since the preference was saved fall
+// back to their default — so the table keeps working across schema changes.
+// Any corruption or version mismatch degrades silently to defaults.
+function readVisibility(
+  table: string,
+  columns: ColumnConfig[],
+  defaults: ColumnVisibility,
+): ColumnVisibility {
+  if (typeof window === 'undefined') return defaults;
+  try {
+    const raw = window.localStorage.getItem(storageKey(table));
+    if (!raw) return defaults;
+    const stored = parseStored(JSON.parse(raw));
+    if (!stored) return defaults;
+    const out = { ...defaults };
+    for (const c of columns) {
+      if (c.locked) continue;
+      if (typeof stored[c.id] === 'boolean') out[c.id] = stored[c.id];
+    }
+    return out;
+  } catch {
+    return defaults;
+  }
+}
+
+function writeVisibility(table: string, visible: ColumnVisibility): void {
+  if (typeof window === 'undefined') return;
+  try {
+    const payload: StoredVisibility = { v: SCHEMA_VERSION, columns: visible };
+    window.localStorage.setItem(storageKey(table), JSON.stringify(payload));
+  } catch {
+    // Best-effort: the choice just won't persist across reloads.
+  }
+}
+
+export interface UseColumnVisibility {
+  visible: ColumnVisibility;
+  isVisible: (id: string) => boolean;
+  toggle: (id: string) => void;
+}
+
+// Pass a module-level `columns` array (stable identity) so the persisted values
+// are read once after mount. Starting from defaults keeps the server render and
+// first client render identical (hydration-safe); the saved values apply after
+// mount, matching the timezone-preference pattern.
+export function useColumnVisibility(table: string, columns: ColumnConfig[]): UseColumnVisibility {
+  const defaults = useMemo(() => computeDefaults(columns), [columns]);
+  const [visible, setVisible] = useState<ColumnVisibility>(defaults);
+
+  useEffect(() => {
+    setVisible(readVisibility(table, columns, defaults));
+  }, [table, columns, defaults]);
+
+  const toggle = useCallback(
+    (id: string) => {
+      setVisible((prev) => {
+        const next = { ...prev, [id]: !prev[id] };
+        writeVisibility(table, next);
+        return next;
+      });
+    },
+    [table],
+  );
+
+  const isVisible = useCallback((id: string) => visible[id] ?? true, [visible]);
+
+  return { visible, isVisible, toggle };
+}


### PR DESCRIPTION
## Summary
- Adds a **column picker** (▥ button) to the right of the **Agents** and **Agent Groups** tables so users can choose which columns are shown.
- The selection is **persisted to `localStorage` per table**, so it survives reloads. The stored value is a **versioned envelope** (`{"v":1,"columns":{…}}`) that is **defensively validated** on read — corrupt JSON, an unknown/legacy shape, a schema-version mismatch, or non-boolean fields all degrade gracefully to defaults (and a locked column can never be forced off).
- **Agents table:** `Sequence` is now **hidden by default**. Three columns are added as **opt-in** (hidden by default): `Capabilities`, `Description (identifying attributes)`, `Description (non-identifying attributes)`.
- The capability bitmask decoder is lifted into `lib/agents.ts` so the list and detail pages share one implementation.
- **Global font size** reduced (root `16px → 14px` via a `MuiCssBaseline` override) so all rem-based typography scales down uniformly while px-based spacing stays put.

## Implementation notes
- New `lib/column-visibility.ts` — `useColumnVisibility(table, columns)` hook. Hydration-safe (starts from defaults, reads persisted values after mount, matching the existing timezone-preference pattern). `locked` columns are always visible.
- New `components/ColumnPicker.tsx` — checklist menu; locked columns show checked + disabled so the full column set stays discoverable.
- Pages render headers/cells conditionally on visibility; `colSpan` is computed from the visible count.

## Testing
- `lib/column-visibility.test.ts` — 7 tests covering defaults, persistence across remount, corrupt JSON, incompatible/legacy envelopes, dropping non-boolean fields, and locked-column protection.
- `npx tsc --noEmit`, `npx eslint`, `npx vitest run` (56 tests) all pass.
- Verified live in the browser against the alpha backend: default columns, toggling each opt-in column (real capability/attribute data renders), and persistence across a full reload. Column picker also verified on the Agent Groups page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)