### PR TITLE
ci(deploy): auto-deploy opampcommander alpha-standalone overlay

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -81,25 +81,36 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.MINUK_CLUSTER_DEPLOY_KEY }}
 
-      - name: Deploy alpha and alpha-ha to minuk-cluster
+      - name: Deploy alpha, alpha-ha and alpha-standalone to minuk-cluster
         if: startsWith(github.ref, 'refs/heads/')
         run: |
           git clone git@github.com:minuk-cluster/minuk-cluster.git /tmp/minuk-cluster
           cd /tmp/minuk-cluster
 
-          overlays=(alpha alpha-ha)
-          for overlay in "${overlays[@]}"; do
-            kustomization="argocd/apps/opampcommander/overlays/${overlay}/kustomization.yaml"
-            yq '(.images[] | select(.name == "ghcr.io/minuk-dev/opampcommander")).newTag = strenv(VERSION)' \
-              -i "${kustomization}"
+          kustomizations=(
+            "argocd/apps/opampcommander/overlays/alpha/kustomization.yaml"
+            "argocd/apps/opampcommander/overlays/alpha-ha/kustomization.yaml"
+            "argocd/apps/opampcommander-alpha-standalone/kustomization.yaml"
+          )
+          # Only touch the apiserver entry if that kustomization declares it, so a
+          # missing/renamed target is skipped instead of failing the whole run.
+          for kustomization in "${kustomizations[@]}"; do
+            if yq -e '.images[] | select(.name == "ghcr.io/minuk-dev/opampcommander")' "${kustomization}" >/dev/null 2>&1; then
+              yq '(.images[] | select(.name == "ghcr.io/minuk-dev/opampcommander")).newTag = strenv(VERSION)' \
+                -i "${kustomization}"
+            fi
           done
 
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
-          for overlay in "${overlays[@]}"; do
-            git add "argocd/apps/opampcommander/overlays/${overlay}/kustomization.yaml"
+          for kustomization in "${kustomizations[@]}"; do
+            git add "${kustomization}"
           done
-          git commit -m "chore(deploy): update opampcommander apiserver alpha and alpha-ha to ${VERSION}"
+          if git diff --cached --quiet; then
+            echo "No apiserver image tag updates needed."
+            exit 0
+          fi
+          git commit -m "chore(deploy): update opampcommander apiserver alpha, alpha-ha and alpha-standalone to ${VERSION}"
 
           # retry on push conflict from concurrent CI runs (web-release runs in parallel)
           for i in 1 2 3; do

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -87,29 +87,18 @@ jobs:
           git clone git@github.com:minuk-cluster/minuk-cluster.git /tmp/minuk-cluster
           cd /tmp/minuk-cluster
 
-          kustomizations=(
-            "argocd/apps/opampcommander/overlays/alpha/kustomization.yaml"
-            "argocd/apps/opampcommander/overlays/alpha-ha/kustomization.yaml"
-            "argocd/apps/opampcommander-alpha-standalone/kustomization.yaml"
-          )
-          # Only touch the apiserver entry if that kustomization declares it, so a
-          # missing/renamed target is skipped instead of failing the whole run.
-          for kustomization in "${kustomizations[@]}"; do
-            if yq -e '.images[] | select(.name == "ghcr.io/minuk-dev/opampcommander")' "${kustomization}" >/dev/null 2>&1; then
-              yq '(.images[] | select(.name == "ghcr.io/minuk-dev/opampcommander")).newTag = strenv(VERSION)' \
-                -i "${kustomization}"
-            fi
+          overlays=(alpha alpha-ha alpha-standalone)
+          for overlay in "${overlays[@]}"; do
+            kustomization="argocd/apps/opampcommander/overlays/${overlay}/kustomization.yaml"
+            yq '(.images[] | select(.name == "ghcr.io/minuk-dev/opampcommander")).newTag = strenv(VERSION)' \
+              -i "${kustomization}"
           done
 
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
-          for kustomization in "${kustomizations[@]}"; do
-            git add "${kustomization}"
+          for overlay in "${overlays[@]}"; do
+            git add "argocd/apps/opampcommander/overlays/${overlay}/kustomization.yaml"
           done
-          if git diff --cached --quiet; then
-            echo "No apiserver image tag updates needed."
-            exit 0
-          fi
           git commit -m "chore(deploy): update opampcommander apiserver alpha, alpha-ha and alpha-standalone to ${VERSION}"
 
           # retry on push conflict from concurrent CI runs (web-release runs in parallel)

--- a/.github/workflows/web-release.yaml
+++ b/.github/workflows/web-release.yaml
@@ -81,14 +81,11 @@ jobs:
           git clone git@github.com:minuk-cluster/minuk-cluster.git /tmp/minuk-cluster
           cd /tmp/minuk-cluster
 
