### PR TITLE
feat: search agents by non-identifying attribute (web + opampctl)

### DIFF
--- a/pkg/apiserver/adapter/primary/http/v1/agent/controller.go
+++ b/pkg/apiserver/adapter/primary/http/v1/agent/controller.go
@@ -93,6 +93,7 @@ func (c *Controller) RoutesInfo() gin.RoutesInfo {
 // @Param continue query string false "Token to continue listing agents"
 // @Param connected query bool false "When true, return only currently-connected agents"
 // @Param selector query []string false "Identifying attribute filter (key=value, repeatable)" collectionFormat(multi)
+// @Param nonIdentifyingSelector query []string false "Non-identifying attribute (key=value)" collectionFormat(multi)
 // @Failure 400 {object} ErrorModel
 // @Failure 500 {object} ErrorModel
 // @Router /api/v1/namespaces/{namespace}/agents [get].
@@ -125,13 +126,22 @@ func (c *Controller) List(ctx *gin.Context) {
 		return
 	}
 
+	nonIdentifyingAttributes, err := parseSelector(ctx.QueryArray("nonIdentifyingSelector"))
+	if err != nil {
+		ginutil.HandleValidationError(ctx, "nonIdentifyingSelector",
+			strings.Join(ctx.QueryArray("nonIdentifyingSelector"), ","), err, false)
+
+		return
+	}
+
 	continueToken := ctx.Query("continue")
 
 	response, err := c.agentUsecase.ListAgents(ctx.Request.Context(), namespace, &model.ListOptions{
-		Limit:                 limit,
-		Continue:              continueToken,
-		ConnectedOnly:         connectedOnly,
-		IdentifyingAttributes: identifyingAttributes,
+		Limit:                    limit,
+		Continue:                 continueToken,
+		ConnectedOnly:            connectedOnly,
+		IdentifyingAttributes:    identifyingAttributes,
+		NonIdentifyingAttributes: nonIdentifyingAttributes,
 	})
 	if err != nil {
 		c.logger.Error("failed to list agents", "error", err.Error())

--- a/pkg/apiserver/adapter/primary/http/v1/agent/controller_test.go
+++ b/pkg/apiserver/adapter/primary/http/v1/agent/controller_test.go
@@ -279,6 +279,46 @@ func TestAgentControllerListAgent(t *testing.T) {
 	})
 }
 
