### PR TITLE
feat(web): Platform page with Hosts and Containers tabs

### DIFF
--- a/web/app/platform/page.tsx
+++ b/web/app/platform/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '@views/platform';

--- a/web/src/entities/container/index.ts
+++ b/web/src/entities/container/index.ts
@@ -1,0 +1,1 @@
+export * from './model/types';

--- a/web/src/entities/container/model/types.ts
+++ b/web/src/entities/container/model/types.ts
@@ -1,0 +1,35 @@
+import type { Condition } from '@shared/api';
+
+export interface ContainerMetadata {
+  id: string;
+  name?: string;
+  labels?: Record<string, string>;
+  annotations?: Record<string, string>;
+  firstSeenAt: string;
+  lastSeenAt: string;
+}
+
+export interface ContainerSpec {
+  /** Deployment environment: docker | kubernetes | ecs | unknown. */
+  platform: string;
+  imageName?: string;
+  runtime?: string;
+  /** The host (node) this container runs on, when known. */
+  hostId?: string;
+  k8sPodName?: string;
+  k8sNamespaceName?: string;
+  k8sNodeName?: string;
+}
+
+export interface ContainerStatus {
+  agentInstanceUids: string[];
+  conditions?: Condition[];
+}
+
+export interface Container {
+  kind: string;
+  apiVersion: string;
+  metadata: ContainerMetadata;
+  spec: ContainerSpec;
+  status: ContainerStatus;
+}

--- a/web/src/entities/host/index.ts
+++ b/web/src/entities/host/index.ts
@@ -1,0 +1,1 @@
+export * from './model/types';

--- a/web/src/entities/host/model/types.ts
+++ b/web/src/entities/host/model/types.ts
@@ -1,0 +1,35 @@
+import type { Condition } from '@shared/api';
+
+export interface HostMetadata {
+  id: string;
+  name?: string;
+  labels?: Record<string, string>;
+  annotations?: Record<string, string>;
+  firstSeenAt: string;
+  lastSeenAt: string;
+}
+
+export interface HostSpec {
+  /** Deployment environment: baremetal | vm | docker | kubernetes | ecs | unknown. */
+  platform: string;
+  arch?: string;
+  type?: string;
+  osType?: string;
+  osVersion?: string;
+  cloudProvider?: string;
+  cloudPlatform?: string;
+  cloudRegion?: string;
+}
+
+export interface HostStatus {
+  agentInstanceUids: string[];
+  conditions?: Condition[];
+}
+
+export interface Host {
+  kind: string;
+  apiVersion: string;
+  metadata: HostMetadata;
+  spec: HostSpec;
+  status: HostStatus;
+}

--- a/web/src/views/platform/index.ts
+++ b/web/src/views/platform/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ui/PlatformPage';