-          kustomizations=(
-            "argocd/apps/opampcommander/overlays/alpha/kustomization.yaml"
-            "argocd/apps/opampcommander/overlays/alpha-ha/kustomization.yaml"
-            "argocd/apps/opampcommander-alpha-standalone/kustomization.yaml"
-          )
-          # Only touch the web entry if that kustomization already declares it,
-          # so a target without a web image is skipped instead of failing the run.
-          for kustomization in "${kustomizations[@]}"; do
+          overlays=(alpha alpha-ha alpha-standalone)
+          # Only touch the web entry if minuk-cluster already declares it,
+          # so this workflow stays a no-op while that side is being wired up.
+          for overlay in "${overlays[@]}"; do
+            kustomization="argocd/apps/opampcommander/overlays/${overlay}/kustomization.yaml"
             if yq -e '.images[] | select(.name == "ghcr.io/minuk-dev/opampcommander-web")' "${kustomization}" >/dev/null 2>&1; then
               yq '(.images[] | select(.name == "ghcr.io/minuk-dev/opampcommander-web")).newTag = strenv(VERSION)' \
                 -i "${kustomization}"
@@ -97,8 +94,8 @@ jobs:
 
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
-          for kustomization in "${kustomizations[@]}"; do
-            git add "${kustomization}"
+          for overlay in "${overlays[@]}"; do
+            git add "argocd/apps/opampcommander/overlays/${overlay}/kustomization.yaml"
           done
           if git diff --cached --quiet; then
             echo "No web image tag updates needed."

--- a/.github/workflows/web-release.yaml
+++ b/.github/workflows/web-release.yaml
@@ -75,17 +75,20 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.MINUK_CLUSTER_DEPLOY_KEY }}
 
-      - name: Deploy alpha and alpha-ha to minuk-cluster
+      - name: Deploy alpha, alpha-ha and alpha-standalone to minuk-cluster
         if: startsWith(github.ref, 'refs/heads/')
         run: |
           git clone git@github.com:minuk-cluster/minuk-cluster.git /tmp/minuk-cluster
           cd /tmp/minuk-cluster
 
-          overlays=(alpha alpha-ha)
-          # Only touch the web entry if minuk-cluster already declares it,
-          # so this workflow stays a no-op while that side is being wired up.
-          for overlay in "${overlays[@]}"; do
-            kustomization="argocd/apps/opampcommander/overlays/${overlay}/kustomization.yaml"
+          kustomizations=(
+            "argocd/apps/opampcommander/overlays/alpha/kustomization.yaml"
+            "argocd/apps/opampcommander/overlays/alpha-ha/kustomization.yaml"
+            "argocd/apps/opampcommander-alpha-standalone/kustomization.yaml"
+          )
+          # Only touch the web entry if that kustomization already declares it,
+          # so a target without a web image is skipped instead of failing the run.
+          for kustomization in "${kustomizations[@]}"; do
             if yq -e '.images[] | select(.name == "ghcr.io/minuk-dev/opampcommander-web")' "${kustomization}" >/dev/null 2>&1; then
               yq '(.images[] | select(.name == "ghcr.io/minuk-dev/opampcommander-web")).newTag = strenv(VERSION)' \
                 -i "${kustomization}"
@@ -94,14 +97,14 @@ jobs:
 
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git config user.name "github-actions[bot]"
-          for overlay in "${overlays[@]}"; do
-            git add "argocd/apps/opampcommander/overlays/${overlay}/kustomization.yaml"
+          for kustomization in "${kustomizations[@]}"; do
+            git add "${kustomization}"
           done
           if git diff --cached --quiet; then
             echo "No web image tag updates needed."
             exit 0
           fi
-          git commit -m "chore(deploy): update opampcommander-web alpha and alpha-ha to ${VERSION}"
+          git commit -m "chore(deploy): update opampcommander-web alpha, alpha-ha and alpha-standalone to ${VERSION}"
 
           # retry on push conflict from concurrent CI runs (release runs in parallel)
           for i in 1 2 3; do


### PR DESCRIPTION
## What

Adds the new **alpha-standalone** overlay to the minuk-cluster auto-deploy step in `release.yaml` and `web-release.yaml`, so its apiserver/web image tags are bumped on every push to `main`, exactly like `alpha` and `alpha-ha`.

## How

`alpha-standalone` is a base overlay (`argocd/apps/opampcommander/overlays/alpha-standalone`, in-memory persistence, no MongoDB, with web), so it just joins the overlay list the deploy step already iterates:

```
overlays=(alpha alpha-ha alpha-standalone)
```

No structural change to the workflows beyond the added overlay and the commit messages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)