+func TestAgentControllerListAgentSelectorThreading(t *testing.T) {
+	t.Parallel()
+
+	ctrlBase := testutil.NewBase(t).ForController()
+	agentUsecase := usecasemock.NewMockManageUsecase(t)
+	controller := agent.NewController(agentUsecase, ctrlBase.Logger)
+	ctrlBase.SetupRouter(controller)
+	router := ctrlBase.Router
+
+	// given: selector and nonIdentifyingSelector map to their own attribute sets.
+	agentUsecase.EXPECT().
+		ListAgents(mock.Anything, "default", mock.MatchedBy(func(opts *model.ListOptions) bool {
+			return opts != nil &&
+				opts.IdentifyingAttributes["service.name"] == "otel-collector" &&
+				opts.NonIdentifyingAttributes["os.type"] == "linux"
+		})).
+		Return(&v1.ListResponse[v1.Agent]{
+			APIVersion: "v1",
+			Kind:       v1.AgentKind,
+			Items:      []v1.Agent{},
+			Metadata: v1.ListMeta{
+				RemainingItemCount: 0,
+				Continue:           "",
+			},
+		}, nil)
+
+	// when
+	recorder := httptest.NewRecorder()
+	req, err := http.NewRequestWithContext(
+		t.Context(), http.MethodGet,
+		"/api/v1/namespaces/default/agents?selector=service.name=otel-collector&nonIdentifyingSelector=os.type=linux",
+		nil,
+	)
+	require.NoError(t, err)
+
+	// then
+	router.ServeHTTP(recorder, req)
+	assert.Equal(t, http.StatusOK, recorder.Code)
+}
+
 func TestAgentControllerGetAgent(t *testing.T) {
 	t.Parallel()
 	t.Run("Get Agent - happycase", func(t *testing.T) {

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/agent.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/agent.go
@@ -62,9 +62,10 @@ func (r *AgentRepository) ListAgents(
 ) (*model.ListResponse[*agentmodel.Agent], error) {
 	connectedOnly := options != nil && options.ConnectedOnly
 
-	var identifyingAttributes map[string]string
+	var identifyingAttributes, nonIdentifyingAttributes map[string]string
 	if options != nil {
 		identifyingAttributes = options.IdentifyingAttributes
+		nonIdentifyingAttributes = options.NonIdentifyingAttributes
 	}
 
 	return r.store.list(options, func(agent *agentmodel.Agent) bool {
@@ -72,7 +73,11 @@ func (r *AgentRepository) ListAgents(
 			return false
 		}
 
-		if !matchesIdentifyingAttributes(agent, identifyingAttributes) {
+		if !matchesAttributes(agent.Metadata.Description.IdentifyingAttributes, identifyingAttributes) {
+			return false
+		}
+
+		if !matchesAttributes(agent.Metadata.Description.NonIdentifyingAttributes, nonIdentifyingAttributes) {
 			return false
 		}
 

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/common.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/common.go
@@ -38,13 +38,14 @@ func matchesSelector(agent *agentmodel.Agent, selector agentmodel.AgentSelector)
 	return true
 }
 
-// matchesIdentifyingAttributes reports whether the agent's identifying attributes
-// contain every key=value pair (an AND of equality conditions). An empty map
-// matches all agents, mirroring the MongoDB identifying-attribute filter used by
-// the namespaced agent listing.
-func matchesIdentifyingAttributes(agent *agentmodel.Agent, attributes map[string]string) bool {
-	for key, value := range attributes {
-		if agent.Metadata.Description.IdentifyingAttributes[key] != value {
+// matchesAttributes reports whether the stored attribute map contains every
+// key=value pair in the selector (an AND of equality conditions). An empty
+// selector matches everything, mirroring the MongoDB attribute filter used by the
+// namespaced agent listing. It is used for both identifying and non-identifying
+// attributes.
+func matchesAttributes(stored, selector map[string]string) bool {
+	for key, value := range selector {
+		if stored[key] != value {
 			return false
 		}
 	}

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/inmemory_test.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/inmemory_test.go
@@ -147,6 +147,54 @@ func TestAgentRepository_ListByIdentifyingAttributesSelector(t *testing.T) {
 	assert.Empty(t, resp.Items)
 }
 
+func TestAgentRepository_ListByNonIdentifyingAttributesSelector(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo := inmemory.NewAgentRepository()
+
+	const selectorNamespace = "sel-ns"
+
+	match := agentmodel.NewAgent(uuid.New())
+	match.Metadata.Namespace = selectorNamespace
+	match.Metadata.Description.IdentifyingAttributes = map[string]string{"service.name": "otel-collector"}
+	match.Metadata.Description.NonIdentifyingAttributes = map[string]string{"os.type": "linux", "host.arch": "amd64"}
+	require.NoError(t, repo.PutAgent(ctx, match))
+
+	// Same non-identifying key, different value -> excluded by exact match.
+	otherValue := agentmodel.NewAgent(uuid.New())
+	otherValue.Metadata.Namespace = selectorNamespace
+	otherValue.Metadata.Description.NonIdentifyingAttributes = map[string]string{"os.type": "windows"}
+	require.NoError(t, repo.PutAgent(ctx, otherValue))
+
+	//exhaustruct:ignore
+	resp, err := repo.ListAgents(ctx, selectorNamespace, &model.ListOptions{
+		NonIdentifyingAttributes: map[string]string{"os.type": "linux"},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Items, 1)
+	assert.Equal(t, match.Metadata.InstanceUID, resp.Items[0].Metadata.InstanceUID)
+
+	// Identifying and non-identifying selectors are AND-combined.
+	//exhaustruct:ignore
+	resp, err = repo.ListAgents(ctx, selectorNamespace, &model.ListOptions{
+		IdentifyingAttributes:    map[string]string{"service.name": "otel-collector"},
+		NonIdentifyingAttributes: map[string]string{"os.type": "linux"},
+	})
+	require.NoError(t, err)
+	require.Len(t, resp.Items, 1)
+	assert.Equal(t, match.Metadata.InstanceUID, resp.Items[0].Metadata.InstanceUID)
+
+	// A non-identifying mismatch excludes the agent even when identifying matches.
+	//exhaustruct:ignore
+	resp, err = repo.ListAgents(ctx, selectorNamespace, &model.ListOptions{
+		IdentifyingAttributes:    map[string]string{"service.name": "otel-collector"},
+		NonIdentifyingAttributes: map[string]string{"os.type": "darwin"},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, resp.Items)
+}
+
 func TestNamespaceRepository_SoftDeleteHiddenUnlessIncluded(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/agent.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/agent.go
@@ -95,11 +95,13 @@ func (a *AgentRepository) ListAgents(
 		if options.ConnectedOnly {
 			conditions = append(conditions, connectedMatchFilter())
 		}
-		// Each identifying-attribute condition is a separate $elemMatch on the same
-		// field, so they must be combined with $and (via buildFilter) rather than
-		// flattened into one map, which would drop all but the last.
+		// Each attribute condition is a separate $elemMatch on the same field, so
+		// they must be combined with $and (via buildFilter) rather than flattened
+		// into one map, which would drop all but the last.
 		conditions = append(conditions,
 			IdentifyingAttributesSelectorToMatchConditions(options.IdentifyingAttributes)...)
+		conditions = append(conditions,
+			NonIdentifyingAttributesSelectorToMatchConditions(options.NonIdentifyingAttributes)...)
 	}
 
 	resp, err := a.common.listWithFilter(ctx, options, buildFilter(conditions))

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/agent_test.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/agent_test.go
@@ -316,6 +316,64 @@ func TestAgentMongoAdapter_ListAgents(t *testing.T) {
 	})
 }
 
+func TestAgentMongoAdapter_ListAgentsByNonIdentifyingSelector(t *testing.T) {
+	testcontainers.SkipIfProviderIsNotHealthy(t)
+	t.Parallel()
+	base := testutil.NewBase(t)
+	ctx := t.Context()
+	mongoDBContainer, err := mongoTestContainer.Run(
+		ctx,
+		testMongoDBImage,
+	)
+	require.NoError(t, err)
+
+	mongoDBURI, err := mongoDBContainer.ConnectionString(ctx)
+	require.NoError(t, err)
+
+	client, err := mongo.Connect(options.Client().ApplyURI(mongoDBURI))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := client.Disconnect(ctx)
+		require.NoError(t, err)
+	})
+
+	database := client.Database("testdb_selector_nonident")
+	agentRepository := mongodb.NewAgentRepository(database, base.Logger)
+
+	match := agentmodel.NewAgent(uuid.New(), agentmodel.WithDescription(&agent.Description{
+		IdentifyingAttributes:    map[string]string{"service.name": "otel-collector"},
+		NonIdentifyingAttributes: map[string]string{"os.type": "linux", "host.arch": "amd64"},
+	}))
+	require.NoError(t, agentRepository.PutAgent(ctx, match))
+
+	otherValue := agentmodel.NewAgent(uuid.New(), agentmodel.WithDescription(&agent.Description{
+		IdentifyingAttributes:    map[string]string{"service.name": "otel-collector"},
+		NonIdentifyingAttributes: map[string]string{"os.type": "windows"},
+	}))
+	require.NoError(t, agentRepository.PutAgent(ctx, otherValue))
+
+	// when: filter by a non-identifying attribute.
+	//exhaustruct:ignore
+	listResponse, err := agentRepository.ListAgents(ctx, "default", &model.ListOptions{
+		NonIdentifyingAttributes: map[string]string{"os.type": "linux"},
+	})
+
+	// then
+	require.NoError(t, err)
+	require.Len(t, listResponse.Items, 1)
+	assert.Equal(t, match.Metadata.InstanceUID, listResponse.Items[0].Metadata.InstanceUID)
+
+	// when: identifying and non-identifying selectors are AND-combined; a
+	// non-identifying mismatch excludes the agent even when identifying matches.
+	//exhaustruct:ignore
+	none, err := agentRepository.ListAgents(ctx, "default", &model.ListOptions{
+		IdentifyingAttributes:    map[string]string{"service.name": "otel-collector"},
+		NonIdentifyingAttributes: map[string]string{"os.type": "darwin"},
+	})
+	require.NoError(t, err)
+	assert.Empty(t, none.Items)
+}
+
 func TestAgentMongoAdapter_ListAgents_ConnectedOnly(t *testing.T) {
 	testcontainers.SkipIfProviderIsNotHealthy(t)
 	t.Parallel()

--- a/pkg/apiserver/docs/docs.go
+++ b/pkg/apiserver/docs/docs.go
@@ -898,6 +898,16 @@ const docTemplate = `{
                         "description": "Identifying attribute filter (key=value, repeatable)",
                         "name": "selector",
                         "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Non-identifying attribute (key=value)",
+                        "name": "nonIdentifyingSelector",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/pkg/apiserver/docs/swagger.json
+++ b/pkg/apiserver/docs/swagger.json
@@ -890,6 +890,16 @@
                         "description": "Identifying attribute filter (key=value, repeatable)",
                         "name": "selector",
                         "in": "query"
+                    },
+                    {
+                        "type": "array",
+                        "items": {
+                            "type": "string"
+                        },
+                        "collectionFormat": "multi",
+                        "description": "Non-identifying attribute (key=value)",
+                        "name": "nonIdentifyingSelector",
+                        "in": "query"
                     }
                 ],
                 "responses": {

--- a/pkg/apiserver/docs/swagger.yaml
+++ b/pkg/apiserver/docs/swagger.yaml
@@ -1733,6 +1733,13 @@ paths:
           type: string
         name: selector
         type: array
+      - collectionFormat: multi
+        description: Non-identifying attribute (key=value)
+        in: query
+        items:
+          type: string
+        name: nonIdentifyingSelector
+        type: array
       produces:
       - application/json
       responses:

--- a/pkg/apiserver/domain/model/listoption.go
+++ b/pkg/apiserver/domain/model/listoption.go
@@ -19,6 +19,12 @@ type ListOptions struct {
 	// equality conditions, mirroring agent-group selector semantics). It is a
 	// no-op for resources that have no identifying attributes.
 	IdentifyingAttributes map[string]string
+
+	// NonIdentifyingAttributes, when non-empty, restricts an agent listing to
+	// agents whose non-identifying attributes match every key=value pair exactly
+	// (an AND of equality conditions). It is combined with IdentifyingAttributes
+	// via AND, and is a no-op for resources that have no non-identifying attributes.
+	NonIdentifyingAttributes map[string]string
 }
 
 // GetOptions is a struct that holds options for getting a single resource.

--- a/pkg/client/option.go
+++ b/pkg/client/option.go
@@ -81,6 +81,9 @@ type ListSettings struct {
 	// selector filters agents by identifying attributes (exact key=value match);
 	// nil or empty means no attribute filter.
 	selector map[string]string
+	// nonIdentifyingSelector filters agents by non-identifying attributes (exact
+	// key=value match); nil or empty means no attribute filter.
+	nonIdentifyingSelector map[string]string
 }
 
 // ListOptionFunc is a function type that implements the ListOption interface.
@@ -124,6 +127,15 @@ func WithSelector(selector map[string]string) ListOption {
 	})
 }
 
+// WithNonIdentifyingSelector filters an agent listing by non-identifying
+// attributes, matching every key=value pair exactly. An empty map applies no
+// filter.
+func WithNonIdentifyingSelector(selector map[string]string) ListOption {
+	return ListOptionFunc(func(opt *ListSettings) {
+		opt.nonIdentifyingSelector = selector
+	})
+}
+
 // GetOption is an interface for options that can be applied to get operations.
 type GetOption interface {
 	Apply(settings *GetSettings)
@@ -164,22 +176,33 @@ func (s ListSettings) applyTo(req *resty.Request) {
 		req.SetQueryParam("includeDeleted", "true")
 	}
 
-	if len(s.selector) > 0 {
-		pairs := make([]string, 0, len(s.selector))
-		for key, value := range s.selector {
-			pairs = append(pairs, key+"="+value)
-		}
-		// Sort for a deterministic, cache-friendly query string. Each pair is sent
-		// as a separate `selector` parameter (rather than comma-joined) so attribute
-		// values may safely contain commas.
-		sort.Strings(pairs)
+	values := url.Values{}
+	addSelectorParams(values, "selector", s.selector)
+	addSelectorParams(values, "nonIdentifyingSelector", s.nonIdentifyingSelector)
 
-		values := url.Values{}
-		for _, pair := range pairs {
-			values.Add("selector", pair)
-		}
-
+	if len(values) > 0 {
 		req.SetQueryParamsFromValues(values)
+	}
+}
+
+// addSelectorParams adds one query parameter named paramName per key=value pair in
+// selector. Pairs are sorted for a deterministic, cache-friendly query string and
+// sent separately (rather than comma-joined) so attribute values may safely
+// contain commas. An empty selector adds nothing.
+func addSelectorParams(values url.Values, paramName string, selector map[string]string) {
+	if len(selector) == 0 {
+		return
+	}
+
+	pairs := make([]string, 0, len(selector))
+	for key, value := range selector {
+		pairs = append(pairs, key+"="+value)
+	}
+
+	sort.Strings(pairs)
+
+	for _, pair := range pairs {
+		values.Add(paramName, pair)
 	}
 }
 

--- a/pkg/cmd/opampctl/get/agent/agent.go
+++ b/pkg/cmd/opampctl/get/agent/agent.go
@@ -35,12 +35,13 @@ type CommandOptions struct {
 	*config.GlobalConfig
 
 	// flags
-	formatType         string
-	byAgentGroup       string
-	namespace          string
-	allNamespaces      bool
-	decodeCapabilities bool
-	selector           map[string]string
+	formatType             string
+	byAgentGroup           string
+	namespace              string
+	allNamespaces          bool
+	decodeCapabilities     bool
+	selector               map[string]string
+	nonIdentifyingSelector map[string]string
 
 	// internal
 	client *client.Client
@@ -78,6 +79,10 @@ func NewCommand(options CommandOptions) *cobra.Command {
 	cmd.Flags().StringToStringVarP(
 		&options.selector, "selector", "l", nil,
 		"Filter agents by identifying attributes (exact match), e.g. -l service.name=otel-collector,service.namespace=prod",
+	)
+	cmd.Flags().StringToStringVar(
+		&options.nonIdentifyingSelector, "non-identifying-selector", nil,
+		"Filter agents by non-identifying attributes (exact match), e.g. --non-identifying-selector os.type=linux",
 	)
 
 	return cmd
@@ -147,30 +152,40 @@ func (opt *CommandOptions) List(cmd *cobra.Command) error {
 		return err
 	}
 
-	// The agent-group endpoint does not understand the selector, so apply the
-	// identifying-attribute filter client-side here. For the plain list paths the
-	// server has already filtered, making this a harmless no-op.
-	agents = filterAgentsBySelector(agents, opt.selector)
+	// The agent-group endpoint does not understand the selectors, so apply the
+	// attribute filters client-side here. For the plain list paths the server has
+	// already filtered, making this a harmless no-op.
+	agents = filterAgentsBySelectors(agents, opt.selector, opt.nonIdentifyingSelector)
 
 	return opt.formatAgents(cmd, agents)
 }
 
-// filterAgentsBySelector keeps only agents whose identifying attributes match every
-// key=value pair in the selector. An empty selector returns the input unchanged.
-func filterAgentsBySelector(agents []v1.Agent, selector map[string]string) []v1.Agent {
-	if len(selector) == 0 {
+// filterAgentsBySelectors keeps only agents whose identifying and non-identifying
+// attributes each match every key=value pair in the respective selector. Empty
+// selectors return the input unchanged.
+func filterAgentsBySelectors(
+	agents []v1.Agent,
+	identifying, nonIdentifying map[string]string,
+) []v1.Agent {
+	if len(identifying) == 0 && len(nonIdentifying) == 0 {
 		return agents
 	}
 
 	return lo.Filter(agents, func(agent v1.Agent, _ int) bool {
-		for key, value := range selector {
-			if agent.Metadata.Description.IdentifyingAttributes[key] != value {
-				return false
-			}
-		}
-
-		return true
+		return attributesMatch(agent.Metadata.Description.IdentifyingAttributes, identifying) &&
+			attributesMatch(agent.Metadata.Description.NonIdentifyingAttributes, nonIdentifying)
 	})
+}
+
+// attributesMatch reports whether stored contains every key=value pair in selector.
+func attributesMatch(stored, selector map[string]string) bool {
+	for key, value := range selector {
+		if stored[key] != value {
+			return false
+		}
+	}
+
+	return true
 }
 
 // Get retrieves the agent information for the given agent UIDs.
@@ -254,7 +269,9 @@ func (opt *CommandOptions) ValidArgsFunction(
 func (opt *CommandOptions) listSingleNamespace(cmd *cobra.Command) ([]v1.Agent, error) {
 	if opt.byAgentGroup == "" {
 		agents, err := clientutil.ListAgentFully(
-			cmd.Context(), opt.client, opt.namespace, client.WithSelector(opt.selector),
+			cmd.Context(), opt.client, opt.namespace,
+			client.WithSelector(opt.selector),
+			client.WithNonIdentifyingSelector(opt.nonIdentifyingSelector),
 		)
 		if err != nil {
 			return nil, fmt.Errorf("failed to list agents: %w", err)
@@ -278,7 +295,9 @@ func (opt *CommandOptions) listAllNamespaces(cmd *cobra.Command) ([]v1.Agent, er
 		cmd.Context(), opt.client,
 		func(ctx context.Context, namespace string) ([]v1.Agent, error) {
 			if opt.byAgentGroup == "" {
-				return clientutil.ListAgentFully(ctx, opt.client, namespace, client.WithSelector(opt.selector))
+				return clientutil.ListAgentFully(ctx, opt.client, namespace,
+					client.WithSelector(opt.selector),
+					client.WithNonIdentifyingSelector(opt.nonIdentifyingSelector))
 			}
 
 			return clientutil.ListAgentFullyByAgentGroup(ctx, opt.client, namespace, opt.byAgentGroup)

--- a/web/app/agents/page.tsx
+++ b/web/app/agents/page.tsx
@@ -50,7 +50,7 @@ import { useCursorPagination } from '@/lib/pagination';
 import { useApi } from '@/lib/swr';
 import type { Agent, AgentGroup, ListResponse } from '@/lib/types';
 
-type SearchMode = 'uid' | 'group' | 'description' | 'attribute';
+type SearchMode = 'uid' | 'group' | 'description' | 'attribute' | 'nattribute';
 
 // `lcNeedle` is expected to be pre-lowercased by the caller so we don't redo
 // it for every agent in a filter pass.
@@ -134,9 +134,18 @@ function AgentsInner() {
   const qParam = search.get('q') || '';
   const descParam = search.get('desc') || '';
   const selectorParam = search.get('selector') || '';
+  const nonIdentifyingSelectorParam = search.get('nonIdentifyingSelector') || '';
   const modeParam =
     (search.get('mode') as SearchMode | null) ||
-    (agentGroupParam ? 'group' : descParam ? 'description' : selectorParam ? 'attribute' : 'uid');
+    (agentGroupParam
+      ? 'group'
+      : descParam
+        ? 'description'
+        : selectorParam
+          ? 'attribute'
+          : nonIdentifyingSelectorParam
+            ? 'nattribute'
+            : 'uid');
 
   const [mode, setMode] = useState<SearchMode>(modeParam);
   const [query, setQuery] = useState(qParam);
@@ -166,6 +175,9 @@ function AgentsInner() {
     if (selectorParam) {
       listQuery.selector = selectorParam;
     }
+    if (nonIdentifyingSelectorParam) {
+      listQuery.nonIdentifyingSelector = nonIdentifyingSelectorParam;
+    }
   }
   if (!showDisconnected) {
     listQuery.connected = 'true';
@@ -190,7 +202,8 @@ function AgentsInner() {
     else if (mode === 'description') setQuery(descParam);
     else if (mode === 'group') setQuery(agentGroupParam);
     else if (mode === 'attribute') setQuery(selectorParam);
-  }, [mode, qParam, descParam, agentGroupParam, selectorParam]);
+    else if (mode === 'nattribute') setQuery(nonIdentifyingSelectorParam);
+  }, [mode, qParam, descParam, agentGroupParam, selectorParam, nonIdentifyingSelectorParam]);
 
   // Sync mode state if URL changes externally
   useEffect(() => {
@@ -202,6 +215,7 @@ function AgentsInner() {
     agentGroup?: string;
     desc?: string;
     selector?: string;
+    nonIdentifyingSelector?: string;
     mode?: SearchMode;
   }) => {
     const params = new URLSearchParams();
@@ -210,10 +224,13 @@ function AgentsInner() {
     const g = next.agentGroup ?? (m === 'group' ? agentGroupParam : '');
     const d = next.desc ?? (m === 'description' ? descParam : '');
     const s = next.selector ?? (m === 'attribute' ? selectorParam : '');
+    const ns =
+      next.nonIdentifyingSelector ?? (m === 'nattribute' ? nonIdentifyingSelectorParam : '');
     if (q) params.set('q', q);
     if (g) params.set('agentGroup', g);
     if (d) params.set('desc', d);
     if (s) params.set('selector', s);
+    if (ns) params.set('nonIdentifyingSelector', ns);
     if (m !== 'uid' || !q) params.set('mode', m);
     const qs = params.toString();
     router.replace(qs ? `/agents?${qs}` : '/agents');
@@ -223,20 +240,64 @@ function AgentsInner() {
     e.preventDefault();
     const value = query.trim();
     if (mode === 'uid') {
-      updateUrl({ q: value, agentGroup: '', desc: '', selector: '', mode: 'uid' });
+      updateUrl({
+        q: value,
+        agentGroup: '',
+        desc: '',
+        selector: '',
+        nonIdentifyingSelector: '',
+        mode: 'uid',
+      });
     } else if (mode === 'group') {
-      updateUrl({ agentGroup: value, q: '', desc: '', selector: '', mode: 'group' });
+      updateUrl({
+        agentGroup: value,
+        q: '',
+        desc: '',
+        selector: '',
+        nonIdentifyingSelector: '',
+        mode: 'group',
+      });
     } else if (mode === 'attribute') {
-      updateUrl({ selector: value, q: '', agentGroup: '', desc: '', mode: 'attribute' });
+      updateUrl({
+        selector: value,
+        q: '',
+        agentGroup: '',
+        desc: '',
+        nonIdentifyingSelector: '',
+        mode: 'attribute',
+      });
+    } else if (mode === 'nattribute') {
+      updateUrl({
+        nonIdentifyingSelector: value,
+        q: '',
+        agentGroup: '',
+        desc: '',
+        selector: '',
+        mode: 'nattribute',
+      });
     } else {
-      updateUrl({ desc: value, q: '', agentGroup: '', selector: '', mode: 'description' });
+      updateUrl({
+        desc: value,
+        q: '',
+        agentGroup: '',
+        selector: '',
+        nonIdentifyingSelector: '',
+        mode: 'description',
+      });
     }
   };
 
   const setSearchMode = (next: SearchMode) => {
     setMode(next);
     setQuery('');
-    updateUrl({ q: '', agentGroup: '', desc: '', selector: '', mode: next });
+    updateUrl({
+      q: '',
+      agentGroup: '',
+      desc: '',
+      selector: '',
+      nonIdentifyingSelector: '',
+      mode: next,
+    });
   };
 
   // Triggered by clicking an identifying-attribute chip: jump to an exact,
@@ -245,7 +306,30 @@ function AgentsInner() {
     const selector = `${key}=${value}`;
     setMode('attribute');
     setQuery(selector);
-    updateUrl({ selector, q: '', agentGroup: '', desc: '', mode: 'attribute' });
+    updateUrl({
+      selector,
+      q: '',
+      agentGroup: '',
+      desc: '',
+      nonIdentifyingSelector: '',
+      mode: 'attribute',
+    });
+  };
+
+  // Triggered by clicking a non-identifying-attribute chip: jump to an exact,
+  // server-side search for that attribute.
+  const searchByNonIdentifyingAttribute = (key: string, value: string) => {
+    const selector = `${key}=${value}`;
+    setMode('nattribute');
+    setQuery(selector);
+    updateUrl({
+      nonIdentifyingSelector: selector,
+      q: '',
+      agentGroup: '',
+      desc: '',
+      selector: '',
+      mode: 'nattribute',
+    });
   };
 
   const clearGroup = () => updateUrl({ agentGroup: '' });
@@ -265,7 +349,9 @@ function AgentsInner() {
     pagination.reset();
   };
 
-  const filterActive = Boolean(agentGroupParam || qParam || descParam || selectorParam);
+  const filterActive = Boolean(
+    agentGroupParam || qParam || descParam || selectorParam || nonIdentifyingSelectorParam,
+  );
   const lcDesc = descParam.toLowerCase();
   const visibleAgents = descParam
     ? agents.filter((a) => attrMatchesDescription(a, lcDesc))
@@ -298,6 +384,7 @@ function AgentsInner() {
                   <MenuItem value="group">Agent Group</MenuItem>
                   <MenuItem value="uid">Instance UID</MenuItem>
                   <MenuItem value="attribute">Identifying Attribute</MenuItem>
+                  <MenuItem value="nattribute">Non-identifying Attribute</MenuItem>
                   <MenuItem value="description">Description</MenuItem>
                 </Select>
               </FormControl>
@@ -343,7 +430,9 @@ function AgentsInner() {
                       ? 'Instance UID contains… (server-side)'
                       : mode === 'attribute'
                         ? 'key=value identifying attribute (exact, server-side)'
-                        : 'Attribute key/value contains… (client-side, current page)'
+                        : mode === 'nattribute'
+                          ? 'key=value non-identifying attribute (exact, server-side)'
+                          : 'Attribute key/value contains… (client-side, current page)'
                   }
                   value={query}
                   onChange={(e) => setQuery(e.target.value)}
@@ -424,6 +513,19 @@ function AgentsInner() {
                   onDelete={() => {
                     setQuery('');
                     updateUrl({ selector: '' });
+                  }}
+                  color="primary"
+                  variant="outlined"
+                  size="small"
+                />
+              )}
+              {nonIdentifyingSelectorParam && (
+                <Chip
+                  icon={<SearchIcon />}
+                  label={`Non-identifying: ${nonIdentifyingSelectorParam}`}
+                  onDelete={() => {
+                    setQuery('');
+                    updateUrl({ nonIdentifyingSelector: '' });
                   }}
                   color="primary"
                   variant="outlined"
@@ -551,7 +653,10 @@ function AgentsInner() {
                   )}
                   {isVisible('nonIdentifyingAttributes') && (
                     <TableCell>
-                      <AttrChips attrs={agent.metadata.description?.nonIdentifyingAttributes} />
+                      <AttrChips
+                        attrs={agent.metadata.description?.nonIdentifyingAttributes}
+                        onSelect={searchByNonIdentifyingAttribute}
+                      />
                     </TableCell>
                   )}
                   <TableCell align="right">


### PR DESCRIPTION
## What

Extends the agent attribute search added in #415 to **non-identifying attributes**, in both the web UI and `opampctl`. Same model: server-side, exact `key=value`, namespace-scoped, paginated.

## Changes

**API**
- Agent list endpoint accepts a repeatable `nonIdentifyingSelector` query param (one `key=value` per entry, AND semantics), combined with the existing `selector` (identifying) via AND. Reuses the existing `parseSelector`, so values may contain `,`/`=`.
- Threaded via `ListOptions.NonIdentifyingAttributes` into the MongoDB (`$elemMatch`) and in-memory adapters.

**Client / opampctl**
- `client.WithNonIdentifyingSelector(...)`; `applyTo` now emits both selector params through a shared `addSelectorParams` helper.
- `opampctl get agent --non-identifying-selector key=value` (server-side on the plain/all-namespaces paths, client-side filter for the agentgroup path).

**Web (`/agents`)**
- New **"Non-identifying Attribute"** search mode (exact, server-side, paginated via a `nonIdentifyingSelector` URL param) with its own filter chip.
- Non-identifying attribute **chips in the table are now clickable** and jump to that exact search (mirrors the identifying-attribute chips).

**Cleanup**
- Generalized the in-memory matcher to `matchesAttributes(stored, selector)` and the opampctl client-side filter to cover both attribute sets, instead of duplicating the identifying logic.

## Tests
- In-memory and MongoDB non-identifying filtering (exact match, AND-combination with identifying).
- Controller test that `selector` and `nonIdentifyingSelector` thread into separate `ListOptions` fields.
- Swagger regenerated.

Go unit + web `tsc`/`eslint`/`vitest` pass; `golangci-lint` clean. MongoDB integration tests run in CI (Docker was unavailable locally).

🤖 Generated with [Claude Code](https://claude.com/claude-code)