--- a/web/src/views/platform/ui/PlatformPage.tsx
+++ b/web/src/views/platform/ui/PlatformPage.tsx
@@ -1,0 +1,224 @@
+'use client';
+
+import {
+  Alert,
+  Box,
+  Chip,
+  CircularProgress,
+  IconButton,
+  Paper,
+  Table,
+  TableBody,
+  TableCell,
+  TableContainer,
+  TableHead,
+  TableRow,
+  Tab,
+  Tabs,
+} from '@mui/material';
+import { Refresh as RefreshIcon } from '@mui/icons-material';
+import { useCallback, useEffect, useState } from 'react';
+import { PageHeader } from '@shared/ui';
+import { TimeDisplay } from '@shared/preferences';
+import { api, type ListResponse } from '@shared/api';
+import type { Host } from '@entities/host';
+import type { Container } from '@entities/container';
+
+// platformColor maps a Platform label to an MUI chip color so the deployment
+// environment is visually scannable across the host/container tabs.
+function platformColor(
+  platform: string,
+): 'default' | 'primary' | 'secondary' | 'info' | 'success' | 'warning' {
+  switch (platform) {
+    case 'kubernetes':
+      return 'primary';
+    case 'docker':
+      return 'info';
+    case 'vm':
+      return 'success';
+    case 'baremetal':
+      return 'warning';
+    case 'ecs':
+      return 'secondary';
+    default:
+      return 'default';
+  }
+}
+
+function PlatformChip({ platform }: { platform: string }) {
+  return <Chip size="small" label={platform || 'unknown'} color={platformColor(platform)} />;
+}
+
+function dash(value: string | undefined): string {
+  return value && value.length > 0 ? value : '-';
+}
+
+export default function PlatformPage() {
+  const [tab, setTab] = useState(0);
+  const [hosts, setHosts] = useState<Host[]>([]);
+  const [containers, setContainers] = useState<Container[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchAll = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [hostsRes, containersRes] = await Promise.all([
+        api.get<ListResponse<Host>>('/api/v1/hosts', { query: { limit: 200 } }),
+        api.get<ListResponse<Container>>('/api/v1/containers', { query: { limit: 200 } }),
+      ]);
+      setHosts(hostsRes.items ?? []);
+      setContainers(containersRes.items ?? []);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch platform inventory');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchAll();
+  }, [fetchAll]);
+
+  return (
+    <Box>
+      <PageHeader
+        title="Platform"
+        actions={
+          <IconButton color="primary" onClick={fetchAll}>
+            <RefreshIcon />
+          </IconButton>
+        }
+      />
+
+      {error && (
+        <Alert severity="error" sx={{ mb: 2 }}>
+          {error}
+        </Alert>
+      )}
+
+      <Tabs value={tab} onChange={(_, v) => setTab(v)} sx={{ mb: 2 }}>
+        <Tab label={`Hosts (${hosts.length})`} />
+        <Tab label={`Containers (${containers.length})`} />
+      </Tabs>
+
+      {tab === 0 && <HostsTable hosts={hosts} loading={loading} />}
+      {tab === 1 && <ContainersTable containers={containers} loading={loading} />}
+    </Box>
+  );
+}
+
+function HostsTable({ hosts, loading }: { hosts: Host[]; loading: boolean }) {
+  return (
+    <TableContainer component={Paper}>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>ID</TableCell>
+            <TableCell>Name</TableCell>
+            <TableCell>Platform</TableCell>
+            <TableCell>Arch</TableCell>
+            <TableCell>OS</TableCell>
+            <TableCell>Cloud</TableCell>
+            <TableCell align="right">Agents</TableCell>
+            <TableCell>Last Seen</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {loading ? (
+            <TableRow>
+              <TableCell colSpan={8} align="center">
+                <CircularProgress size={24} />
+              </TableCell>
+            </TableRow>
+          ) : hosts.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={8} align="center">
+                No hosts discovered
+              </TableCell>
+            </TableRow>
+          ) : (
+            hosts.map((host) => (
+              <TableRow key={host.metadata.id} hover>
+                <TableCell sx={{ fontFamily: 'monospace', fontSize: 12 }}>
+                  {host.metadata.id}
+                </TableCell>
+                <TableCell>{dash(host.metadata.name)}</TableCell>
+                <TableCell>
+                  <PlatformChip platform={host.spec.platform} />
+                </TableCell>
+                <TableCell>{dash(host.spec.arch)}</TableCell>
+                <TableCell>{dash(host.spec.osType)}</TableCell>
+                <TableCell>{dash(host.spec.cloudProvider)}</TableCell>
+                <TableCell align="right">{host.status.agentInstanceUids?.length ?? 0}</TableCell>
+                <TableCell>
+                  <TimeDisplay value={host.metadata.lastSeenAt} />
+                </TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}
+
+function ContainersTable({ containers, loading }: { containers: Container[]; loading: boolean }) {
+  return (
+    <TableContainer component={Paper}>
+      <Table>
+        <TableHead>
+          <TableRow>
+            <TableCell>ID</TableCell>
+            <TableCell>Name</TableCell>
+            <TableCell>Platform</TableCell>
+            <TableCell>Image</TableCell>
+            <TableCell>Runtime</TableCell>
+            <TableCell>Host</TableCell>
+            <TableCell align="right">Agents</TableCell>
+            <TableCell>Last Seen</TableCell>
+          </TableRow>
+        </TableHead>
+        <TableBody>
+          {loading ? (
+            <TableRow>
+              <TableCell colSpan={8} align="center">
+                <CircularProgress size={24} />
+              </TableCell>
+            </TableRow>
+          ) : containers.length === 0 ? (
+            <TableRow>
+              <TableCell colSpan={8} align="center">
+                No containers discovered
+              </TableCell>
+            </TableRow>
+          ) : (
+            containers.map((container) => (
+              <TableRow key={container.metadata.id} hover>
+                <TableCell sx={{ fontFamily: 'monospace', fontSize: 12 }}>
+                  {container.metadata.id}
+                </TableCell>
+                <TableCell>{dash(container.metadata.name)}</TableCell>
+                <TableCell>
+                  <PlatformChip platform={container.spec.platform} />
+                </TableCell>
+                <TableCell>{dash(container.spec.imageName)}</TableCell>
+                <TableCell>{dash(container.spec.runtime)}</TableCell>
+                <TableCell sx={{ fontFamily: 'monospace', fontSize: 12 }}>
+                  {dash(container.spec.hostId)}
+                </TableCell>
+                <TableCell align="right">
+                  {container.status.agentInstanceUids?.length ?? 0}
+                </TableCell>
+                <TableCell>
+                  <TimeDisplay value={container.metadata.lastSeenAt} />
+                </TableCell>
+              </TableRow>
+            ))
+          )}
+        </TableBody>
+      </Table>
+    </TableContainer>
+  );
+}

--- a/web/src/widgets/app-layout/ui/AppLayout.tsx
+++ b/web/src/widgets/app-layout/ui/AppLayout.tsx
@@ -26,6 +26,7 @@ import {
   Group as GroupIcon,
   Computer as ComputerIcon,
   Cable as CableIcon,
+  Layers as LayersIcon,
   Dns as DnsIcon,
   Inventory2 as PackageIcon,
   Tune as TuneIcon,
@@ -94,6 +95,13 @@ const sections: NavSection[] = [
         icon: <CableIcon />,
         href: '/connections',
         requires: { resource: 'connection', action: 'LIST' },
+      },
+      {
+        // Platform (hosts/containers) is discovered, not RBAC-scoped per
+        // resource, so it has no `requires` and is shown to any authenticated user.
+        text: 'Platform',
+        icon: <LayersIcon />,
+        href: '/platform',
       },
       {
         text: 'Agent Packages',


### PR DESCRIPTION
## What

Adds a **Platform** page (`/platform`) to the web UI that surfaces the discovered host/container inventory in **two tabs** (Hosts, Containers), so operators can see where agents run.

## UI

- **Hosts tab**: ID, Name, Platform (color-coded chip), Arch, OS, Cloud, agent count, Last Seen.
- **Containers tab**: ID, Name, Platform, Image, Runtime, Host (node link), agent count, Last Seen.
- Tab labels show live counts; a Refresh action reloads both lists.
- New "Platform" item in the sidebar (Agents section).

## Notes

- New FSD slices: `entities/host`, `entities/container` (types mirroring the `api/v1` DTOs), `views/platform` (the page body), and a thin `app/platform/page.tsx` route wrapper.
- The `/api/v1/hosts` and `/api/v1/containers` read APIs are authenticated but not RBAC-scoped per resource, so the nav item has no `requires` and is shown to any authenticated user.
- **Depends on the host/container backend (#418)** for data; the page renders empty until that is deployed.

## Verification

- `tsc --noEmit` clean, `eslint` clean, `next build` succeeds and pre-renders `/platform`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)