### PR TITLE
perf(web): load fonts from CDN and code-split heavy dialogs

### DIFF
--- a/web/app/layout.tsx
+++ b/web/app/layout.tsx
@@ -1,20 +1,9 @@
 import type { Metadata } from 'next';
-import { Geist, Geist_Mono } from 'next/font/google';
 import { AppRouterCacheProvider } from '@mui/material-nextjs/v16-appRouter';
 import '@app/styles/globals.css';
 import ThemeRegistry from '@app/providers/ThemeRegistry';
 import AppShell from '@app/app-shell';
 import { PreferencesProvider } from '@shared/preferences';
-
-const geistSans = Geist({
-  variable: '--font-geist-sans',
-  subsets: ['latin'],
-});
-
-const geistMono = Geist_Mono({
-  variable: '--font-geist-mono',
-  subsets: ['latin'],
-});
 
 export const metadata: Metadata = {
   title: 'OpAMP Commander',
@@ -28,7 +17,21 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
+      <head>
+        {/* Fonts served from the Google Fonts CDN. preconnect warms up the
+            TCP+TLS connection to the font hosts before the stylesheet request. */}
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+        {/* App Router: a <link> in the root layout's <head> loads on every
+            page, so the no-page-custom-font rule (aimed at the pages/ router)
+            does not apply here. */}
+        {/* eslint-disable-next-line @next/next/no-page-custom-font */}
+        <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/css2?family=Geist:wght@100..900&family=Geist+Mono:wght@100..900&display=swap"
+        />
+      </head>
+      <body className="antialiased">
         {/* Emotion cache + useServerInsertedHTML so MUI styles render correctly
             during SSR/RSC and don't cause hydration mismatches. */}
         <AppRouterCacheProvider>

--- a/web/src/app/styles/globals.css
+++ b/web/src/app/styles/globals.css
@@ -3,6 +3,11 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  /* Font families loaded from the Google Fonts CDN (see app/layout.tsx).
+     System fallbacks keep text readable until the webfont arrives. */
+  --font-geist-sans: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial,
+    sans-serif;
+  --font-geist-mono: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
 }
 
 @theme inline {

--- a/web/src/app/styles/globals.css
+++ b/web/src/app/styles/globals.css
@@ -5,8 +5,8 @@
   --foreground: #171717;
   /* Font families loaded from the Google Fonts CDN (see app/layout.tsx).
      System fallbacks keep text readable until the webfont arrives. */
-  --font-geist-sans: 'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial,
-    sans-serif;
+  --font-geist-sans:
+    'Geist', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Arial, sans-serif;
   --font-geist-mono: 'Geist Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, monospace;
 }
 

--- a/web/src/views/agent-detail/ui/AgentDetailPage.tsx
+++ b/web/src/views/agent-detail/ui/AgentDetailPage.tsx
@@ -34,7 +34,11 @@ import {
   deleteAgent,
   type Agent,
 } from '@entities/agent';
