### PR TITLE
feat(apiserver): standalone mode with in-memory persistence (no MongoDB/Kafka)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,10 +79,9 @@ run-dev-server: build-dev start-dev-services
 	@sleep 2
 	go run ./cmd/apiserver/main.go --config ./configs/apiserver/dev.yaml
 
-run-standalone: build-dev start-mongodb
-	@sleep 2
-	@echo "Starting server in standalone mode (no NATS)..."
-	go run ./cmd/apiserver/main.go --config ./configs/apiserver/dev.yaml
+run-standalone: build-dev
+	@echo "Starting server in standalone mode (in-memory store, no MongoDB/Kafka)..."
+	go run ./cmd/apiserver/main.go --config ./configs/apiserver/standalone.yaml
 
 debug-server: start-dev-services
 	@echo "Starting debug server with delve..."

--- a/configs/apiserver/standalone.yaml
+++ b/configs/apiserver/standalone.yaml
@@ -1,0 +1,50 @@
+# Standalone mode: single-node, no external dependencies.
+#
+# Persistence is held in process memory (database.type "inmemory") and inter-server
+# coordination is disabled (event.type "inmemory"), so neither MongoDB nor Kafka is
+# required. All data is lost when the process exits — use this for local development,
+# demos, and small single-node deployments, not production.
+address: localhost:8080
+database:
+  type: "inmemory" # in-memory store; no MongoDB needed. Data is not persisted across restarts.
+event:
+  enabled: false # no inter-server communication in standalone mode
+  type: "inmemory" # in-memory event hub; no Kafka needed
+management:
+  address: localhost:9090
+  metric:
+    enabled: true
+    type: prometheus
+    prometheus:
+      path: /metrics
+  log:
+    level: info
+    format: text
+  trace:
+    enabled: false # no OpenTelemetry collector required in standalone mode
+auth:
+  enabled: true
+  admin:
+    username: "admin"
+    password: "admin"
+  jwt:
+    issuer: "opampcommander"
+    expire: 5m
+    refreshExpire: 168h
+    secret: "your_jwt_secret"
+    audience:
+    - "opampcommander"
+  type: "oauth2"
+  oauth2:
+    provider: github
+    clientId: "your_client_id"
+    clientSecret: "your_client_secret"
+    redirectUri: "http://localhost:8080/auth/callback"
+    state: # to prevent CSRF attacks
+      mode: jwt
+      jwt:
+        issuer: "opampcommander"
+        expire: 5m
+        secret: "your_jwt_secret"
+        audience:
+        - "opampcommander"

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/agent.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/agent.go
@@ -1,0 +1,140 @@
+package inmemory
+
+import (
+	"context"
+	"errors"
+	"strings"
+
+	"github.com/google/uuid"
+
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
+	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	"github.com/minuk-dev/opampcommander/pkg/utils/clock"
+)
+
+var (
+	_ agentport.AgentPersistencePort = (*AgentRepository)(nil)
+
+	// ErrQueryTooLong is returned when the search query exceeds the maximum length.
+	ErrQueryTooLong = errors.New("query too long: maximum length is 100 characters")
+)
+
+// AgentRepository is the in-memory implementation of [agentport.AgentPersistencePort].
+//
+// Agents have no soft-delete concept (DeleteAgent is a hard delete), matching
+// the MongoDB adapter.
+type AgentRepository struct {
+	store *store[uuid.UUID, *agentmodel.Agent]
+	clock clock.PassiveClock
+}
+
+// NewAgentRepository creates a new in-memory AgentRepository.
+func NewAgentRepository() *AgentRepository {
+	return &AgentRepository{
+		store: newStore[uuid.UUID, *agentmodel.Agent](nil),
+		clock: clock.NewRealClock(),
+	}
+}
+
+// GetAgent implements agentport.AgentPersistencePort.
+func (r *AgentRepository) GetAgent(_ context.Context, instanceUID uuid.UUID) (*agentmodel.Agent, error) {
+	return r.store.get(instanceUID, nil)
+}
+
+// PutAgent implements agentport.AgentPersistencePort.
+func (r *AgentRepository) PutAgent(_ context.Context, agent *agentmodel.Agent) error {
+	r.store.put(agent.Metadata.InstanceUID, agent)
+
+	return nil
+}
+
+// DeleteAgent implements agentport.AgentPersistencePort.
+func (r *AgentRepository) DeleteAgent(_ context.Context, instanceUID uuid.UUID) error {
+	return r.store.delete(instanceUID)
+}
+
+// ListAgents implements agentport.AgentPersistencePort.
+func (r *AgentRepository) ListAgents(
+	_ context.Context,
+	namespace string,
+	options *model.ListOptions,
+) (*model.ListResponse[*agentmodel.Agent], error) {
+	connectedOnly := options != nil && options.ConnectedOnly
+
+	return r.store.list(options, func(agent *agentmodel.Agent) bool {
+		if agent.Metadata.Namespace != namespace {
+			return false
+		}
+
+		return !connectedOnly || r.isConnected(agent)
+	})
+}
+
+// ListAgentsBySelector implements agentport.AgentPersistencePort.
+func (r *AgentRepository) ListAgentsBySelector(
+	_ context.Context,
+	selector agentmodel.AgentSelector,
+	options *model.ListOptions,
+) (*model.ListResponse[*agentmodel.Agent], error) {
+	connectedOnly := options != nil && options.ConnectedOnly
+
+	return r.store.list(options, func(agent *agentmodel.Agent) bool {
+		if !matchesSelector(agent, selector) {
+			return false
+		}
+
+		return !connectedOnly || r.isConnected(agent)
+	})
+}
+
+// SearchAgents implements agentport.AgentPersistencePort.
+func (r *AgentRepository) SearchAgents(
+	_ context.Context,
+	namespace string,
+	query string,
+	options *model.ListOptions,
+) (*model.ListResponse[*agentmodel.Agent], error) {
+	const maxQueryLength = 100
+	if len(query) > maxQueryLength {
+		return nil, ErrQueryTooLong
+	}
+
+	if query == "" {
+		return &model.ListResponse[*agentmodel.Agent]{
+			Items:              []*agentmodel.Agent{},
+			Continue:           "",
+			RemainingItemCount: 0,
+		}, nil
+	}
+
+	connectedOnly := options != nil && options.ConnectedOnly
+	prefix := strings.ToLower(query)
+
+	return r.store.list(options, func(agent *agentmodel.Agent) bool {
+		if agent.Metadata.Namespace != namespace {
+			return false
+		}
+
+		if !strings.HasPrefix(strings.ToLower(agent.Metadata.InstanceUID.String()), prefix) {
+			return false
+		}
+
+		return !connectedOnly || r.isConnected(agent)
+	})
+}
+
+// isConnected mirrors the MongoDB connected filter: the explicit Connected flag
+// plus heartbeat staleness, evaluated against the repository clock.
+func (r *AgentRepository) isConnected(agent *agentmodel.Agent) bool {
+	return agent.IsConnectedAt(r.clock.Now(), agentmodel.DefaultConnectionStaleness)
+}
+
+// agentsMatchingSelector returns every stored agent (including hard-undeletable
+// ones) matching the selector. Used by the agent-group repository to compute
+// group statistics.
+func (r *AgentRepository) agentsMatchingSelector(selector agentmodel.AgentSelector) []*agentmodel.Agent {
+	return r.store.snapshot(false, func(agent *agentmodel.Agent) bool {
+		return matchesSelector(agent, selector)
+	})
+}

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/agent.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/agent.go
@@ -32,7 +32,7 @@ type AgentRepository struct {
 // NewAgentRepository creates a new in-memory AgentRepository.
 func NewAgentRepository() *AgentRepository {
 	return &AgentRepository{
-		store: newStore[uuid.UUID, *agentmodel.Agent](nil),
+		store: newStore[uuid.UUID]((*agentmodel.Agent).Clone, nil),
 		clock: clock.NewRealClock(),
 	}
 }

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/agentgroup.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/agentgroup.go
@@ -26,7 +26,7 @@ type AgentGroupRepository struct {
 // the agent store (via agentRepo) to compute group statistics.
 func NewAgentGroupRepository(agentRepo *AgentRepository) *AgentGroupRepository {
 	return &AgentGroupRepository{
-		store: newStore[namespacedName](func(ag *agentmodel.AgentGroup) *time.Time {
+		store: newStore[namespacedName](cloneAgentGroup, func(ag *agentmodel.AgentGroup) *time.Time {
 			return &ag.Metadata.DeletedAt
 		}),
 		agentRepo: agentRepo,

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/agentgroup.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/agentgroup.go
@@ -1,0 +1,108 @@
+package inmemory
+
+import (
+	"context"
+	"time"
+
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
+	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+)
+
+var _ agentport.AgentGroupPersistencePort = (*AgentGroupRepository)(nil)
+
+// AgentGroupRepository is the in-memory implementation of
+// [agentport.AgentGroupPersistencePort].
+//
+// Like the MongoDB adapter it recomputes per-group agent statistics
+// (total/connected/healthy/...) on every read from the live agent store, so the
+// counts reflect current agent state rather than whatever was stored.
+type AgentGroupRepository struct {
+	store     *store[namespacedName, *agentmodel.AgentGroup]
+	agentRepo *AgentRepository
+}
+
+// NewAgentGroupRepository creates a new in-memory AgentGroupRepository. It reads
+// the agent store (via agentRepo) to compute group statistics.
+func NewAgentGroupRepository(agentRepo *AgentRepository) *AgentGroupRepository {
+	return &AgentGroupRepository{
+		store: newStore[namespacedName](func(ag *agentmodel.AgentGroup) *time.Time {
+			return &ag.Metadata.DeletedAt
+		}),
+		agentRepo: agentRepo,
+	}
+}
+
+// GetAgentGroup implements agentport.AgentGroupPersistencePort.
+func (r *AgentGroupRepository) GetAgentGroup(
+	_ context.Context, namespace string, name string, options *model.GetOptions,
+) (*agentmodel.AgentGroup, error) {
+	agentGroup, err := r.store.get(namespacedName{Namespace: namespace, Name: name}, options)
+	if err != nil {
+		return nil, err
+	}
+
+	r.applyStatistics(agentGroup)
+
+	return agentGroup, nil
+}
+
+// ListAgentGroups implements agentport.AgentGroupPersistencePort.
+func (r *AgentGroupRepository) ListAgentGroups(
+	_ context.Context, options *model.ListOptions,
+) (*model.ListResponse[*agentmodel.AgentGroup], error) {
+	resp, err := r.store.list(options, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, agentGroup := range resp.Items {
+		r.applyStatistics(agentGroup)
+	}
+
+	return resp, nil
+}
+
+// PutAgentGroup implements agentport.AgentGroupPersistencePort.
+func (r *AgentGroupRepository) PutAgentGroup(
+	_ context.Context, namespace string, name string, agentGroup *agentmodel.AgentGroup,
+) (*agentmodel.AgentGroup, error) {
+	r.store.put(namespacedName{Namespace: namespace, Name: name}, agentGroup)
+
+	if !agentGroup.IsDeleted() {
+		r.applyStatistics(agentGroup)
+	}
+
+	return agentGroup, nil
+}
+
+// applyStatistics recomputes the agent-count status fields for the group from
+// the current agent store, mirroring the MongoDB aggregation pipeline. Healthy
+// and unhealthy counts only consider connected agents.
+func (r *AgentGroupRepository) applyStatistics(agentGroup *agentmodel.AgentGroup) {
+	agents := r.agentRepo.agentsMatchingSelector(agentGroup.Spec.Selector)
+
+	//exhaustruct:ignore
+	stats := agentmodel.AgentGroupStatus{}
+	stats.Conditions = agentGroup.Status.Conditions
+
+	for _, agent := range agents {
+		stats.NumAgents++
+
+		if !r.agentRepo.isConnected(agent) {
+			stats.NumNotConnectedAgents++
+
+			continue
+		}
+
+		stats.NumConnectedAgents++
+
+		if agent.Status.ComponentHealth.Healthy {
+			stats.NumHealthyAgents++
+		} else {
+			stats.NumUnhealthyAgents++
+		}
+	}
+
+	agentGroup.Status = stats
+}

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/agentpackage.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/agentpackage.go
@@ -1,0 +1,54 @@
+//nolint:dupl // namespaced CRUD repositories intentionally share this shape.
+package inmemory
+
+import (
+	"context"
+	"time"
+
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
+	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+)
+
+var _ agentport.AgentPackagePersistencePort = (*AgentPackageRepository)(nil)
+
+// AgentPackageRepository is the in-memory implementation of
+// [agentport.AgentPackagePersistencePort].
+type AgentPackageRepository struct {
+	store *store[namespacedName, *agentmodel.AgentPackage]
+}
+
+// NewAgentPackageRepository creates a new in-memory AgentPackageRepository.
+func NewAgentPackageRepository() *AgentPackageRepository {
+	return &AgentPackageRepository{
+		store: newStore[namespacedName](func(ap *agentmodel.AgentPackage) *time.Time {
+			return ap.Metadata.DeletedAt
+		}),
+	}
+}
+
+// GetAgentPackage implements agentport.AgentPackagePersistencePort.
+func (r *AgentPackageRepository) GetAgentPackage(
+	_ context.Context, namespace string, name string, options *model.GetOptions,
+) (*agentmodel.AgentPackage, error) {
+	return r.store.get(namespacedName{Namespace: namespace, Name: name}, options)
+}
+
+// PutAgentPackage implements agentport.AgentPackagePersistencePort.
+func (r *AgentPackageRepository) PutAgentPackage(
+	_ context.Context, agentPackage *agentmodel.AgentPackage,
+) (*agentmodel.AgentPackage, error) {
+	r.store.put(namespacedName{
+		Namespace: agentPackage.Metadata.Namespace,
+		Name:      agentPackage.Metadata.Name,
+	}, agentPackage)
+
+	return agentPackage, nil
+}
+
+// ListAgentPackages implements agentport.AgentPackagePersistencePort.
+func (r *AgentPackageRepository) ListAgentPackages(
+	_ context.Context, options *model.ListOptions,
+) (*model.ListResponse[*agentmodel.AgentPackage], error) {
+	return r.store.list(options, nil)
+}

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/agentpackage.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/agentpackage.go
@@ -21,7 +21,7 @@ type AgentPackageRepository struct {
 // NewAgentPackageRepository creates a new in-memory AgentPackageRepository.
 func NewAgentPackageRepository() *AgentPackageRepository {
 	return &AgentPackageRepository{
-		store: newStore[namespacedName](func(ap *agentmodel.AgentPackage) *time.Time {
+		store: newStore[namespacedName](cloneAgentPackage, func(ap *agentmodel.AgentPackage) *time.Time {
 			return ap.Metadata.DeletedAt
 		}),
 	}

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/agentremoteconfig.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/agentremoteconfig.go
@@ -1,0 +1,54 @@
+//nolint:dupl // namespaced CRUD repositories intentionally share this shape.
+package inmemory
+
+import (
+	"context"
+	"time"
+
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
+	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+)
+
+var _ agentport.AgentRemoteConfigPersistencePort = (*AgentRemoteConfigRepository)(nil)
+
+// AgentRemoteConfigRepository is the in-memory implementation of
+// [agentport.AgentRemoteConfigPersistencePort].
+type AgentRemoteConfigRepository struct {
+	store *store[namespacedName, *agentmodel.AgentRemoteConfig]
+}
+
+// NewAgentRemoteConfigRepository creates a new in-memory AgentRemoteConfigRepository.
+func NewAgentRemoteConfigRepository() *AgentRemoteConfigRepository {
+	return &AgentRemoteConfigRepository{
+		store: newStore[namespacedName](func(arc *agentmodel.AgentRemoteConfig) *time.Time {
+			return arc.Metadata.DeletedAt
+		}),
+	}
+}
+
+// GetAgentRemoteConfig implements agentport.AgentRemoteConfigPersistencePort.
+func (r *AgentRemoteConfigRepository) GetAgentRemoteConfig(
+	_ context.Context, namespace string, name string, options *model.GetOptions,
+) (*agentmodel.AgentRemoteConfig, error) {
+	return r.store.get(namespacedName{Namespace: namespace, Name: name}, options)
+}
+
+// PutAgentRemoteConfig implements agentport.AgentRemoteConfigPersistencePort.
+func (r *AgentRemoteConfigRepository) PutAgentRemoteConfig(
+	_ context.Context, config *agentmodel.AgentRemoteConfig,
+) (*agentmodel.AgentRemoteConfig, error) {
+	r.store.put(namespacedName{
+		Namespace: config.Metadata.Namespace,
+		Name:      config.Metadata.Name,
+	}, config)
+
+	return config, nil
+}
+
+// ListAgentRemoteConfigs implements agentport.AgentRemoteConfigPersistencePort.
+func (r *AgentRemoteConfigRepository) ListAgentRemoteConfigs(
+	_ context.Context, options *model.ListOptions,
+) (*model.ListResponse[*agentmodel.AgentRemoteConfig], error) {
+	return r.store.list(options, nil)
+}

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/agentremoteconfig.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/agentremoteconfig.go
@@ -21,7 +21,7 @@ type AgentRemoteConfigRepository struct {
 // NewAgentRemoteConfigRepository creates a new in-memory AgentRemoteConfigRepository.
 func NewAgentRemoteConfigRepository() *AgentRemoteConfigRepository {
 	return &AgentRemoteConfigRepository{
-		store: newStore[namespacedName](func(arc *agentmodel.AgentRemoteConfig) *time.Time {
+		store: newStore[namespacedName](cloneAgentRemoteConfig, func(arc *agentmodel.AgentRemoteConfig) *time.Time {
 			return arc.Metadata.DeletedAt
 		}),
 	}

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/certificate.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/certificate.go
@@ -20,7 +20,7 @@ type CertificateRepository struct {
 // NewCertificateRepository creates a new in-memory CertificateRepository.
 func NewCertificateRepository() *CertificateRepository {
 	return &CertificateRepository{
-		store: newStore[namespacedName](func(cert *agentmodel.Certificate) *time.Time {
+		store: newStore[namespacedName](cloneCertificate, func(cert *agentmodel.Certificate) *time.Time {
 			return &cert.Metadata.DeletedAt
 		}),
 	}

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/certificate.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/certificate.go
@@ -1,0 +1,53 @@
+package inmemory
+
+import (
+	"context"
+	"time"
+
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
+	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+)
+
+var _ agentport.CertificatePersistencePort = (*CertificateRepository)(nil)
+
+// CertificateRepository is the in-memory implementation of
+// [agentport.CertificatePersistencePort].
+type CertificateRepository struct {
+	store *store[namespacedName, *agentmodel.Certificate]
+}
+
+// NewCertificateRepository creates a new in-memory CertificateRepository.
+func NewCertificateRepository() *CertificateRepository {
+	return &CertificateRepository{
+		store: newStore[namespacedName](func(cert *agentmodel.Certificate) *time.Time {
+			return &cert.Metadata.DeletedAt
+		}),
+	}
+}
+
+// GetCertificate implements agentport.CertificatePersistencePort.
+func (r *CertificateRepository) GetCertificate(
+	_ context.Context, namespace string, name string, options *model.GetOptions,
+) (*agentmodel.Certificate, error) {
+	return r.store.get(namespacedName{Namespace: namespace, Name: name}, options)
+}
+
+// PutCertificate implements agentport.CertificatePersistencePort.
+func (r *CertificateRepository) PutCertificate(
+	_ context.Context, certificate *agentmodel.Certificate,
+) (*agentmodel.Certificate, error) {
+	r.store.put(namespacedName{
+		Namespace: certificate.Metadata.Namespace,
+		Name:      certificate.Metadata.Name,
+	}, certificate)
+
+	return certificate, nil
+}
+
+// ListCertificate implements agentport.CertificatePersistencePort.
+func (r *CertificateRepository) ListCertificate(
+	_ context.Context, options *model.ListOptions,
+) (*model.ListResponse[*agentmodel.Certificate], error) {
+	return r.store.list(options, nil)
+}

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/clone.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/clone.go
@@ -1,0 +1,293 @@
+package inmemory
+
+import (
+	"maps"
+	"slices"
+	"time"
+
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
+	usermodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/model"
+)
+
+// The clone* functions deep-copy a domain value so the in-memory store never
+// shares mutable state (maps, slices, pointers) with its callers — reproducing
+// the MongoDB adapter's fresh-copy-per-call semantics. Each one copies the
+// top-level struct by value (handling all scalar fields) and then replaces every
+// reference-typed field with an independent copy.
+//
+// Agent and Server already expose deep Clone() methods, so the store reuses them
+// directly rather than duplicating the logic here.
+
+func cloneTimePtr(t *time.Time) *time.Time {
+	if t == nil {
+		return nil
+	}
+
+	cloned := *t
+
+	return &cloned
+}
+
+func cloneStringPtr(str *string) *string {
+	if str == nil {
+		return nil
+	}
+
+	cloned := *str
+
+	return &cloned
+}
+
+func cloneBytes(data []byte) []byte {
+	if data == nil {
+		return nil
+	}
+
+	return slices.Clone(data)
+}
+
+// cloneHeaders deep-copies a header map, including each value slice (maps.Clone
+// alone would leave the []string values shared).
+func cloneHeaders(headers map[string][]string) map[string][]string {
+	if headers == nil {
+		return nil
+	}
+
+	cloned := make(map[string][]string, len(headers))
+	for key, values := range headers {
+		cloned[key] = slices.Clone(values)
+	}
+
+	return cloned
+}
+
+func cloneNamespace(namespace *agentmodel.Namespace) *agentmodel.Namespace {
+	if namespace == nil {
+		return nil
+	}
+
+	cloned := *namespace
+	cloned.Metadata.Labels = maps.Clone(namespace.Metadata.Labels)
+	cloned.Metadata.Annotations = maps.Clone(namespace.Metadata.Annotations)
+	cloned.Metadata.DeletedAt = cloneTimePtr(namespace.Metadata.DeletedAt)
+	cloned.Status.Conditions = slices.Clone(namespace.Status.Conditions)
+
+	return &cloned
+}
+
+func cloneAgentGroup(agentGroup *agentmodel.AgentGroup) *agentmodel.AgentGroup {
+	if agentGroup == nil {
+		return nil
+	}
+
+	cloned := *agentGroup
+	cloned.Metadata.Attributes = maps.Clone(agentGroup.Metadata.Attributes)
+	cloned.Spec.Selector.IdentifyingAttributes = maps.Clone(agentGroup.Spec.Selector.IdentifyingAttributes)
+	cloned.Spec.Selector.NonIdentifyingAttributes = maps.Clone(agentGroup.Spec.Selector.NonIdentifyingAttributes)
+	cloned.Spec.AgentConnectionConfig = cloneAgentGroupConnectionConfig(agentGroup.Spec.AgentConnectionConfig)
+	cloned.Status.Conditions = slices.Clone(agentGroup.Status.Conditions)
+
+	// The deprecated single-config field is still copied so a stored value that
+	// uses it round-trips identically.
+	//nolint:staticcheck // must deep-copy the deprecated field to preserve it.
+	cloned.Spec.AgentRemoteConfig = cloneAgentGroupRemoteConfig(agentGroup.Spec.AgentRemoteConfig)
+
+	if agentGroup.Spec.AgentRemoteConfigs != nil {
+		configs := make([]agentmodel.AgentGroupAgentRemoteConfig, len(agentGroup.Spec.AgentRemoteConfigs))
+		for i := range agentGroup.Spec.AgentRemoteConfigs {
+			configs[i] = *cloneAgentGroupRemoteConfig(&agentGroup.Spec.AgentRemoteConfigs[i])
+		}
+
+		cloned.Spec.AgentRemoteConfigs = configs
+	}
+
+	return &cloned
+}
+
+func cloneAgentGroupRemoteConfig(
+	remoteConfig *agentmodel.AgentGroupAgentRemoteConfig,
+) *agentmodel.AgentGroupAgentRemoteConfig {
+	if remoteConfig == nil {
+		return nil
+	}
+
+	cloned := *remoteConfig
+	cloned.AgentRemoteConfigName = cloneStringPtr(remoteConfig.AgentRemoteConfigName)
+	cloned.AgentRemoteConfigRef = cloneStringPtr(remoteConfig.AgentRemoteConfigRef)
+
+	if remoteConfig.AgentRemoteConfigSpec != nil {
+		spec := *remoteConfig.AgentRemoteConfigSpec
+		spec.Value = cloneBytes(remoteConfig.AgentRemoteConfigSpec.Value)
+		cloned.AgentRemoteConfigSpec = &spec
+	}
+
+	return &cloned
+}
+
+func cloneAgentGroupConnectionConfig(
+	connectionConfig *agentmodel.AgentGroupConnectionConfig,
+) *agentmodel.AgentGroupConnectionConfig {
+	if connectionConfig == nil {
+		return nil
+	}
+
+	cloned := *connectionConfig
+	cloned.OpAMPConnection = cloneOpAMPConnectionSettings(connectionConfig.OpAMPConnection)
+	cloned.OwnMetrics = cloneTelemetryConnectionSettings(connectionConfig.OwnMetrics)
+	cloned.OwnLogs = cloneTelemetryConnectionSettings(connectionConfig.OwnLogs)
+	cloned.OwnTraces = cloneTelemetryConnectionSettings(connectionConfig.OwnTraces)
+
+	if connectionConfig.OtherConnections != nil {
+		others := make(map[string]agentmodel.OtherConnectionSettings, len(connectionConfig.OtherConnections))
+		for key, value := range connectionConfig.OtherConnections {
+			others[key] = agentmodel.OtherConnectionSettings{
+				DestinationEndpoint: value.DestinationEndpoint,
+				Headers:             cloneHeaders(value.Headers),
+				CertificateName:     cloneStringPtr(value.CertificateName),
+			}
+		}
+
+		cloned.OtherConnections = others
+	}
+
+	return &cloned
+}
+
+func cloneOpAMPConnectionSettings(
+	settings *agentmodel.OpAMPConnectionSettings,
+) *agentmodel.OpAMPConnectionSettings {
+	if settings == nil {
+		return nil
+	}
+
+	return &agentmodel.OpAMPConnectionSettings{
+		DestinationEndpoint: settings.DestinationEndpoint,
+		Headers:             cloneHeaders(settings.Headers),
+		CertificateName:     cloneStringPtr(settings.CertificateName),
+	}
+}
+
+func cloneTelemetryConnectionSettings(
+	settings *agentmodel.TelemetryConnectionSettings,
+) *agentmodel.TelemetryConnectionSettings {
+	if settings == nil {
+		return nil
+	}
+
+	return &agentmodel.TelemetryConnectionSettings{
+		DestinationEndpoint: settings.DestinationEndpoint,
+		Headers:             cloneHeaders(settings.Headers),
+		CertificateName:     cloneStringPtr(settings.CertificateName),
+	}
+}
+
+func cloneAgentPackage(agentPackage *agentmodel.AgentPackage) *agentmodel.AgentPackage {
+	if agentPackage == nil {
+		return nil
+	}
+
+	cloned := *agentPackage
+	cloned.Metadata.Attributes = maps.Clone(agentPackage.Metadata.Attributes)
+	cloned.Metadata.DeletedAt = cloneTimePtr(agentPackage.Metadata.DeletedAt)
+	cloned.Spec.ContentHash = cloneBytes(agentPackage.Spec.ContentHash)
+	cloned.Spec.Signature = cloneBytes(agentPackage.Spec.Signature)
+	cloned.Spec.Headers = maps.Clone(agentPackage.Spec.Headers)
+	cloned.Spec.Hash = cloneBytes(agentPackage.Spec.Hash)
+	cloned.Status.Conditions = slices.Clone(agentPackage.Status.Conditions)
+
+	return &cloned
+}
+
+func cloneAgentRemoteConfig(remoteConfig *agentmodel.AgentRemoteConfig) *agentmodel.AgentRemoteConfig {
+	if remoteConfig == nil {
+		return nil
+	}
+
+	cloned := *remoteConfig
+	cloned.Metadata.Attributes = maps.Clone(remoteConfig.Metadata.Attributes)
+	cloned.Metadata.DeletedAt = cloneTimePtr(remoteConfig.Metadata.DeletedAt)
+	cloned.Spec.Value = cloneBytes(remoteConfig.Spec.Value)
+	cloned.Status.Conditions = slices.Clone(remoteConfig.Status.Conditions)
+
+	return &cloned
+}
+
+func cloneCertificate(certificate *agentmodel.Certificate) *agentmodel.Certificate {
+	if certificate == nil {
+		return nil
+	}
+
+	cloned := *certificate
+	cloned.Metadata.Attributes = maps.Clone(certificate.Metadata.Attributes)
+	cloned.Spec.Cert = cloneBytes(certificate.Spec.Cert)
+	cloned.Spec.PrivateKey = cloneBytes(certificate.Spec.PrivateKey)
+	cloned.Spec.CaCert = cloneBytes(certificate.Spec.CaCert)
+	cloned.Status.Conditions = slices.Clone(certificate.Status.Conditions)
+
+	return &cloned
+}
+
+func cloneUser(user *usermodel.User) *usermodel.User {
+	if user == nil {
+		return nil
+	}
+
+	cloned := *user
+	cloned.Metadata.DeletedAt = cloneTimePtr(user.Metadata.DeletedAt)
+	cloned.Metadata.Labels = maps.Clone(user.Metadata.Labels)
+	cloned.Spec.Identities = slices.Clone(user.Spec.Identities)
+	cloned.Status.Conditions = slices.Clone(user.Status.Conditions)
+	cloned.Status.Roles = slices.Clone(user.Status.Roles)
+
+	return &cloned
+}
+
+func cloneRole(role *usermodel.Role) *usermodel.Role {
+	if role == nil {
+		return nil
+	}
+
+	cloned := *role
+	cloned.Metadata.DeletedAt = cloneTimePtr(role.Metadata.DeletedAt)
+	cloned.Spec.Permissions = slices.Clone(role.Spec.Permissions)
+	cloned.Status.Conditions = slices.Clone(role.Status.Conditions)
+
+	return &cloned
+}
+
+func clonePermission(permission *usermodel.Permission) *usermodel.Permission {
+	if permission == nil {
+		return nil
+	}
+
+	cloned := *permission
+	cloned.Metadata.DeletedAt = cloneTimePtr(permission.Metadata.DeletedAt)
+	cloned.Status.Conditions = slices.Clone(permission.Status.Conditions)
+
+	return &cloned
+}
+
+func cloneUserRole(userRole *usermodel.UserRole) *usermodel.UserRole {
+	if userRole == nil {
+		return nil
+	}
+
+	cloned := *userRole
+	cloned.Metadata.DeletedAt = cloneTimePtr(userRole.Metadata.DeletedAt)
+	cloned.Status.Conditions = slices.Clone(userRole.Status.Conditions)
+
+	return &cloned
+}
+
+func cloneRoleBinding(roleBinding *usermodel.RoleBinding) *usermodel.RoleBinding {
+	if roleBinding == nil {
+		return nil
+	}
+
+	cloned := *roleBinding
+	cloned.Metadata.DeletedAt = cloneTimePtr(roleBinding.Metadata.DeletedAt)
+	cloned.Spec.Subjects = slices.Clone(roleBinding.Spec.Subjects)
+	cloned.Status.Conditions = slices.Clone(roleBinding.Status.Conditions)
+
+	return &cloned
+}

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/common.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/common.go
@@ -1,0 +1,39 @@
+package inmemory
+
+import (
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/port"
+)
+
+// namespacedName is the composite key for resources identified by a
+// (namespace, name) pair, e.g. agent groups, packages, remote configs,
+// certificates, and role bindings.
+type namespacedName struct {
+	Namespace string
+	Name      string
+}
+
+// errResourceNotExist returns the shared not-found error so callers (and the
+// HTTP layer's RFC 9457 mapping) treat in-memory misses exactly like MongoDB's.
+func errResourceNotExist() error {
+	return port.ErrResourceNotExist
+}
+
+// matchesSelector reports whether the agent satisfies every identifying and
+// non-identifying attribute in the selector. An empty selector matches all
+// agents, mirroring the MongoDB selector-to-filter behaviour.
+func matchesSelector(agent *agentmodel.Agent, selector agentmodel.AgentSelector) bool {
+	for key, value := range selector.IdentifyingAttributes {
+		if agent.Metadata.Description.IdentifyingAttributes[key] != value {
+			return false
+		}
+	}
+
+	for key, value := range selector.NonIdentifyingAttributes {
+		if agent.Metadata.Description.NonIdentifyingAttributes[key] != value {
+			return false
+		}
+	}
+
+	return true
+}

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/inmemory_test.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/inmemory_test.go
@@ -3,6 +3,7 @@ package inmemory_test
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -175,6 +176,74 @@ func TestAgentGroupRepository_StatisticsFromAgentStore(t *testing.T) {
 	assert.Equal(t, 1, stored.Status.NumHealthyAgents)
 	assert.Equal(t, 0, stored.Status.NumUnhealthyAgents)
 	assert.Equal(t, 1, stored.Status.NumNotConnectedAgents)
+}
+
+func TestAgentRepository_GetReturnsIsolatedCopy(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo := inmemory.NewAgentRepository()
+	uid := uuid.New()
+	require.NoError(t, repo.PutAgent(ctx, agentmodel.NewAgent(uid)))
+
+	// Mutating the value returned by Get must not affect the stored copy, since
+	// the store hands out deep copies (matching MongoDB's fresh-copy semantics).
+	got, err := repo.GetAgent(ctx, uid)
+	require.NoError(t, err)
+
+	got.Status.Connected = true
+	got.Metadata.Namespace = "mutated"
+
+	reread, err := repo.GetAgent(ctx, uid)
+	require.NoError(t, err)
+	assert.False(t, reread.Status.Connected, "mutation of a Get result must not leak into the store")
+	assert.Equal(t, agentmodel.DefaultNamespaceName, reread.Metadata.Namespace)
+}
+
+// TestAgentGroupRepository_ConcurrentAccessNoRace exercises the store under
+// concurrent readers and writers; it is meaningful under `go test -race`, where
+// it would previously have reported a data race on the shared stored pointer.
+func TestAgentGroupRepository_ConcurrentAccessNoRace(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	agentRepo := inmemory.NewAgentRepository()
+	groupRepo := inmemory.NewAgentGroupRepository(agentRepo)
+
+	const groupName = "race-grp"
+
+	group := agentmodel.NewAgentGroup("default", groupName, nil, time.Now(), "tester")
+	_, err := groupRepo.PutAgentGroup(ctx, "default", groupName, group)
+	require.NoError(t, err)
+
+	var waitGroup sync.WaitGroup
+
+	const workers = 8
+
+	for range workers {
+		// Each iteration starts one reader and one writer goroutine.
+		waitGroup.Add(2)
+
+		go func() {
+			defer waitGroup.Done()
+
+			for range 50 {
+				_, _ = groupRepo.GetAgentGroup(ctx, "default", groupName, nil)
+				_, _ = groupRepo.ListAgentGroups(ctx, nil)
+			}
+		}()
+
+		go func() {
+			defer waitGroup.Done()
+
+			for range 50 {
+				updated := agentmodel.NewAgentGroup("default", groupName, nil, time.Now(), "tester")
+				_, _ = groupRepo.PutAgentGroup(ctx, "default", groupName, updated)
+			}
+		}()
+	}
+
+	waitGroup.Wait()
 }
 
 func TestTransactionRunner_RunsCallback(t *testing.T) {

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/inmemory_test.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/inmemory_test.go
@@ -1,0 +1,198 @@
+package inmemory_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/secondary/persistence/inmemory"
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/port"
+)
+
+// errSentinel is a static error used to assert transaction error propagation.
+var errSentinel = errors.New("boom")
+
+func TestAgentRepository_PutGetDelete(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo := inmemory.NewAgentRepository()
+	uid := uuid.New()
+	agent := agentmodel.NewAgent(uid)
+
+	require.NoError(t, repo.PutAgent(ctx, agent))
+
+	got, err := repo.GetAgent(ctx, uid)
+	require.NoError(t, err)
+	assert.Equal(t, uid, got.Metadata.InstanceUID)
+
+	require.NoError(t, repo.DeleteAgent(ctx, uid))
+
+	_, err = repo.GetAgent(ctx, uid)
+	require.ErrorIs(t, err, port.ErrResourceNotExist)
+
+	// Deleting a missing agent reports not-found.
+	require.ErrorIs(t, repo.DeleteAgent(ctx, uid), port.ErrResourceNotExist)
+}
+
+func TestAgentRepository_ListByNamespaceAndPagination(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo := inmemory.NewAgentRepository()
+
+	for range 3 {
+		agent := agentmodel.NewAgent(uuid.New())
+		agent.Metadata.Namespace = "ns-a"
+		require.NoError(t, repo.PutAgent(ctx, agent))
+	}
+
+	other := agentmodel.NewAgent(uuid.New())
+	other.Metadata.Namespace = "ns-b"
+	require.NoError(t, repo.PutAgent(ctx, other))
+
+	// First page of 2 from ns-a, then resume via the continue token.
+	//exhaustruct:ignore
+	page1, err := repo.ListAgents(ctx, "ns-a", &model.ListOptions{Limit: 2})
+	require.NoError(t, err)
+	assert.Len(t, page1.Items, 2)
+	assert.Equal(t, int64(1), page1.RemainingItemCount)
+	require.NotEmpty(t, page1.Continue)
+
+	//exhaustruct:ignore
+	page2, err := repo.ListAgents(ctx, "ns-a", &model.ListOptions{Limit: 2, Continue: page1.Continue})
+	require.NoError(t, err)
+	assert.Len(t, page2.Items, 1)
+	assert.Equal(t, int64(0), page2.RemainingItemCount)
+}
+
+func TestAgentRepository_SearchByInstanceUIDPrefix(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo := inmemory.NewAgentRepository()
+
+	uid := uuid.New()
+	agent := agentmodel.NewAgent(uid)
+	require.NoError(t, repo.PutAgent(ctx, agent))
+
+	prefix := uid.String()[:8]
+
+	resp, err := repo.SearchAgents(ctx, agentmodel.DefaultNamespaceName, prefix, nil)
+	require.NoError(t, err)
+	require.Len(t, resp.Items, 1)
+	assert.Equal(t, uid, resp.Items[0].Metadata.InstanceUID)
+
+	// A non-matching prefix yields nothing.
+	resp, err = repo.SearchAgents(ctx, agentmodel.DefaultNamespaceName, "zzzzzzzz", nil)
+	require.NoError(t, err)
+	assert.Empty(t, resp.Items)
+
+	// Empty query is valid and returns an empty page.
+	resp, err = repo.SearchAgents(ctx, agentmodel.DefaultNamespaceName, "", nil)
+	require.NoError(t, err)
+	assert.Empty(t, resp.Items)
+}
+
+func TestNamespaceRepository_SoftDeleteHiddenUnlessIncluded(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo := inmemory.NewNamespaceRepository()
+
+	ns := agentmodel.NewNamespace("ns-soft")
+	ns.MarkAsCreated(time.Now(), "tester")
+	_, err := repo.PutNamespace(ctx, ns)
+	require.NoError(t, err)
+
+	ns.MarkAsDeleted(time.Now(), "tester")
+	_, err = repo.PutNamespace(ctx, ns)
+	require.NoError(t, err)
+
+	// Default read excludes the soft-deleted namespace.
+	_, err = repo.GetNamespace(ctx, "ns-soft", nil)
+	require.ErrorIs(t, err, port.ErrResourceNotExist)
+
+	// IncludeDeleted surfaces it again.
+	//exhaustruct:ignore
+	got, err := repo.GetNamespace(ctx, "ns-soft", &model.GetOptions{IncludeDeleted: true})
+	require.NoError(t, err)
+	assert.Equal(t, "ns-soft", got.Metadata.Name)
+
+	// It is excluded from the default listing.
+	list, err := repo.ListNamespaces(ctx, nil)
+	require.NoError(t, err)
+	assert.Empty(t, list.Items)
+}
+
+func TestAgentGroupRepository_StatisticsFromAgentStore(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	agentRepo := inmemory.NewAgentRepository()
+	groupRepo := inmemory.NewAgentGroupRepository(agentRepo)
+
+	selector := map[string]string{"service.name": "otelcol"}
+
+	// A connected+healthy agent matching the selector.
+	connected := agentmodel.NewAgent(uuid.New())
+	connected.Metadata.Description.IdentifyingAttributes = selector
+	connected.Status.Connected = true
+	connected.Status.LastReportedAt = time.Now()
+	connected.Status.ComponentHealth.Healthy = true
+	require.NoError(t, agentRepo.PutAgent(ctx, connected))
+
+	// A matching but disconnected agent.
+	disconnected := agentmodel.NewAgent(uuid.New())
+	disconnected.Metadata.Description.IdentifyingAttributes = selector
+	require.NoError(t, agentRepo.PutAgent(ctx, disconnected))
+
+	// A non-matching agent must not be counted.
+	otherAgent := agentmodel.NewAgent(uuid.New())
+	otherAgent.Metadata.Description.IdentifyingAttributes = map[string]string{"service.name": "nginx"}
+	otherAgent.Status.Connected = true
+	otherAgent.Status.LastReportedAt = time.Now()
+	require.NoError(t, agentRepo.PutAgent(ctx, otherAgent))
+
+	group := agentmodel.NewAgentGroup("default", "grp", nil, time.Now(), "tester")
+	group.Spec.Selector = agentmodel.AgentSelector{
+		IdentifyingAttributes:    selector,
+		NonIdentifyingAttributes: nil,
+	}
+
+	stored, err := groupRepo.PutAgentGroup(ctx, "default", "grp", group)
+	require.NoError(t, err)
+
+	assert.Equal(t, 2, stored.Status.NumAgents)
+	assert.Equal(t, 1, stored.Status.NumConnectedAgents)
+	assert.Equal(t, 1, stored.Status.NumHealthyAgents)
+	assert.Equal(t, 0, stored.Status.NumUnhealthyAgents)
+	assert.Equal(t, 1, stored.Status.NumNotConnectedAgents)
+}
+
+func TestTransactionRunner_RunsCallback(t *testing.T) {
+	t.Parallel()
+
+	runner := inmemory.NewTransactionRunner()
+
+	called := false
+	err := runner.WithinTransaction(context.Background(), func(context.Context) error {
+		called = true
+
+		return nil
+	})
+	require.NoError(t, err)
+	assert.True(t, called)
+
+	err = runner.WithinTransaction(context.Background(), func(context.Context) error {
+		return errSentinel
+	})
+	require.ErrorIs(t, err, errSentinel)
+}

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/namespace.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/namespace.go
@@ -20,7 +20,7 @@ type NamespaceRepository struct {
 // NewNamespaceRepository creates a new in-memory NamespaceRepository.
 func NewNamespaceRepository() *NamespaceRepository {
 	return &NamespaceRepository{
-		store: newStore[string](func(ns *agentmodel.Namespace) *time.Time {
+		store: newStore[string](cloneNamespace, func(ns *agentmodel.Namespace) *time.Time {
 			return ns.Metadata.DeletedAt
 		}),
 	}

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/namespace.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/namespace.go
@@ -1,0 +1,50 @@
+package inmemory
+
+import (
+	"context"
+	"time"
+
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
+	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+)
+
+var _ agentport.NamespacePersistencePort = (*NamespaceRepository)(nil)
+
+// NamespaceRepository is the in-memory implementation of
+// [agentport.NamespacePersistencePort].
+type NamespaceRepository struct {
+	store *store[string, *agentmodel.Namespace]
+}
+
+// NewNamespaceRepository creates a new in-memory NamespaceRepository.
+func NewNamespaceRepository() *NamespaceRepository {
+	return &NamespaceRepository{
+		store: newStore[string](func(ns *agentmodel.Namespace) *time.Time {
+			return ns.Metadata.DeletedAt
+		}),
+	}
+}
+
+// GetNamespace implements agentport.NamespacePersistencePort.
+func (r *NamespaceRepository) GetNamespace(
+	_ context.Context, name string, options *model.GetOptions,
+) (*agentmodel.Namespace, error) {
+	return r.store.get(name, options)
+}
+
+// PutNamespace implements agentport.NamespacePersistencePort.
+func (r *NamespaceRepository) PutNamespace(
+	_ context.Context, namespace *agentmodel.Namespace,
+) (*agentmodel.Namespace, error) {
+	r.store.put(namespace.Metadata.Name, namespace)
+
+	return namespace, nil
+}
+
+// ListNamespaces implements agentport.NamespacePersistencePort.
+func (r *NamespaceRepository) ListNamespaces(
+	_ context.Context, options *model.ListOptions,
+) (*model.ListResponse[*agentmodel.Namespace], error) {
+	return r.store.list(options, nil)
+}

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/permission.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/permission.go
@@ -1,0 +1,75 @@
+package inmemory
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	usermodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/model"
+	userport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/port"
+)
+
+var _ userport.PermissionPersistencePort = (*PermissionRepository)(nil)
+
+// PermissionRepository is the in-memory implementation of
+// [userport.PermissionPersistencePort].
+type PermissionRepository struct {
+	store *store[uuid.UUID, *usermodel.Permission]
+}
+
+// NewPermissionRepository creates a new in-memory PermissionRepository.
+func NewPermissionRepository() *PermissionRepository {
+	return &PermissionRepository{
+		store: newStore[uuid.UUID](func(permission *usermodel.Permission) *time.Time {
+			return permission.Metadata.DeletedAt
+		}),
+	}
+}
+
+// GetPermission implements userport.PermissionPersistencePort.
+func (r *PermissionRepository) GetPermission(_ context.Context, uid uuid.UUID) (*usermodel.Permission, error) {
+	return r.store.get(uid, nil)
+}
+
+// GetPermissionByName implements userport.PermissionPersistencePort.
+func (r *PermissionRepository) GetPermissionByName(_ context.Context, name string) (*usermodel.Permission, error) {
+	permissions := r.store.snapshot(false, func(permission *usermodel.Permission) bool {
+		return permission.Spec.Name == name
+	})
+	if len(permissions) == 0 {
+		return nil, errResourceNotExist()
+	}
+
+	return permissions[0], nil
+}
+
+// PutPermission implements userport.PermissionPersistencePort.
+func (r *PermissionRepository) PutPermission(
+	_ context.Context, permission *usermodel.Permission,
+) (*usermodel.Permission, error) {
+	r.store.put(permission.Metadata.UID, permission)
+
+	return permission, nil
+}
+
+// ListPermissions implements userport.PermissionPersistencePort.
+func (r *PermissionRepository) ListPermissions(
+	_ context.Context, options *model.ListOptions,
+) (*model.ListResponse[*usermodel.Permission], error) {
+	return r.store.list(options, nil)
+}
+
+// DeletePermission implements userport.PermissionPersistencePort. Permissions are soft-deleted.
+func (r *PermissionRepository) DeletePermission(_ context.Context, uid uuid.UUID) error {
+	permission, err := r.store.get(uid, nil)
+	if err != nil {
+		return err
+	}
+
+	permission.Delete()
+	r.store.put(uid, permission)
+
+	return nil
+}

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/permission.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/permission.go
@@ -22,7 +22,7 @@ type PermissionRepository struct {
 // NewPermissionRepository creates a new in-memory PermissionRepository.
 func NewPermissionRepository() *PermissionRepository {
 	return &PermissionRepository{
-		store: newStore[uuid.UUID](func(permission *usermodel.Permission) *time.Time {
+		store: newStore[uuid.UUID](clonePermission, func(permission *usermodel.Permission) *time.Time {
 			return permission.Metadata.DeletedAt
 		}),
 	}

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/role.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/role.go
@@ -21,7 +21,7 @@ type RoleRepository struct {
 // NewRoleRepository creates a new in-memory RoleRepository.
 func NewRoleRepository() *RoleRepository {
 	return &RoleRepository{
-		store: newStore[uuid.UUID](func(role *usermodel.Role) *time.Time {
+		store: newStore[uuid.UUID](cloneRole, func(role *usermodel.Role) *time.Time {
 			return role.Metadata.DeletedAt
 		}),
 	}

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/role.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/role.go
@@ -1,0 +1,88 @@
+package inmemory
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	usermodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/model"
+	userport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/port"
+)
+
+var _ userport.RolePersistencePort = (*RoleRepository)(nil)
+
+// RoleRepository is the in-memory implementation of [userport.RolePersistencePort].
+type RoleRepository struct {
+	store *store[uuid.UUID, *usermodel.Role]
+}
+
+// NewRoleRepository creates a new in-memory RoleRepository.
+func NewRoleRepository() *RoleRepository {
+	return &RoleRepository{
+		store: newStore[uuid.UUID](func(role *usermodel.Role) *time.Time {
+			return role.Metadata.DeletedAt
+		}),
+	}
+}
+
+// GetRole implements userport.RolePersistencePort.
+func (r *RoleRepository) GetRole(
+	_ context.Context, uid uuid.UUID, options *model.GetOptions,
+) (*usermodel.Role, error) {
+	return r.store.get(uid, options)
+}
+
+// GetRoleByName implements userport.RolePersistencePort.
+func (r *RoleRepository) GetRoleByName(_ context.Context, displayName string) (*usermodel.Role, error) {
+	roles := r.store.snapshot(false, func(role *usermodel.Role) bool {
+		return role.Spec.DisplayName == displayName
+	})
+	if len(roles) == 0 {
+		return nil, errResourceNotExist()
+	}
+
+	return roles[0], nil
+}
+
+// PutRole implements userport.RolePersistencePort.
+func (r *RoleRepository) PutRole(_ context.Context, role *usermodel.Role) (*usermodel.Role, error) {
+	r.store.put(role.Metadata.UID, role)
+
+	return role, nil
+}
+
+// ListRoles implements userport.RolePersistencePort.
+func (r *RoleRepository) ListRoles(
+	_ context.Context, options *model.ListOptions,
+) (*model.ListResponse[*usermodel.Role], error) {
+	return r.store.list(options, nil)
+}
+
+// DeleteRole implements userport.RolePersistencePort. Roles are soft-deleted.
+func (r *RoleRepository) DeleteRole(_ context.Context, uid uuid.UUID) error {
+	role, err := r.store.get(uid, nil)
+	if err != nil {
+		return err
+	}
+
+	role.Delete()
+	r.store.put(uid, role)
+
+	return nil
+}
+
+// getByUIDs returns the non-deleted roles for the given UIDs, preserving store order.
+func (r *RoleRepository) getByUIDs(uids []uuid.UUID) []*usermodel.Role {
+	wanted := make(map[uuid.UUID]struct{}, len(uids))
+	for _, uid := range uids {
+		wanted[uid] = struct{}{}
+	}
+
+	return r.store.snapshot(false, func(role *usermodel.Role) bool {
+		_, ok := wanted[role.Metadata.UID]
+
+		return ok
+	})
+}

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/rolebinding.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/rolebinding.go
@@ -1,0 +1,65 @@
+package inmemory
+
+import (
+	"context"
+	"time"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	usermodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/model"
+	userport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/port"
+)
+
+var _ userport.RoleBindingPersistencePort = (*RoleBindingRepository)(nil)
+
+// RoleBindingRepository is the in-memory implementation of
+// [userport.RoleBindingPersistencePort].
+type RoleBindingRepository struct {
+	store *store[namespacedName, *usermodel.RoleBinding]
+}
+
+// NewRoleBindingRepository creates a new in-memory RoleBindingRepository.
+func NewRoleBindingRepository() *RoleBindingRepository {
+	return &RoleBindingRepository{
+		store: newStore[namespacedName](func(rb *usermodel.RoleBinding) *time.Time {
+			return rb.Metadata.DeletedAt
+		}),
+	}
+}
+
+// GetRoleBinding implements userport.RoleBindingPersistencePort.
+func (r *RoleBindingRepository) GetRoleBinding(
+	_ context.Context, namespace, name string, options *model.GetOptions,
+) (*usermodel.RoleBinding, error) {
+	return r.store.get(namespacedName{Namespace: namespace, Name: name}, options)
+}
+
+// PutRoleBinding implements userport.RoleBindingPersistencePort.
+func (r *RoleBindingRepository) PutRoleBinding(
+	_ context.Context, rb *usermodel.RoleBinding,
+) (*usermodel.RoleBinding, error) {
+	r.store.put(namespacedName{Namespace: rb.Metadata.Namespace, Name: rb.Metadata.Name}, rb)
+
+	return rb, nil
+}
+
+// ListRoleBindings implements userport.RoleBindingPersistencePort.
+func (r *RoleBindingRepository) ListRoleBindings(
+	_ context.Context, options *model.ListOptions,
+) (*model.ListResponse[*usermodel.RoleBinding], error) {
+	return r.store.list(options, nil)
+}
+
+// DeleteRoleBinding implements userport.RoleBindingPersistencePort. Bindings are soft-deleted.
+func (r *RoleBindingRepository) DeleteRoleBinding(_ context.Context, namespace, name string) error {
+	key := namespacedName{Namespace: namespace, Name: name}
+
+	roleBinding, err := r.store.get(key, nil)
+	if err != nil {
+		return err
+	}
+
+	roleBinding.MarkDeleted()
+	r.store.put(key, roleBinding)
+
+	return nil
+}

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/rolebinding.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/rolebinding.go
@@ -20,7 +20,7 @@ type RoleBindingRepository struct {
 // NewRoleBindingRepository creates a new in-memory RoleBindingRepository.
 func NewRoleBindingRepository() *RoleBindingRepository {
 	return &RoleBindingRepository{
-		store: newStore[namespacedName](func(rb *usermodel.RoleBinding) *time.Time {
+		store: newStore[namespacedName](cloneRoleBinding, func(rb *usermodel.RoleBinding) *time.Time {
 			return rb.Metadata.DeletedAt
 		}),
 	}

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/server.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/server.go
@@ -1,0 +1,40 @@
+package inmemory
+
+import (
+	"context"
+
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
+	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
+)
+
+var _ agentport.ServerPersistencePort = (*ServerRepository)(nil)
+
+// ServerRepository is the in-memory implementation of
+// [agentport.ServerPersistencePort]. Servers have no soft-delete concept.
+type ServerRepository struct {
+	store *store[string, *agentmodel.Server]
+}
+
+// NewServerRepository creates a new in-memory ServerRepository.
+func NewServerRepository() *ServerRepository {
+	return &ServerRepository{
+		store: newStore[string, *agentmodel.Server](nil),
+	}
+}
+
+// GetServer implements agentport.ServerPersistencePort.
+func (r *ServerRepository) GetServer(_ context.Context, id string) (*agentmodel.Server, error) {
+	return r.store.get(id, nil)
+}
+
+// PutServer implements agentport.ServerPersistencePort.
+func (r *ServerRepository) PutServer(_ context.Context, server *agentmodel.Server) error {
+	r.store.put(server.ID, server)
+
+	return nil
+}
+
+// ListServers implements agentport.ServerPersistencePort.
+func (r *ServerRepository) ListServers(_ context.Context) ([]*agentmodel.Server, error) {
+	return r.store.snapshot(false, nil), nil
+}

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/server.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/server.go
@@ -18,7 +18,7 @@ type ServerRepository struct {
 // NewServerRepository creates a new in-memory ServerRepository.
 func NewServerRepository() *ServerRepository {
 	return &ServerRepository{
-		store: newStore[string, *agentmodel.Server](nil),
+		store: newStore[string]((*agentmodel.Server).Clone, nil),
 	}
 }
 

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/store.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/store.go
@@ -1,0 +1,223 @@
+// Package inmemory provides in-memory implementations of the persistence ports.
+//
+// It backs "standalone" mode (config database type "inmemory"), letting the
+// apiserver run as a single node without MongoDB. Data lives only in process
+// memory and is lost on restart, so it is intended for development, demos, and
+// small single-node deployments rather than production multi-server setups.
+//
+// Each repository wraps a generic [store], which reproduces the get/list/put
+// semantics of the MongoDB common adapter: soft-delete-aware reads, stable
+// insertion ordering, and cursor-based pagination via an opaque continue token.
+package inmemory
+
+import (
+	"cmp"
+	"fmt"
+	"slices"
+	"strconv"
+	"sync"
+	"time"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+)
+
+// item wraps a stored value with a stable, monotonically increasing insertion
+// sequence. The sequence gives deterministic ordering and serves as the
+// pagination cursor, mirroring MongoDB's ascending _id ordering.
+type item[V any] struct {
+	seq   uint64
+	value V
+}
+
+// store is a concurrency-safe in-memory key/value collection that mirrors the
+// list/get/put behaviour of the MongoDB common adapter, including soft-delete
+// filtering and cursor pagination.
+//
+// V is normally a pointer to a domain model. Stored values are NOT cloned: the
+// store keeps and returns the same reference the caller passed to put. Callers
+// in this codebase follow a get -> mutate -> put cycle, so this matches how the
+// application layer already behaves; it does mean a mutation that is never
+// put-back is visible on the next get (unlike MongoDB, which only persists on
+// an explicit write).
+type store[K comparable, V any] struct {
+	mu      sync.RWMutex
+	items   map[K]*item[V]
+	nextSeq uint64
+
+	// deletedAt extracts a value's soft-delete timestamp, or nil when the type
+	// has no soft-delete concept. A non-nil, non-zero timestamp marks the value
+	// as deleted and hides it from reads that do not opt into IncludeDeleted.
+	deletedAt func(V) *time.Time
+}
+
+// newStore creates an empty store. Pass a deletedAt accessor for soft-deletable
+// types, or nil for types that are hard-deleted (e.g. agents, servers).
+func newStore[K comparable, V any](deletedAt func(V) *time.Time) *store[K, V] {
+	return &store[K, V]{
+		mu:        sync.RWMutex{},
+		items:     make(map[K]*item[V]),
+		nextSeq:   1,
+		deletedAt: deletedAt,
+	}
+}
+
+func (s *store[K, V]) isDeleted(value V) bool {
+	if s.deletedAt == nil {
+		return false
+	}
+
+	deletedAt := s.deletedAt(value)
+
+	return deletedAt != nil && !deletedAt.IsZero()
+}
+
+// get returns the value for key. It returns [port.ErrResourceNotExist] when the
+// key is absent, or when the value is soft-deleted and options does not request
+// IncludeDeleted.
+func (s *store[K, V]) get(key K, options *model.GetOptions) (V, error) {
+	var zero V
+
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	entry, ok := s.items[key]
+	if !ok {
+		return zero, errResourceNotExist()
+	}
+
+	if s.isDeleted(entry.value) && (options == nil || !options.IncludeDeleted) {
+		return zero, errResourceNotExist()
+	}
+
+	return entry.value, nil
+}
+
+// put inserts or replaces the value for key. An existing key keeps its original
+// insertion sequence so its position in list ordering is stable across updates.
+func (s *store[K, V]) put(key K, value V) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if existing, ok := s.items[key]; ok {
+		existing.value = value
+
+		return
+	}
+
+	s.items[key] = &item[V]{seq: s.nextSeq, value: value}
+	s.nextSeq++
+}
+
+// delete permanently removes key (hard delete). It returns
+// [port.ErrResourceNotExist] when the key is absent.
+func (s *store[K, V]) delete(key K) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.items[key]; !ok {
+		return errResourceNotExist()
+	}
+
+	delete(s.items, key)
+
+	return nil
+}
+
+// collect returns the entries matching the given criteria, ordered by insertion
+// sequence. Entries are excluded when soft-deleted (unless includeDeleted), when
+// their sequence is not strictly greater than afterSeq, or when filter rejects
+// them. afterSeq of 0 disables the cursor.
+func (s *store[K, V]) collect(includeDeleted bool, afterSeq uint64, filter func(V) bool) []*item[V] {
+	s.mu.RLock()
+	entries := make([]*item[V], 0, len(s.items))
+
+	for _, entry := range s.items {
+		switch {
+		case !includeDeleted && s.isDeleted(entry.value):
+			continue
+		case entry.seq <= afterSeq:
+			continue
+		case filter != nil && !filter(entry.value):
+			continue
+		}
+
+		entries = append(entries, entry)
+	}
+
+	s.mu.RUnlock()
+
+	slices.SortFunc(entries, func(a, b *item[V]) int {
+		return cmp.Compare(a.seq, b.seq)
+	})
+
+	return entries
+}
+
+// snapshot returns the non-deleted values matching filter, in insertion order.
+// Pass includeDeleted to also include soft-deleted values, and a nil filter to
+// match everything. It is the building block for the typed list/find helpers
+// the repositories need beyond plain pagination.
+func (s *store[K, V]) snapshot(includeDeleted bool, filter func(V) bool) []V {
+	entries := s.collect(includeDeleted, 0, filter)
+
+	values := make([]V, 0, len(entries))
+	for _, entry := range entries {
+		values = append(values, entry.value)
+	}
+
+	return values
+}
+
+// list returns a paginated [model.ListResponse] for the values matching filter.
+//
+// It mirrors the MongoDB common adapter: soft-deleted values are excluded unless
+// options.IncludeDeleted is set, results are ordered by insertion sequence, and
+// the continue token resumes strictly after the last returned element. The
+// returned Continue is the last element's cursor (empty when the page is empty),
+// and RemainingItemCount is how many matching values follow this page.
+func (s *store[K, V]) list(options *model.ListOptions, filter func(V) bool) (*model.ListResponse[V], error) {
+	if options == nil {
+		//exhaustruct:ignore
+		options = &model.ListOptions{}
+	}
+
+	var afterSeq uint64
+
+	if options.Continue != "" {
+		parsed, err := strconv.ParseUint(options.Continue, 10, 64)
+		if err != nil {
+			return nil, fmt.Errorf("invalid continue token %q: %w", options.Continue, err)
+		}
+
+		afterSeq = parsed
+	}
+
+	candidates := s.collect(options.IncludeDeleted, afterSeq, filter)
+
+	total := int64(len(candidates))
+
+	page := candidates
+	if options.Limit > 0 && int64(len(candidates)) > options.Limit {
+		page = candidates[:options.Limit]
+	}
+
+	items := make([]V, 0, len(page))
+
+	var lastSeq uint64
+
+	for _, entry := range page {
+		items = append(items, entry.value)
+		lastSeq = entry.seq
+	}
+
+	continueToken := ""
+	if len(page) > 0 {
+		continueToken = strconv.FormatUint(lastSeq, 10)
+	}
+
+	return &model.ListResponse[V]{
+		Items:              items,
+		Continue:           continueToken,
+		RemainingItemCount: total - int64(len(page)),
+	}, nil
+}

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/store.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/store.go
@@ -33,16 +33,19 @@ type item[V any] struct {
 // list/get/put behaviour of the MongoDB common adapter, including soft-delete
 // filtering and cursor pagination.
 //
-// V is normally a pointer to a domain model. Stored values are NOT cloned: the
-// store keeps and returns the same reference the caller passed to put. Callers
-// in this codebase follow a get -> mutate -> put cycle, so this matches how the
-// application layer already behaves; it does mean a mutation that is never
-// put-back is visible on the next get (unlike MongoDB, which only persists on
-// an explicit write).
+// V is normally a pointer to a domain model. The store deep-copies values on the
+// way in (put) and on the way out (get/list/snapshot) via the clone function, so
+// it never shares a mutable reference with its callers. This reproduces the
+// MongoDB adapter's "fresh copy per call" semantics: a caller mutating a value it
+// read does not affect the stored copy (only an explicit put persists), and two
+// concurrent callers never race on the same object.
 type store[K comparable, V any] struct {
 	mu      sync.RWMutex
 	items   map[K]*item[V]
 	nextSeq uint64
+
+	// clone deep-copies a value so the store shares no mutable state with callers.
+	clone func(V) V
 
 	// deletedAt extracts a value's soft-delete timestamp, or nil when the type
 	// has no soft-delete concept. A non-nil, non-zero timestamp marks the value
@@ -50,13 +53,16 @@ type store[K comparable, V any] struct {
 	deletedAt func(V) *time.Time
 }
 
-// newStore creates an empty store. Pass a deletedAt accessor for soft-deletable
-// types, or nil for types that are hard-deleted (e.g. agents, servers).
-func newStore[K comparable, V any](deletedAt func(V) *time.Time) *store[K, V] {
+// newStore creates an empty store. clone must deep-copy a value (it is applied on
+// every read and write to isolate the store from callers). Pass a deletedAt
+// accessor for soft-deletable types, or nil for types that are hard-deleted
+// (e.g. agents, servers).
+func newStore[K comparable, V any](clone func(V) V, deletedAt func(V) *time.Time) *store[K, V] {
 	return &store[K, V]{
 		mu:        sync.RWMutex{},
 		items:     make(map[K]*item[V]),
 		nextSeq:   1,
+		clone:     clone,
 		deletedAt: deletedAt,
 	}
 }
@@ -89,22 +95,25 @@ func (s *store[K, V]) get(key K, options *model.GetOptions) (V, error) {
 		return zero, errResourceNotExist()
 	}
 
-	return entry.value, nil
+	return s.clone(entry.value), nil
 }
 
-// put inserts or replaces the value for key. An existing key keeps its original
+// put inserts or replaces the value for key, storing a deep copy so later caller
+// mutations do not leak into the store. An existing key keeps its original
 // insertion sequence so its position in list ordering is stable across updates.
 func (s *store[K, V]) put(key K, value V) {
+	stored := s.clone(value)
+
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
 	if existing, ok := s.items[key]; ok {
-		existing.value = value
+		existing.value = stored
 
 		return
 	}
 
-	s.items[key] = &item[V]{seq: s.nextSeq, value: value}
+	s.items[key] = &item[V]{seq: s.nextSeq, value: stored}
 	s.nextSeq++
 }
 
@@ -127,9 +136,12 @@ func (s *store[K, V]) delete(key K) error {
 // sequence. Entries are excluded when soft-deleted (unless includeDeleted), when
 // their sequence is not strictly greater than afterSeq, or when filter rejects
 // them. afterSeq of 0 disables the cursor.
-func (s *store[K, V]) collect(includeDeleted bool, afterSeq uint64, filter func(V) bool) []*item[V] {
+//
+// Returned entries hold deep copies of the stored values, cloned while the read
+// lock is held, so callers never observe (or race on) the live stored objects.
+func (s *store[K, V]) collect(includeDeleted bool, afterSeq uint64, filter func(V) bool) []item[V] {
 	s.mu.RLock()
-	entries := make([]*item[V], 0, len(s.items))
+	entries := make([]item[V], 0, len(s.items))
 
 	for _, entry := range s.items {
 		switch {
@@ -141,12 +153,12 @@ func (s *store[K, V]) collect(includeDeleted bool, afterSeq uint64, filter func(
 			continue
 		}
 
-		entries = append(entries, entry)
+		entries = append(entries, item[V]{seq: entry.seq, value: s.clone(entry.value)})
 	}
 
 	s.mu.RUnlock()
 
-	slices.SortFunc(entries, func(a, b *item[V]) int {
+	slices.SortFunc(entries, func(a, b item[V]) int {
 		return cmp.Compare(a.seq, b.seq)
 	})
 

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/transaction.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/transaction.go
@@ -1,0 +1,39 @@
+package inmemory
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
+)
+
+var _ port.TransactionRunner = (*TransactionRunner)(nil)
+
+// TransactionRunner is the in-memory implementation of [port.TransactionRunner].
+//
+// The in-memory stores are not transactional: there is no snapshot/rollback, so
+// the callback simply runs against the live stores. A callback that fails after
+// already mutating some stores leaves those mutations in place. This is an
+// accepted limitation of standalone mode, which targets single-node development
+// and demo use rather than the multi-server consistency guarantees MongoDB
+// transactions provide.
+type TransactionRunner struct{}
+
+// NewTransactionRunner creates a new in-memory TransactionRunner.
+func NewTransactionRunner() *TransactionRunner {
+	return &TransactionRunner{}
+}
+
+// WithinTransaction implements [port.TransactionRunner] by invoking fn directly
+// with the unmodified context.
+func (r *TransactionRunner) WithinTransaction(
+	ctx context.Context,
+	callback func(ctx context.Context) error,
+) error {
+	err := callback(ctx)
+	if err != nil {
+		return fmt.Errorf("in-memory transaction callback failed: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/user.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/user.go
@@ -21,7 +21,7 @@ type UserRepository struct {
 // NewUserRepository creates a new in-memory UserRepository.
 func NewUserRepository() *UserRepository {
 	return &UserRepository{
-		store: newStore[uuid.UUID](func(user *usermodel.User) *time.Time {
+		store: newStore[uuid.UUID](cloneUser, func(user *usermodel.User) *time.Time {
 			return user.Metadata.DeletedAt
 		}),
 	}

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/user.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/user.go
@@ -1,0 +1,83 @@
+package inmemory
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	usermodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/model"
+	userport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/port"
+)
+
+var _ userport.UserPersistencePort = (*UserRepository)(nil)
+
+// UserRepository is the in-memory implementation of [userport.UserPersistencePort].
+type UserRepository struct {
+	store *store[uuid.UUID, *usermodel.User]
+}
+
+// NewUserRepository creates a new in-memory UserRepository.
+func NewUserRepository() *UserRepository {
+	return &UserRepository{
+		store: newStore[uuid.UUID](func(user *usermodel.User) *time.Time {
+			return user.Metadata.DeletedAt
+		}),
+	}
+}
+
+// GetUser implements userport.UserPersistencePort.
+func (r *UserRepository) GetUser(
+	_ context.Context, uid uuid.UUID, options *model.GetOptions,
+) (*usermodel.User, error) {
+	return r.store.get(uid, options)
+}
+
+// GetUserByEmail implements userport.UserPersistencePort.
+func (r *UserRepository) GetUserByEmail(_ context.Context, email string) (*usermodel.User, error) {
+	return r.findByEmail(email, false)
+}
+
+// GetUserByEmailIncludingDeleted implements userport.UserPersistencePort.
+func (r *UserRepository) GetUserByEmailIncludingDeleted(_ context.Context, email string) (*usermodel.User, error) {
+	return r.findByEmail(email, true)
+}
+
+// PutUser implements userport.UserPersistencePort.
+func (r *UserRepository) PutUser(_ context.Context, user *usermodel.User) (*usermodel.User, error) {
+	r.store.put(user.Metadata.UID, user)
+
+	return user, nil
+}
+
+// ListUsers implements userport.UserPersistencePort.
+func (r *UserRepository) ListUsers(
+	_ context.Context, options *model.ListOptions,
+) (*model.ListResponse[*usermodel.User], error) {
+	return r.store.list(options, nil)
+}
+
+// DeleteUser implements userport.UserPersistencePort. Users are soft-deleted.
+func (r *UserRepository) DeleteUser(_ context.Context, uid uuid.UUID) error {
+	user, err := r.store.get(uid, nil)
+	if err != nil {
+		return err
+	}
+
+	user.Delete()
+	r.store.put(uid, user)
+
+	return nil
+}
+
+func (r *UserRepository) findByEmail(email string, includeDeleted bool) (*usermodel.User, error) {
+	users := r.store.snapshot(includeDeleted, func(user *usermodel.User) bool {
+		return user.Spec.Email == email
+	})
+	if len(users) == 0 {
+		return nil, errResourceNotExist()
+	}
+
+	return users[0], nil
+}

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/userrole.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/userrole.go
@@ -25,7 +25,7 @@ type UserRoleRepository struct {
 // NewUserRoleRepository creates a new in-memory UserRoleRepository.
 func NewUserRoleRepository(roleRepo *RoleRepository, userRepo *UserRepository) *UserRoleRepository {
 	return &UserRoleRepository{
-		store: newStore[uuid.UUID](func(ur *usermodel.UserRole) *time.Time {
+		store: newStore[uuid.UUID](cloneUserRole, func(ur *usermodel.UserRole) *time.Time {
 			return ur.Metadata.DeletedAt
 		}),
 		roleRepo: roleRepo,

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/userrole.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/userrole.go
@@ -1,0 +1,164 @@
+package inmemory
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	usermodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/model"
+	userport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/port"
+)
+
+var _ userport.UserRolePersistencePort = (*UserRoleRepository)(nil)
+
+// UserRoleRepository is the in-memory implementation of
+// [userport.UserRolePersistencePort]. It reads the role and user stores to
+// resolve the cross-entity queries (GetUserRoles, GetRoleUsers, ...).
+type UserRoleRepository struct {
+	store    *store[uuid.UUID, *usermodel.UserRole]
+	roleRepo *RoleRepository
+	userRepo *UserRepository
+}
+
+// NewUserRoleRepository creates a new in-memory UserRoleRepository.
+func NewUserRoleRepository(roleRepo *RoleRepository, userRepo *UserRepository) *UserRoleRepository {
+	return &UserRoleRepository{
+		store: newStore[uuid.UUID](func(ur *usermodel.UserRole) *time.Time {
+			return ur.Metadata.DeletedAt
+		}),
+		roleRepo: roleRepo,
+		userRepo: userRepo,
+	}
+}
+
+// GetUserRole implements userport.UserRolePersistencePort.
+func (r *UserRoleRepository) GetUserRole(_ context.Context, uid uuid.UUID) (*usermodel.UserRole, error) {
+	return r.store.get(uid, nil)
+}
+
+// GetUserRoleByUserAndRole implements userport.UserRolePersistencePort.
+func (r *UserRoleRepository) GetUserRoleByUserAndRole(
+	_ context.Context, userID, roleID uuid.UUID, namespace string,
+) (*usermodel.UserRole, error) {
+	matches := r.store.snapshot(false, func(ur *usermodel.UserRole) bool {
+		return ur.Spec.UserID == userID &&
+			ur.Spec.RoleID == roleID &&
+			ur.Spec.Namespace == namespace
+	})
+	if len(matches) == 0 {
+		return nil, errResourceNotExist()
+	}
+
+	return matches[0], nil
+}
+
+// PutUserRole implements userport.UserRolePersistencePort.
+func (r *UserRoleRepository) PutUserRole(
+	_ context.Context, userRole *usermodel.UserRole,
+) (*usermodel.UserRole, error) {
+	r.store.put(userRole.Metadata.UID, userRole)
+
+	return userRole, nil
+}
+
+// ListUserRoles implements userport.UserRolePersistencePort.
+func (r *UserRoleRepository) ListUserRoles(
+	_ context.Context, options *model.ListOptions,
+) (*model.ListResponse[*usermodel.UserRole], error) {
+	return r.store.list(options, nil)
+}
+
+// GetUserRoles implements userport.UserRolePersistencePort.
+func (r *UserRoleRepository) GetUserRoles(_ context.Context, userID uuid.UUID) ([]*usermodel.Role, error) {
+	roleIDs := r.roleIDsMatching(func(ur *usermodel.UserRole) bool {
+		return ur.Spec.UserID == userID
+	})
+
+	return r.roleRepo.getByUIDs(roleIDs), nil
+}
+
+// GetUserRolesInNamespace implements userport.UserRolePersistencePort.
+// It returns roles assigned in the given namespace or cluster-wide ("*").
+func (r *UserRoleRepository) GetUserRolesInNamespace(
+	_ context.Context, userID uuid.UUID, namespace string,
+) ([]*usermodel.Role, error) {
+	roleIDs := r.roleIDsMatching(func(ur *usermodel.UserRole) bool {
+		return ur.Spec.UserID == userID &&
+			(ur.Spec.Namespace == namespace || ur.Spec.Namespace == usermodel.WildcardAll)
+	})
+
+	return r.roleRepo.getByUIDs(roleIDs), nil
+}
+
+// GetRoleUsers implements userport.UserRolePersistencePort.
+func (r *UserRoleRepository) GetRoleUsers(_ context.Context, roleID uuid.UUID) ([]*usermodel.User, error) {
+	userRoles := r.store.snapshot(false, func(ur *usermodel.UserRole) bool {
+		return ur.Spec.RoleID == roleID
+	})
+
+	users := make([]*usermodel.User, 0, len(userRoles))
+
+	for _, ur := range userRoles {
+		user, err := r.userRepo.store.get(ur.Spec.UserID, nil)
+		if err != nil {
+			continue
+		}
+
+		users = append(users, user)
+	}
+
+	return users, nil
+}
+
+// DeleteUserRole implements userport.UserRolePersistencePort. Assignments are soft-deleted.
+func (r *UserRoleRepository) DeleteUserRole(_ context.Context, uid uuid.UUID) error {
+	userRole, err := r.store.get(uid, nil)
+	if err != nil {
+		return err
+	}
+
+	userRole.Delete()
+	r.store.put(uid, userRole)
+
+	return nil
+}
+
+// DeleteUserRoles implements userport.UserRolePersistencePort.
+func (r *UserRoleRepository) DeleteUserRoles(_ context.Context, userID uuid.UUID) error {
+	r.softDeleteMatching(func(ur *usermodel.UserRole) bool {
+		return ur.Spec.UserID == userID
+	})
+
+	return nil
+}
+
+// DeleteRoleUsers implements userport.UserRolePersistencePort.
+func (r *UserRoleRepository) DeleteRoleUsers(_ context.Context, roleID uuid.UUID) error {
+	r.softDeleteMatching(func(ur *usermodel.UserRole) bool {
+		return ur.Spec.RoleID == roleID
+	})
+
+	return nil
+}
+
+// roleIDsMatching returns the role UIDs of the non-deleted assignments matching predicate.
+func (r *UserRoleRepository) roleIDsMatching(predicate func(*usermodel.UserRole) bool) []uuid.UUID {
+	userRoles := r.store.snapshot(false, predicate)
+
+	roleIDs := make([]uuid.UUID, 0, len(userRoles))
+	for _, ur := range userRoles {
+		roleIDs = append(roleIDs, ur.Spec.RoleID)
+	}
+
+	return roleIDs
+}
+
+// softDeleteMatching marks every non-deleted assignment matching predicate as deleted.
+func (r *UserRoleRepository) softDeleteMatching(predicate func(*usermodel.UserRole) bool) {
+	for _, ur := range r.store.snapshot(false, predicate) {
+		ur.Delete()
+		r.store.put(ur.Metadata.UID, ur)
+	}
+}

--- a/pkg/apiserver/adapter/secondary/rbac/casbin/memoryadapter.go
+++ b/pkg/apiserver/adapter/secondary/rbac/casbin/memoryadapter.go
@@ -1,0 +1,42 @@
+package casbin
+
+import (
+	"log/slog"
+
+	"github.com/casbin/casbin/v2/model"
+	"github.com/casbin/casbin/v2/persist"
+)
+
+var _ persist.Adapter = (*noopAdapter)(nil)
+
+// noopAdapter is a Casbin storage adapter that persists nothing. It exists so a
+// purely in-memory enforcer (standalone mode) can still satisfy the enforcer's
+// LoadPolicy/SavePolicy contract: the plain in-memory enforcer created from a
+// model alone has a nil adapter, and calling SavePolicy on it panics.
+//
+// Policy rules live only in the enforcer's in-memory model; this adapter just
+// makes load/save/add/remove succeed as no-ops, so RBAC sync works without any
+// external policy store.
+type noopAdapter struct{}
+
+// LoadPolicy implements persist.Adapter. There is nothing to load.
+func (*noopAdapter) LoadPolicy(model.Model) error { return nil }
+
+// SavePolicy implements persist.Adapter. There is nothing to persist.
+func (*noopAdapter) SavePolicy(model.Model) error { return nil }
+
+// AddPolicy implements persist.Adapter (auto-save). No-op.
+func (*noopAdapter) AddPolicy(string, string, []string) error { return nil }
+
+// RemovePolicy implements persist.Adapter (auto-save). No-op.
+func (*noopAdapter) RemovePolicy(string, string, []string) error { return nil }
+
+// RemoveFilteredPolicy implements persist.Adapter (auto-save). No-op.
+func (*noopAdapter) RemoveFilteredPolicy(string, string, int, ...string) error { return nil }
+
+// NewInMemoryEnforcer creates an Enforcer whose policies live only in process
+// memory, backed by a no-op storage adapter so SavePolicy/LoadPolicy are safe.
+// Used in standalone mode where there is no external policy store.
+func NewInMemoryEnforcer(logger *slog.Logger, casbinModel model.Model) (*Enforcer, error) {
+	return NewEnforcerWithAdapter(logger, casbinModel, &noopAdapter{})
+}

--- a/pkg/apiserver/config/database.go
+++ b/pkg/apiserver/config/database.go
@@ -18,4 +18,8 @@ type DatabaseType string
 const (
 	// DatabaseTypeMongoDB represents a MongoDB database.
 	DatabaseTypeMongoDB DatabaseType = "mongodb"
+	// DatabaseTypeInMemory represents an in-memory database used for standalone
+	// (single-node, no external dependency) mode. Data is not persisted across
+	// restarts.
+	DatabaseTypeInMemory DatabaseType = "inmemory"
 )

--- a/pkg/apiserver/internal/app/app.go
+++ b/pkg/apiserver/internal/app/app.go
@@ -42,11 +42,11 @@ type Server struct {
 func New(settings config.ServerSettings) *Server {
 	app := fx.New(
 		// Hexagonal architecture layers
-		adaptermodule.NewAdapterModules(), // Adapters: HTTP, DB, messaging, scheduler
-		infrastructuremodule.New(),        // Bootstrap: Casbin RBAC + default seed hooks
-		applicationmodule.New(),           // Application services
-		domainmodule.New(),                // Domain services
-		NewConfigModule(&settings),        // Configuration
+		adaptermodule.NewAdapterModules(settings.DatabaseSettings.Type), // Adapters: HTTP, DB, messaging, scheduler
+		infrastructuremodule.New(settings.DatabaseSettings.Type),        // Bootstrap: Casbin RBAC + default seed hooks
+		applicationmodule.New(),    // Application services
+		domainmodule.New(),         // Domain services
+		NewConfigModule(&settings), // Configuration
 
 		// Base utilities
 		helper.NewModule(),

--- a/pkg/apiserver/internal/module/adapter/adapter.go
+++ b/pkg/apiserver/internal/module/adapter/adapter.go
@@ -10,17 +10,19 @@ package adapter
 import (
 	"go.uber.org/fx"
 
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/config"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/internal/module/adapter/common"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/internal/module/adapter/primary"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/internal/module/adapter/secondary"
 )
 
-// NewAdapterModules creates the adapter layer module.
-func NewAdapterModules() fx.Option {
+// NewAdapterModules creates the adapter layer module. The database type selects
+// the secondary persistence backend (MongoDB or in-memory standalone).
+func NewAdapterModules(databaseType config.DatabaseType) fx.Option {
 	return fx.Module(
 		"adapter",
 		primary.New(),
-		secondary.New(),
+		secondary.New(databaseType),
 		common.New(),
 	)
 }

--- a/pkg/apiserver/internal/module/adapter/secondary/inmemory.go
+++ b/pkg/apiserver/internal/module/adapter/secondary/inmemory.go
@@ -1,0 +1,96 @@
+package secondary
+
+import (
+	"context"
+
+	"go.uber.org/fx"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/secondary/persistence/inmemory"
+	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
+	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
+	userport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/port"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/internal/module/helper"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/management/healthcheck"
+)
+
+// NewInMemory provides the in-memory persistence adapters used in standalone
+// (single-node) mode, replacing the MongoDB client/database and repositories.
+//
+// Three repositories are provided as concrete singletons in addition to their
+// port bindings, because other repositories depend on the concrete type and
+// must share the very same store instance:
+//   - *inmemory.AgentRepository backs the agent-group statistics,
+//   - *inmemory.RoleRepository and *inmemory.UserRepository back the user-role
+//     cross-entity lookups.
+func NewInMemory() fx.Option {
+	return fx.Options(
+		// Concrete singletons shared across repositories.
+		fx.Provide(
+			inmemory.NewAgentRepository,
+			inmemory.NewRoleRepository,
+			inmemory.NewUserRepository,
+		),
+		fx.Provide(
+			// Bind the shared concrete singletons to their persistence ports.
+			fx.Annotate(identity[*inmemory.AgentRepository], fx.As(new(agentport.AgentPersistencePort))),
+			fx.Annotate(identity[*inmemory.RoleRepository], fx.As(new(userport.RolePersistencePort))),
+			fx.Annotate(identity[*inmemory.UserRepository], fx.As(new(userport.UserPersistencePort))),
+
+			// Health + transaction.
+			helper.AsHealthIndicator(NewInMemoryHealthIndicator),
+			fx.Annotate(inmemory.NewTransactionRunner, fx.As(new(applicationport.TransactionRunner))),
+
+			// Agent-domain repositories.
+			fx.Annotate(inmemory.NewAgentGroupRepository, fx.As(new(agentport.AgentGroupPersistencePort))),
+			fx.Annotate(inmemory.NewServerRepository, fx.As(new(agentport.ServerPersistencePort))),
+			fx.Annotate(inmemory.NewAgentPackageRepository, fx.As(new(agentport.AgentPackagePersistencePort))),
+			fx.Annotate(inmemory.NewNamespaceRepository, fx.As(new(agentport.NamespacePersistencePort))),
+			fx.Annotate(inmemory.NewAgentRemoteConfigRepository, fx.As(new(agentport.AgentRemoteConfigPersistencePort))),
+			fx.Annotate(inmemory.NewCertificateRepository, fx.As(new(agentport.CertificatePersistencePort))),
+
+			// RBAC repositories.
+			fx.Annotate(inmemory.NewPermissionRepository, fx.As(new(userport.PermissionPersistencePort))),
+			fx.Annotate(inmemory.NewUserRoleRepository, fx.As(new(userport.UserRolePersistencePort))),
+			fx.Annotate(inmemory.NewRoleBindingRepository, fx.As(new(userport.RoleBindingPersistencePort))),
+		),
+	)
+}
+
+// identity returns its argument. It lets FX expose a concrete singleton under an
+// interface type without re-running the constructor (which would create a second
+// instance with its own, unshared store).
+func identity[T any](value T) T {
+	return value
+}
+
+// InMemoryHealthIndicator is a health indicator for the in-memory store. It is
+// always healthy and ready, since the store lives in process memory.
+type InMemoryHealthIndicator struct{}
+
+var _ healthcheck.HealthIndicator = (*InMemoryHealthIndicator)(nil)
+
+// NewInMemoryHealthIndicator creates a new InMemoryHealthIndicator.
+func NewInMemoryHealthIndicator() *InMemoryHealthIndicator {
+	return &InMemoryHealthIndicator{}
+}
+
+// Name returns the name of the health indicator.
+func (*InMemoryHealthIndicator) Name() string {
+	return "InMemory"
+}
+
+// Readiness always reports ready.
+func (*InMemoryHealthIndicator) Readiness(context.Context) healthcheck.Readiness {
+	return healthcheck.Readiness{
+		Ready:  true,
+		Reason: "",
+	}
+}
+
+// Health always reports healthy.
+func (*InMemoryHealthIndicator) Health(context.Context) healthcheck.Health {
+	return healthcheck.Health{
+		Healthy: true,
+		Reason:  "in-memory store is always healthy",
+	}
+}

--- a/pkg/apiserver/internal/module/adapter/secondary/secondary.go
+++ b/pkg/apiserver/internal/module/adapter/secondary/secondary.go
@@ -4,12 +4,22 @@ package secondary
 
 import (
 	"go.uber.org/fx"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/config"
 )
 
-// New creates the secondary adapter module.
-func New() fx.Option {
+// New creates the secondary adapter module, selecting the persistence backend
+// from the configured database type. "inmemory" wires the in-memory store
+// (standalone mode); any other value (including the default "mongodb") wires the
+// MongoDB client, database, and repositories.
+func New(databaseType config.DatabaseType) fx.Option {
+	persistence := NewMongoDB()
+	if databaseType == config.DatabaseTypeInMemory {
+		persistence = NewInMemory()
+	}
+
 	return fx.Options(
-		NewMongoDB(),
+		persistence,
 		// Outbound messaging: server-event sender.
 		fx.Provide(newEventSender),
 	)

--- a/pkg/apiserver/internal/module/adapter/secondary/secondary.go
+++ b/pkg/apiserver/internal/module/adapter/secondary/secondary.go
@@ -9,13 +9,13 @@ import (
 )
 
 // New creates the secondary adapter module, selecting the persistence backend
-// from the configured database type. "inmemory" wires the in-memory store
-// (standalone mode); any other value (including the default "mongodb") wires the
-// MongoDB client, database, and repositories.
+// from the configured database type. Only the explicit "mongodb" wires the
+// MongoDB client, database, and repositories; any other value (including the
+// default/empty) wires the in-memory store (standalone mode).
 func New(databaseType config.DatabaseType) fx.Option {
-	persistence := NewMongoDB()
-	if databaseType == config.DatabaseTypeInMemory {
-		persistence = NewInMemory()
+	persistence := NewInMemory()
+	if databaseType == config.DatabaseTypeMongoDB {
+		persistence = NewMongoDB()
 	}
 
 	return fx.Options(

--- a/pkg/apiserver/internal/module/infrastructure/infrastructure.go
+++ b/pkg/apiserver/internal/module/infrastructure/infrastructure.go
@@ -21,9 +21,10 @@ import (
 // New creates the infrastructure bootstrap module: the Casbin RBAC enforcer and
 // the startup hooks that seed the default namespace, default role, and RBAC policies.
 //
-// The database type selects how the Casbin enforcer stores its policies: MongoDB
-// mode persists them in a "casbin_rules" collection, while in-memory (standalone)
-// mode keeps them in process memory and does not depend on a *mongo.Client.
+// The database type selects how the Casbin enforcer stores its policies: the
+// explicit "mongodb" persists them in a "casbin_rules" collection, while any
+// other value (including the default/empty, i.e. standalone) keeps them in
+// process memory and does not depend on a *mongo.Client.
 func New(databaseType config.DatabaseType) fx.Option {
 	return fx.Module(
 		"infrastructure",
@@ -42,9 +43,9 @@ func New(databaseType config.DatabaseType) fx.Option {
 
 // provideRBACComponents provides RBAC enforcer components.
 func provideRBACComponents(databaseType config.DatabaseType) fx.Option {
-	enforcerProvider := any(provideCasbinEnforcer)
-	if databaseType == config.DatabaseTypeInMemory {
-		enforcerProvider = provideInMemoryCasbinEnforcer
+	enforcerProvider := any(provideInMemoryCasbinEnforcer)
+	if databaseType == config.DatabaseTypeMongoDB {
+		enforcerProvider = provideCasbinEnforcer
 	}
 
 	return fx.Options(

--- a/pkg/apiserver/internal/module/infrastructure/infrastructure.go
+++ b/pkg/apiserver/internal/module/infrastructure/infrastructure.go
@@ -20,12 +20,16 @@ import (
 
 // New creates the infrastructure bootstrap module: the Casbin RBAC enforcer and
 // the startup hooks that seed the default namespace, default role, and RBAC policies.
-func New() fx.Option {
+//
+// The database type selects how the Casbin enforcer stores its policies: MongoDB
+// mode persists them in a "casbin_rules" collection, while in-memory (standalone)
+// mode keeps them in process memory and does not depend on a *mongo.Client.
+func New(databaseType config.DatabaseType) fx.Option {
 	return fx.Module(
 		"infrastructure",
 
 		// RBAC (Casbin enforcer)
-		provideRBACComponents(),
+		provideRBACComponents(databaseType),
 
 		// Default namespace initialization
 		fx.Invoke(registerDefaultNamespaceHook),
@@ -37,16 +41,34 @@ func New() fx.Option {
 }
 
 // provideRBACComponents provides RBAC enforcer components.
-func provideRBACComponents() fx.Option {
+func provideRBACComponents(databaseType config.DatabaseType) fx.Option {
+	enforcerProvider := any(provideCasbinEnforcer)
+	if databaseType == config.DatabaseTypeInMemory {
+		enforcerProvider = provideInMemoryCasbinEnforcer
+	}
+
 	return fx.Options(
 		fx.Provide(
-			provideCasbinEnforcer,
+			enforcerProvider,
 			fx.Annotate(
 				Identity[*casbinEnforcer.Enforcer],
 				fx.As(new(userport.RBACEnforcerPort)),
 			),
 		),
 	)
+}
+
+// provideInMemoryCasbinEnforcer builds a Casbin enforcer whose policies live only
+// in process memory. Used in standalone mode where there is no *mongo.Client.
+func provideInMemoryCasbinEnforcer(
+	logger *slog.Logger,
+) (*casbinEnforcer.Enforcer, error) {
+	enforcer, err := casbinEnforcer.NewInMemoryEnforcer(logger, defaultRBACModel())
+	if err != nil {
+		return nil, fmt.Errorf("failed to create in-memory casbin enforcer: %w", err)
+	}
+
+	return enforcer, nil
 }
 
 func provideCasbinEnforcer(

--- a/pkg/cmd/apiserver/apiserver.go
+++ b/pkg/cmd/apiserver/apiserver.go
@@ -149,7 +149,7 @@ func NewCommand(opt CommandOption) *cobra.Command {
 		"config file (default is $HOME/.config/opampcommander/apiserver/config.yaml)")
 	cmd.Flags().String("address", "localhost:8080", "server address")
 	cmd.Flags().String("serverId", "", "server ID (default is hostname, can be overridden by SERVER_ID env var)")
-	cmd.Flags().String("database.type", "mongodb", "database type (mongodb, inmemory)")
+	cmd.Flags().String("database.type", "inmemory", "database type (inmemory, mongodb)")
 	cmd.Flags().StringSlice("database.endpoints", []string{"mongodb://localhost:27017"}, "database endpoints")
 	cmd.Flags().Duration("database.connectTimeout", 10*time.Second, "database connection timeout")
 	cmd.Flags().String("database.databaseName", "opampcommander", "database name")

--- a/pkg/cmd/apiserver/apiserver.go
+++ b/pkg/cmd/apiserver/apiserver.go
@@ -149,7 +149,7 @@ func NewCommand(opt CommandOption) *cobra.Command {
 		"config file (default is $HOME/.config/opampcommander/apiserver/config.yaml)")
 	cmd.Flags().String("address", "localhost:8080", "server address")
 	cmd.Flags().String("serverId", "", "server ID (default is hostname, can be overridden by SERVER_ID env var)")
-	cmd.Flags().String("database.type", "mongodb", "database type (mongodb)")
+	cmd.Flags().String("database.type", "mongodb", "database type (mongodb, inmemory)")
 	cmd.Flags().StringSlice("database.endpoints", []string{"mongodb://localhost:27017"}, "database endpoints")
 	cmd.Flags().Duration("database.connectTimeout", 10*time.Second, "database connection timeout")
 	cmd.Flags().String("database.databaseName", "opampcommander", "database name")

--- a/pkg/testutil/apiserver.go
+++ b/pkg/testutil/apiserver.go
@@ -184,26 +184,8 @@ func (b *Base) StartAPIServer(
 	managementPort := b.GetFreeTCPPort()
 
 	settings := buildServerSettings(serverID, serverPort, managementPort, mongoURI, databaseName)
-	server := apiserver.New(settings)
 
-	serverCtx, serverCancel := context.WithCancel(b.t.Context())
-
-	go func() {
-		_ = server.Run(serverCtx)
-	}()
-
-	return &APIServer{
-		Base:               b,
-		Server:             server,
-		ServerID:           serverID,
-		Endpoint:           fmt.Sprintf("http://localhost:%d", serverPort),
-		Port:               serverPort,
-		ManagementEndpoint: fmt.Sprintf("http://localhost:%d", managementPort),
-		ManagementPort:     managementPort,
-		MongoURI:           mongoURI,
-		Settings:           settings,
-		stopServer:         serverCancel,
-	}
+	return b.launchAPIServer(settings, serverID, serverPort, managementPort, mongoURI)
 }
 
 // StartAPIServerWithKafka starts a new API server backed by MongoDB and Kafka for event processing.
@@ -222,6 +204,43 @@ func (b *Base) StartAPIServerWithKafka(mongoURI, kafkaBroker, databaseName strin
 			Topic:   kafkaEventTopic,
 		},
 	}
+
+	return b.launchAPIServer(settings, serverID, serverPort, managementPort, mongoURI)
+}
+
+// StartStandaloneAPIServer starts a new API server in standalone mode: the
+// in-memory persistence store (no MongoDB) and the in-memory event hub (no
+// Kafka). It needs no external dependencies, so it is suitable for fast
+// integration tests that exercise the full HTTP -> application -> domain ->
+// persistence stack without Docker.
+func (b *Base) StartStandaloneAPIServer() *APIServer {
+	b.t.Helper()
+
+	serverID := b.nextServerID()
+	serverPort := b.GetFreeTCPPort()
+	managementPort := b.GetFreeTCPPort()
+
+	settings := buildServerSettings(serverID, serverPort, managementPort, "", "")
+	settings.DatabaseSettings = config.DatabaseSettings{
+		Type:           config.DatabaseTypeInMemory,
+		Endpoints:      nil,
+		ConnectTimeout: 0,
+		DatabaseName:   "",
+		DDLAuto:        false,
+	}
+
+	return b.launchAPIServer(settings, serverID, serverPort, managementPort, "")
+}
+
+// launchAPIServer constructs and starts an API server from the given settings,
+// returning a handle wired with the test ports and shutdown hook.
+func (b *Base) launchAPIServer(
+	settings config.ServerSettings,
+	serverID string,
+	serverPort, managementPort int,
+	mongoURI string,
+) *APIServer {
+	b.t.Helper()
 
 	server := apiserver.New(settings)
 

--- a/test/integration/standalone_test.go
+++ b/test/integration/standalone_test.go
@@ -1,0 +1,201 @@
+package integration_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/minuk-dev/opampcommander/api/v1"
+	"github.com/minuk-dev/opampcommander/pkg/client"
+	"github.com/minuk-dev/opampcommander/pkg/testutil"
+)
+
+// TestStandaloneAPIServer exercises the full HTTP -> application -> domain ->
+// in-memory persistence stack of an apiserver started in standalone mode
+// (database type "inmemory", no MongoDB, no Kafka). It verifies that resources
+// created over the API are stored and read back from the in-memory adapter, and
+// that soft-deletes hide resources from default reads.
+func TestStandaloneAPIServer(t *testing.T) {
+	t.Parallel()
+
+	base := testutil.NewBase(t)
+	server := base.StartStandaloneAPIServer()
+
+	t.Cleanup(server.Stop)
+	server.WaitForReady()
+
+	ctx := t.Context()
+	apiClient := server.Client()
+
+	t.Run("ping and version respond", func(t *testing.T) {
+		t.Parallel()
+
+		require.NoError(t, apiClient.Ping())
+
+		version, err := apiClient.GetServerVersion(ctx)
+		require.NoError(t, err)
+		assert.NotEmpty(t, version.GoVersion)
+	})
+
+	t.Run("default namespace is seeded into the in-memory store", func(t *testing.T) {
+		t.Parallel()
+
+		def, err := apiClient.NamespaceService.GetNamespace(ctx, "default")
+		require.NoError(t, err)
+		assert.Equal(t, "default", def.Metadata.Name)
+	})
+
+	t.Run("namespace create, get, list round-trips through the in-memory store", func(t *testing.T) {
+		t.Parallel()
+
+		const name = "integration-ns"
+
+		//exhaustruct:ignore
+		created, err := apiClient.NamespaceService.CreateNamespace(ctx, &v1.Namespace{
+			//exhaustruct:ignore
+			Metadata: v1.NamespaceMetadata{Name: name},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, name, created.Metadata.Name)
+
+		got, err := apiClient.NamespaceService.GetNamespace(ctx, name)
+		require.NoError(t, err)
+		assert.Equal(t, name, got.Metadata.Name)
+
+		list, err := apiClient.NamespaceService.ListNamespaces(ctx)
+		require.NoError(t, err)
+		assert.True(t, containsNamespace(list.Items, name),
+			"created namespace should appear in the listing")
+	})
+
+	t.Run("agent group lifecycle including soft-delete", func(t *testing.T) {
+		t.Parallel()
+
+		const groupName = "integration-grp"
+
+		created, err := apiClient.AgentGroupService.CreateAgentGroup(ctx, "default", &v1.AgentGroup{
+			//exhaustruct:ignore
+			Metadata: v1.Metadata{Name: groupName},
+			//exhaustruct:ignore
+			Spec: v1.Spec{
+				Priority: 7,
+				Selector: v1.AgentSelector{
+					IdentifyingAttributes: map[string]string{"service.name": "otelcol"},
+				},
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, groupName, created.Metadata.Name)
+		// No agents exist, so the recomputed statistics are all zero.
+		assert.Equal(t, 0, created.Status.NumAgents)
+
+		got, err := apiClient.AgentGroupService.GetAgentGroup(ctx, "default", groupName)
+		require.NoError(t, err)
+		assert.Equal(t, 7, got.Spec.Priority)
+
+		list, err := apiClient.AgentGroupService.ListAgentGroups(ctx, "default")
+		require.NoError(t, err)
+		assert.True(t, containsAgentGroup(list.Items, groupName),
+			"created agent group should appear in the listing")
+
+		// Soft-delete, then confirm it is hidden from the default read path.
+		require.NoError(t, apiClient.AgentGroupService.DeleteAgentGroup(ctx, "default", groupName))
+
+		_, err = apiClient.AgentGroupService.GetAgentGroup(ctx, "default", groupName)
+		require.Error(t, err, "soft-deleted agent group should not be returned by default")
+
+		listAfter, err := apiClient.AgentGroupService.ListAgentGroups(ctx, "default")
+		require.NoError(t, err)
+		assert.False(t, containsAgentGroup(listAfter.Items, groupName),
+			"soft-deleted agent group should not appear in the default listing")
+	})
+}
+
+// TestStandaloneAPIServer_Pagination verifies the in-memory store's cursor
+// pagination over the public API: a limited list returns a continue token that
+// resumes the listing without overlap.
+func TestStandaloneAPIServer_Pagination(t *testing.T) {
+	t.Parallel()
+
+	base := testutil.NewBase(t)
+	server := base.StartStandaloneAPIServer()
+
+	t.Cleanup(server.Stop)
+	server.WaitForReady()
+
+	ctx := t.Context()
+	apiClient := server.Client()
+
+	const total = 5
+	for _, name := range agentGroupNames(total) {
+		_, err := apiClient.AgentGroupService.CreateAgentGroup(ctx, "default", &v1.AgentGroup{
+			//exhaustruct:ignore
+			Metadata: v1.Metadata{Name: name},
+			//exhaustruct:ignore
+			Spec: v1.Spec{
+				Selector: v1.AgentSelector{
+					IdentifyingAttributes: map[string]string{"service.name": name},
+				},
+			},
+		})
+		require.NoError(t, err)
+	}
+
+	seen := map[string]struct{}{}
+
+	const pageSize = 2
+
+	page, err := apiClient.AgentGroupService.ListAgentGroups(ctx, "default", client.WithLimit(pageSize))
+	require.NoError(t, err)
+
+	for {
+		for _, group := range page.Items {
+			_, dup := seen[group.Metadata.Name]
+			require.False(t, dup, "pagination must not return the same group twice: %s", group.Metadata.Name)
+			seen[group.Metadata.Name] = struct{}{}
+		}
+
+		if page.Metadata.Continue == "" {
+			break
+		}
+
+		page, err = apiClient.AgentGroupService.ListAgentGroups(
+			ctx, "default",
+			client.WithLimit(pageSize),
+			client.WithContinueToken(page.Metadata.Continue),
+		)
+		require.NoError(t, err)
+	}
+
+	assert.Len(t, seen, total, "every created agent group should be visited exactly once")
+}
+
+func agentGroupNames(n int) []string {
+	names := make([]string, 0, n)
+	for i := range n {
+		names = append(names, "page-grp-"+string(rune('a'+i)))
+	}
+
+	return names
+}
+
+func containsNamespace(items []v1.Namespace, name string) bool {
+	for i := range items {
+		if items[i].Metadata.Name == name {
+			return true
+		}
+	}
+
+	return false
+}
+
+func containsAgentGroup(items []v1.AgentGroup, name string) bool {
+	for i := range items {
+		if items[i].Metadata.Name == name {
+			return true
+		}
+	}
+
+	return false
+}


### PR DESCRIPTION
## What

Adds a **standalone mode** that runs the apiserver on a single node with **no MongoDB and no Kafka**, and makes it the **default**: the in-memory persistence store is used unless the database type is explicitly set to `mongodb`.

Data lives only in process memory and is lost on restart — intended for development, demos, and small single-node deployments, not production multi-server setups.

## Default behaviour

- **No config / `database.type` unset → in-memory** (no external dependencies; starts out of the box).
- **`database.type: mongodb` (explicit) → MongoDB**, as before. `dev.yaml` and the sample config set this explicitly and are unchanged.

```sh
go run ./cmd/apiserver/main.go                          # in-memory (default)
make run-standalone                                     # in-memory via configs/apiserver/standalone.yaml
go run ./cmd/apiserver/main.go --database.type=mongodb  # MongoDB
make run-dev-server                                     # MongoDB via dev.yaml (explicit)
```

## Changes

- **In-memory persistence package** (`pkg/apiserver/adapter/secondary/persistence/inmemory/`): a generic concurrency-safe store mirroring the MongoDB common adapter's get/list/put semantics (soft-delete filtering, insertion-order cursor pagination) plus a repository per port, a no-op `TransactionRunner`, and an always-healthy health indicator.
- **FX wiring**: thread the configured database type through the adapter and infrastructure modules; only explicit `mongodb` selects the MongoDB repositories + Casbin Mongo adapter, otherwise the in-memory repositories and an in-memory Casbin enforcer (no `*mongo.Client` dependency).
- **Casbin**: add a no-op `persist.Adapter` so a purely in-memory enforcer can satisfy `LoadPolicy`/`SavePolicy` (a nil adapter panics on `SavePolicy`).
- **Config**: add `DatabaseTypeInMemory`, flip the `--database.type` flag default to `inmemory`, add a `standalone.yaml` sample and a no-MongoDB `run-standalone` make target.
- **Deep-copy on read/write**: the store clones values on the way in and out (under the lock), reproducing MongoDB's fresh-copy-per-call semantics so concurrent callers never share/race on the same domain object.

## Tests

- Unit tests for the store (pagination, soft-delete, search, agent-group statistics, copy isolation, concurrent reader/writer).
- Integration tests (`test/integration/standalone_test.go`) that boot the apiserver in standalone mode and drive the full HTTP → application → domain → in-memory persistence stack **without Docker**: ping/version, default-namespace seeding, namespace + agent-group CRUD with soft-delete, and cursor pagination.
- `go test -race` passes for both unit and integration tests; `golangci-lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)