### PR TITLE
fix(apiserver): set agentgroup createdAt and omit zero deletedAt

### DIFF
--- a/pkg/apiserver/application/helper/mapper.go
+++ b/pkg/apiserver/application/helper/mapper.go
@@ -118,7 +118,7 @@ func (mapper *Mapper) MapAgentGroupToAPI(domainAgentGroup *agentmodel.AgentGroup
 			Namespace:  domainAgentGroup.Metadata.Namespace,
 			Name:       domainAgentGroup.Metadata.Name,
 			CreatedAt:  v1.NewTime(domainAgentGroup.Metadata.CreatedAt),
-			DeletedAt:  p(v1.NewTime(domainAgentGroup.Metadata.DeletedAt)),
+			DeletedAt:  mapDeletedAtToAPI(domainAgentGroup.Metadata.DeletedAt),
 			Attributes: v1.Attributes(domainAgentGroup.Metadata.Attributes),
 		},
 		Spec: v1.Spec{
@@ -292,7 +292,7 @@ func (mapper *Mapper) MapCertificateToAPI(domain *agentmodel.Certificate) *v1.Ce
 			Namespace:  domain.Metadata.Namespace,
 			Attributes: v1.Attributes(domain.Metadata.Attributes),
 			CreatedAt:  v1.NewTime(domain.Metadata.CreatedAt),
-			DeletedAt:  p(v1.NewTime(domain.Metadata.DeletedAt)),
+			DeletedAt:  mapDeletedAtToAPI(domain.Metadata.DeletedAt),
 		},
 		Spec: v1.CertificateSpec{
 			Cert:       string(domain.Spec.Cert),
@@ -941,4 +941,14 @@ func mapDeletedAtPtrToAPI(t *time.Time) *v1.Time {
 	}
 
 	return p(v1.NewTime(*t))
+}
+
+// mapDeletedAtToAPI maps a value-typed soft-delete timestamp to an optional API
+// time. A zero time means "not deleted" and maps to nil so the field is omitted.
+func mapDeletedAtToAPI(t time.Time) *v1.Time {
+	if t.IsZero() {
+		return nil
+	}
+
+	return p(v1.NewTime(t))
 }

--- a/pkg/apiserver/application/service/agentgroup/agentgroup_manage_service.go
+++ b/pkg/apiserver/application/service/agentgroup/agentgroup_manage_service.go
@@ -145,6 +145,7 @@ func (s *ManageService) CreateAgentGroup(
 
 	// Set the created condition with createdBy information
 	now := s.clock.Now()
+	domainAgentGroup.Metadata.CreatedAt = now
 	domainAgentGroup.Status.Conditions = []model.Condition{
 		{
 			Type:               model.ConditionTypeCreated,


### PR DESCRIPTION
## Summary
- `CreateAgentGroup` never set `Metadata.CreatedAt`, so agent groups were persisted with Go's zero time and the web UI showed no creation timestamp. Now set from the injected clock, matching the `certificate` and `agentremoteconfig` create services.
- `MapAgentGroupToAPI` / `MapCertificateToAPI` mapped a value-typed **zero** `DeletedAt` through `p(v1.NewTime(...))`, always producing a non-nil `*Time`. This defeated the `json:"...,omitempty"` tag and serialized `deletedAt: "0001-01-01T00:00:00Z"` for non-deleted resources — the web detail page (`group.metadata.deletedAt && ...`) then rendered a bogus "Deleted at: year 0001" row. Added `mapDeletedAtToAPI` to map a zero time to `nil` so the field is omitted.

Existing agent groups (already stored with zero createdAt) are intentionally left as-is.

## Test plan
- `go build` + `go vet` on the affected packages pass.
- New groups now carry `createdAt`; non-deleted groups/certificates no longer emit a zero `deletedAt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)