-import { AgentEditDialog } from '@features/agent-edit';
+import dynamic from 'next/dynamic';
+
+// Lazy-loaded: the edit dialog embeds the JSON/YAML editor (js-yaml), only
+// needed once the user opens it — keep it out of the initial route bundle.
+const AgentEditDialog = dynamic(() => import('@features/agent-edit/ui/AgentEditDialog'));
 
 function AgentDetailInner() {
   const params = useParams<{ id: string }>();
@@ -282,15 +286,17 @@ function AgentDetailInner() {
         </CardContent>
       </Card>
 
-      <AgentEditDialog
-        open={editOpen}
-        agent={agent}
-        onClose={() => setEditOpen(false)}
-        onSaved={(saved) => {
-          void mutate(saved, { revalidate: false });
-          setEditOpen(false);
-        }}
-      />
+      {editOpen && (
+        <AgentEditDialog
+          open
+          agent={agent}
+          onClose={() => setEditOpen(false)}
+          onSaved={(saved) => {
+            void mutate(saved, { revalidate: false });
+            setEditOpen(false);
+          }}
+        />
+      )}
 
       <ConfirmDialog
         open={deleteOpen}

--- a/web/src/views/agent-group-detail/ui/AgentGroupDetailPage.tsx
+++ b/web/src/views/agent-group-detail/ui/AgentGroupDetailPage.tsx
@@ -31,7 +31,13 @@ import { TimeDisplay } from '@shared/preferences';
 import { useNamespace } from '@entities/namespace';
 import { api, useApi } from '@shared/api';
 import type { AgentGroup } from '@entities/agent-group';
-import { AgentGroupEditDialog } from '@features/agent-group-edit';
+import dynamic from 'next/dynamic';
+
+// Lazy-loaded: the edit dialog embeds the JSON/YAML editor (js-yaml), only
+// needed once the user opens it — keep it out of the initial route bundle.
+const AgentGroupEditDialog = dynamic(
+  () => import('@features/agent-group-edit/ui/AgentGroupEditDialog'),
+);
 
 function AgentGroupDetailInner() {
   const params = useParams<{ name: string }>();
@@ -260,16 +266,18 @@ function AgentGroupDetailInner() {
         </CardContent>
       </Card>
 
-      <AgentGroupEditDialog
-        open={editing}
-        mode="edit"
-        initial={group}
-        onClose={() => setEditing(false)}
-        onSaved={() => {
-          setEditing(false);
-          void fetchGroup();
-        }}
-      />
+      {editing && (
+        <AgentGroupEditDialog
+          open
+          mode="edit"
+          initial={group}
+          onClose={() => setEditing(false)}
+          onSaved={() => {
+            setEditing(false);
+            void fetchGroup();
+          }}
+        />
+      )}
       <ConfirmDialog
         open={deleting}
         title="Delete agent group"

--- a/web/src/views/agent-groups/ui/AgentGroupsPage.tsx
+++ b/web/src/views/agent-groups/ui/AgentGroupsPage.tsx
@@ -39,8 +39,14 @@ import { TimeDisplay } from '@shared/preferences';
 import { useNamespace } from '@entities/namespace';
 import { api } from '@shared/api';
 import { type ColumnConfig, useColumnVisibility, useCursorPagination } from '@shared/lib';
+import dynamic from 'next/dynamic';
 import type { AgentGroup } from '@entities/agent-group';
-import { AgentGroupEditDialog } from '@features/agent-group-edit';
+
+// Lazy-loaded: the edit dialog embeds the JSON/YAML editor (js-yaml), only
+// needed once the user opens it — keep it out of the initial route bundle.
+const AgentGroupEditDialog = dynamic(
+  () => import('@features/agent-group-edit/ui/AgentGroupEditDialog'),
+);
 
 // Columns for the agent groups table. `name` is locked (the row identifier);
 // the rest are toggleable via the column picker and persisted per user.
@@ -256,25 +262,29 @@ export default function AgentGroupsPage() {
 
       <PaginationFooter pagination={pagination} />
 
-      <AgentGroupEditDialog
-        open={createOpen}
-        mode="create"
-        onClose={() => setCreateOpen(false)}
-        onSaved={() => {
-          setCreateOpen(false);
-          void fetchGroups();
-        }}
-      />
-      <AgentGroupEditDialog
-        open={editing !== null}
-        mode="edit"
-        initial={editing ?? undefined}
-        onClose={() => setEditing(null)}
-        onSaved={() => {
-          setEditing(null);
-          void fetchGroups();
-        }}
-      />
+      {createOpen && (
+        <AgentGroupEditDialog
+          open
+          mode="create"
+          onClose={() => setCreateOpen(false)}
+          onSaved={() => {
+            setCreateOpen(false);
+            void fetchGroups();
+          }}
+        />
+      )}
+      {editing !== null && (
+        <AgentGroupEditDialog
+          open
+          mode="edit"
+          initial={editing ?? undefined}
+          onClose={() => setEditing(null)}
+          onSaved={() => {
+            setEditing(null);
+            void fetchGroups();
+          }}
+        />
+      )}
       <ConfirmDialog
         open={deleting !== null}
         title="Delete agent group"

--- a/web/src/views/agent-packages/ui/AgentPackagesPage.tsx
+++ b/web/src/views/agent-packages/ui/AgentPackagesPage.tsx
@@ -3,10 +3,14 @@
 import { Box } from '@mui/material';
 import { useNamespace } from '@entities/namespace';
 import { ResourceListPage } from '@widgets/resource-list-page';
-import { JsonEditorDialog } from '@shared/ui';
+import dynamic from 'next/dynamic';
 import { TimeDisplay } from '@shared/preferences';
 import { api } from '@shared/api';
 import type { AgentPackage } from '@entities/agent-package';
+
+// Lazy-loaded: the JSON editor pulls in js-yaml, only needed once a
+// create/edit dialog opens — keep it out of the initial route bundle.
+const JsonEditorDialog = dynamic(() => import('@shared/ui/JsonEditorDialog'));
 
 function emptyPackage(namespace: string, name: string): AgentPackage {
   return {

--- a/web/src/views/agent-remote-configs/ui/AgentRemoteConfigsPage.tsx
+++ b/web/src/views/agent-remote-configs/ui/AgentRemoteConfigsPage.tsx
@@ -4,12 +4,18 @@ import { Box } from '@mui/material';
 import { PlaylistAddCheck as ApplyIcon } from '@mui/icons-material';
 import { useState } from 'react';
 import { useNamespace } from '@entities/namespace';
+import dynamic from 'next/dynamic';
 import { ResourceListPage } from '@widgets/resource-list-page';
-import { JsonEditorDialog } from '@shared/ui';
 import { TimeDisplay } from '@shared/preferences';
 import { api } from '@shared/api';
 import type { AgentRemoteConfig } from '@entities/agent-remote-config';
-import { ApplyToGroupDialog } from '@features/apply-remote-config';
+
+// Lazy-loaded: heavy dialogs (JSON editor pulls in js-yaml, ApplyToGroup pulls
+// in group pickers) — load only when opened, not in the initial route bundle.
+const JsonEditorDialog = dynamic(() => import('@shared/ui/JsonEditorDialog'));
+const ApplyToGroupDialog = dynamic(
+  () => import('@features/apply-remote-config/ui/ApplyToGroupDialog'),
+);
 
 function emptyConfig(namespace: string): AgentRemoteConfig {
   return {
@@ -94,13 +100,15 @@ export default function AgentRemoteConfigsPage() {
           />
         )}
       />
-      <ApplyToGroupDialog
-        open={applyTarget !== null}
-        namespace={namespace}
-        config={applyTarget}
-        onClose={() => setApplyTarget(null)}
-        onApplied={() => setApplyTarget(null)}
-      />
+      {applyTarget !== null && (
+        <ApplyToGroupDialog
+          open
+          namespace={namespace}
+          config={applyTarget}
+          onClose={() => setApplyTarget(null)}
+          onApplied={() => setApplyTarget(null)}
+        />
+      )}
     </Box>
   );
 }

--- a/web/src/views/certificates/ui/CertificatesPage.tsx
+++ b/web/src/views/certificates/ui/CertificatesPage.tsx
@@ -3,10 +3,14 @@
 import { Box, Chip } from '@mui/material';
 import { useNamespace } from '@entities/namespace';
 import { ResourceListPage } from '@widgets/resource-list-page';
-import { JsonEditorDialog } from '@shared/ui';
+import dynamic from 'next/dynamic';
 import { TimeDisplay } from '@shared/preferences';
 import { api } from '@shared/api';
 import type { Certificate } from '@entities/certificate';
+
+// Lazy-loaded: the JSON editor pulls in js-yaml, only needed once a
+// create/edit dialog opens — keep it out of the initial route bundle.
+const JsonEditorDialog = dynamic(() => import('@shared/ui/JsonEditorDialog'));
 
 function emptyCertificate(namespace: string): Certificate {
   return {

--- a/web/src/views/role-bindings/ui/RoleBindingsPage.tsx
+++ b/web/src/views/role-bindings/ui/RoleBindingsPage.tsx
@@ -3,10 +3,14 @@
 import { Box, Chip, Stack } from '@mui/material';
 import { useNamespace } from '@entities/namespace';
 import { ResourceListPage } from '@widgets/resource-list-page';
-import { JsonEditorDialog } from '@shared/ui';
+import dynamic from 'next/dynamic';
 import { TimeDisplay } from '@shared/preferences';
 import { api } from '@shared/api';
 import type { RoleBinding } from '@entities/role-binding';
+
+// Lazy-loaded: the JSON editor pulls in js-yaml, only needed once a
+// create/edit dialog opens — keep it out of the initial route bundle.
+const JsonEditorDialog = dynamic(() => import('@shared/ui/JsonEditorDialog'));
 
 function emptyRoleBinding(namespace: string): RoleBinding {
   return {

--- a/web/src/views/roles/ui/RolesPage.tsx
+++ b/web/src/views/roles/ui/RolesPage.tsx
@@ -2,9 +2,13 @@
 
 import { Box, Chip, Stack } from '@mui/material';
 import { ResourceListPage } from '@widgets/resource-list-page';
-import { JsonEditorDialog } from '@shared/ui';
+import dynamic from 'next/dynamic';
 import { api } from '@shared/api';
 import type { Role } from '@entities/role';
+
+// Lazy-loaded: the JSON editor pulls in js-yaml, only needed once a
+// create/edit dialog opens — keep it out of the initial route bundle.
+const JsonEditorDialog = dynamic(() => import('@shared/ui/JsonEditorDialog'));
 
 function emptyRole(): Role {
   return {

--- a/web/src/views/users/ui/UsersPage.tsx
+++ b/web/src/views/users/ui/UsersPage.tsx
@@ -2,10 +2,14 @@
 
 import { Box, Chip } from '@mui/material';
 import { ResourceListPage } from '@widgets/resource-list-page';
-import { JsonEditorDialog } from '@shared/ui';
+import dynamic from 'next/dynamic';
 import { TimeDisplay } from '@shared/preferences';
 import { api } from '@shared/api';
 import type { User } from '@entities/user';
+
+// Lazy-loaded: the JSON editor pulls in js-yaml, only needed once a
+// create/edit dialog opens — keep it out of the initial route bundle.
+const JsonEditorDialog = dynamic(() => import('@shared/ui/JsonEditorDialog'));
 
 function emptyUser(): User {
   return {

--- a/web/src/widgets/resource-list-page/ui/ResourceListPage.tsx
+++ b/web/src/widgets/resource-list-page/ui/ResourceListPage.tsx
@@ -214,14 +214,15 @@ export default function ResourceListPage<T>({
 
       <PaginationFooter pagination={pagination} />
 
-      {renderCreate?.({
-        open: createOpen,
-        onClose: () => setCreateOpen(false),
-        onSaved: () => {
-          setCreateOpen(false);
-          refresh();
-        },
-      })}
+      {createOpen &&
+        renderCreate?.({
+          open: createOpen,
+          onClose: () => setCreateOpen(false),
+          onSaved: () => {
+            setCreateOpen(false);
+            refresh();
+          },
+        })}
       {editing &&
         renderEdit?.({
           open: editing !== null,


### PR DESCRIPTION
## Summary

Two optimizations to reduce the web app's initial loading weight.

### 1. Fonts → Google Fonts CDN
- Replaced the self-hosted approach (`next/font/google`'s Geist + Geist Mono) with a root-layout `<link rel="stylesheet">` (+ `preconnect`) that loads from the CDN
- The CSS variables `--font-geist-sans` / `--font-geist-mono` are now defined directly in `globals.css` along with system-font fallbacks
- Result: self-hosted woff2 files in the build output go from **28 → 0**

> ⚠️ Note: this goes against Next's recommendation (self-host). The CDN adds an external DNS/TLS round-trip and a possible FOUT, mitigated with `preconnect`. This is an intentional choice.

### 2. Code-split heavy dialogs
- Converted `JsonEditorDialog`, `AgentEditDialog`, `AgentGroupEditDialog`, and `ApplyToGroupDialog` to `next/dynamic` + `{open && ...}` render guards, so they load only when opened
- `ResourceListPage` now mounts the create dialog only when `createOpen` is true
- Result: js-yaml (**~50KB**) and the editor UI are split out of the initial route bundle and loaded as a separate chunk

> Trade-off: the MUI fade-out transition is skipped when a dialog closes (unmount-based).

## Verification
- `npx tsc --noEmit`: 0 errors
- `npm run lint`: clean
- `npm run format:check`: clean
- `npm test`: 56/56 pass
- `npm run build`: success
- Clean build confirmed: self-hosted woff2 **0 files**, js-yaml **split into a single 50.4KB chunk**

## Out of scope (follow-up)
The biggest perceived bottleneck for initial load is that the client `AuthProvider` shows only a spinner during the `/api/v1/auth/info` round-trip before the first paint (`/` is already SSR). Reading auth from an httpOnly session cookie in a server component would remove this round-trip, but the blast radius is large, so it will be handled in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
