### PR TITLE
feat(apiserver): basic-auth users with hashed passwords

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -102,6 +102,8 @@ linters:
             - github.com/golang-jwt/jwt/v5
             - github.com/google/go-github/v72/github
             - github.com/pkg/browser
+            - golang.org/x/crypto/bcrypt
+            - github.com/awnumar/memguard
             # RBAC
             - github.com/casbin/casbin/v2
             - github.com/casbin/mongodb-adapter/v4

--- a/api/v1/user.go
+++ b/api/v1/user.go
@@ -42,6 +42,10 @@ type UserSpec struct {
 	Username string `json:"username"`
 	// IsActive indicates whether the user is active.
 	IsActive bool `json:"isActive"`
+	// Password is the plaintext password for basic (username/password) authentication.
+	// It is WRITE-ONLY: it is read when creating a user and is never returned in any
+	// response. The server stores only a one-way hash of it; the hash is never exposed.
+	Password string `json:"password,omitempty"`
 } // @name UserSpec
 
 // UserStatus represents the status of a user.

--- a/configs/apiserver/config.sample.yaml
+++ b/configs/apiserver/config.sample.yaml
@@ -34,6 +34,11 @@ auth:
   admin:
     username: "admin"
     password: "admin_password"
+  basic:
+    # Server-side secret mixed into every basic-auth user password hash.
+    # Set a long, random value and keep it stable for the lifetime of stored credentials.
+    # Empty disables DB-backed basic-auth user creation and login.
+    pepper: ""
   jwt:
     issuer: "opampcommander"
     expire: 5m

--- a/configs/apiserver/dev.yaml
+++ b/configs/apiserver/dev.yaml
@@ -33,6 +33,10 @@ auth:
   admin:
     username: "admin"
     password: "admin"
+  basic:
+    # Server-side secret mixed into every basic-auth user password hash.
+    # Set a long, random value and keep it stable. Empty disables DB-backed basic-auth users.
+    pepper: "dev_basic_auth_pepper_change_me"
   jwt:
     issuer: "opampcommander"
     expire: 5m

--- a/configs/apiserver/initial/20-user-guest.yaml
+++ b/configs/apiserver/initial/20-user-guest.yaml
@@ -1,0 +1,21 @@
+# Built-in guest user — a basic-auth (username/password) account with only the
+# default role's permissions (read-only access in the default namespace).
+#
+# Reconciled into persistence on every apiserver startup (declarative): spec.password
+# below is the source of truth, so the guest password is reset to match it on each start.
+# The guest user receives no role beyond the built-in "default" role, which the RBAC
+# policy sync grants to every user automatically — so guest can browse the dashboard/CLI
+# but cannot mutate anything or see global resources.
+#
+# Requires auth.basic.pepper to be configured; when the pepper is empty, basic auth is
+# disabled and this manifest is skipped (logged as a warning) instead of failing startup.
+#
+# Remove this file (or point bootstrap.dir elsewhere) to disable the guest account.
+# Change spec.password before exposing the server — guest/guest is a default, not a secret.
+kind: User
+apiVersion: v1
+spec:
+  username: guest
+  email: guest@guest
+  isActive: true
+  password: guest

--- a/configs/apiserver/initial/20-user-guest.yaml.example
+++ b/configs/apiserver/initial/20-user-guest.yaml.example
@@ -1,7 +1,12 @@
-# Built-in guest user — a basic-auth (username/password) account with only the
-# default role's permissions (read-only access in the default namespace).
+# Example: a basic-auth (username/password) guest account with only the default
+# role's permissions (read-only access in the default namespace).
 #
-# Reconciled into persistence on every apiserver startup (declarative): spec.password
+# OPT-IN: the bootstrap reconciler only loads *.yaml / *.yml files, so this *.example
+# file is ignored by default. To enable the guest account, copy it without the suffix:
+#
+#     cp 20-user-guest.yaml.example 20-user-guest.yaml
+#
+# Once enabled it is reconciled on every apiserver startup (declarative): spec.password
 # below is the source of truth, so the guest password is reset to match it on each start.
 # The guest user receives no role beyond the built-in "default" role, which the RBAC
 # policy sync grants to every user automatically — so guest can browse the dashboard/CLI
@@ -10,7 +15,6 @@
 # Requires auth.basic.pepper to be configured; when the pepper is empty, basic auth is
 # disabled and this manifest is skipped (logged as a warning) instead of failing startup.
 #
-# Remove this file (or point bootstrap.dir elsewhere) to disable the guest account.
 # Change spec.password before exposing the server — guest/guest is a default, not a secret.
 kind: User
 apiVersion: v1

--- a/configs/apiserver/standalone.yaml
+++ b/configs/apiserver/standalone.yaml
@@ -34,6 +34,10 @@ auth:
   admin:
     username: "admin"
     password: "admin"
+  basic:
+    # Server-side secret mixed into every basic-auth user password hash.
+    # Set a long, random value and keep it stable. Empty disables DB-backed basic-auth users.
+    pepper: "standalone_basic_auth_pepper_change_me"
   jwt:
     issuer: "opampcommander"
     expire: 5m

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/minuk-dev/opampcommander
 go 1.25.1
 
 require (
+	github.com/awnumar/memguard v0.23.0
 	github.com/casbin/casbin/v2 v2.135.0
 	github.com/casbin/mongodb-adapter/v4 v4.3.0
 	github.com/cloudevents/sdk-go/observability/opentelemetry/v2 v2.16.2
@@ -54,6 +55,7 @@ require (
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
 	github.com/KyleBanks/depth v1.2.1 // indirect
 	github.com/Microsoft/go-winio v0.6.2 // indirect
+	github.com/awnumar/memcall v0.4.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bmatcuk/doublestar/v4 v4.6.1 // indirect
 	github.com/bytedance/gopkg v0.1.4 // indirect
@@ -184,7 +186,7 @@ require (
 	go.uber.org/multierr v1.11.0 // indirect
 	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/arch v0.27.0 // indirect
-	golang.org/x/crypto v0.53.0 // indirect
+	golang.org/x/crypto v0.53.0
 	golang.org/x/net v0.56.0 // indirect
 	golang.org/x/sys v0.46.0 // indirect
 	golang.org/x/text v0.38.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -10,6 +10,10 @@ github.com/KyleBanks/depth v1.2.1 h1:5h8fQADFrWtarTdtDudMmGsC7GPbOAu6RVB3ffsVFHc
 github.com/KyleBanks/depth v1.2.1/go.mod h1:jzSb9d0L43HxTQfT+oSA1EEp2q+ne2uh6XgeJcm8brE=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/awnumar/memcall v0.4.0 h1:B7hgZYdfH6Ot1Goaz8jGne/7i8xD4taZie/PNSFZ29g=
+github.com/awnumar/memcall v0.4.0/go.mod h1:8xOx1YbfyuCg3Fy6TO8DK0kZUua3V42/goA5Ru47E8w=
+github.com/awnumar/memguard v0.23.0 h1:sJ3a1/SWlcuKIQ7MV+R9p0Pvo9CWsMbGZvcZQtmc68A=
+github.com/awnumar/memguard v0.23.0/go.mod h1:olVofBrsPdITtJ2HgxQKrEYEMyIBAIciVG4wNnZhW9M=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwNy7PA4I=

--- a/pkg/apiserver/adapter/primary/http/auth/basic/controller.go
+++ b/pkg/apiserver/adapter/primary/http/auth/basic/controller.go
@@ -87,7 +87,7 @@ func (c *Controller) BasicAuth(ctx *gin.Context) {
 		return
 	}
 
-	result, err := c.service.BasicAuth(username, password)
+	result, err := c.service.BasicAuth(ctx.Request.Context(), username, password)
 	if err != nil {
 		if errors.Is(err, security.ErrInvalidUsernameOrPassword) {
 			ctx.JSON(http.StatusUnauthorized, gin.H{

--- a/pkg/apiserver/adapter/primary/http/v1/user/controller.go
+++ b/pkg/apiserver/adapter/primary/http/v1/user/controller.go
@@ -183,7 +183,7 @@ func (c *Controller) Create(ctx *gin.Context) {
 	created, err := c.userUsecase.CreateUser(ctx.Request.Context(), &req)
 	if err != nil {
 		c.logger.Error("failed to create user", "error", err.Error())
-		ginutil.InternalServerError(ctx, err, "An error occurred while creating the user.")
+		ginutil.HandleDomainError(ctx, err, "An error occurred while creating the user.")
 
 		return
 	}

--- a/pkg/apiserver/adapter/primary/messaging/kafka/kafka_test.go
+++ b/pkg/apiserver/adapter/primary/messaging/kafka/kafka_test.go
@@ -159,33 +159,34 @@ func TestEventReceiverAdapter_FiltersByTargetServer(t *testing.T) {
 	// When: Send messages to both servers
 	sender := createTestSender(t, broker, topic)
 
-	// Message for current server
-	sendTestMessage(ctx, t, sender, currentServerID, uuid.New())
+	// Two messages for the current server and one for another server (which must be filtered).
+	currentAgentUID1 := uuid.New()
+	currentAgentUID2 := uuid.New()
+	otherAgentUID := uuid.New()
 
-	// Message for other server (should be filtered out)
-	sendTestMessage(ctx, t, sender, otherServerID, uuid.New())
+	sendTestMessage(ctx, t, sender, currentServerID, currentAgentUID1)
+	sendTestMessage(ctx, t, sender, otherServerID, otherAgentUID)
+	sendTestMessage(ctx, t, sender, currentServerID, currentAgentUID2)
 
-	// Message for current server again
-	expectedAgentUID := uuid.New()
-	sendTestMessage(ctx, t, sender, currentServerID, expectedAgentUID)
-
-	// Then: Only messages for current server should be received
-	receivedCount := 0
+	// Then: both current-server messages should be received. Kafka only guarantees ordering
+	// within a partition, so assert on the set of received agent UIDs rather than their order.
+	receivedUIDs := make(map[uuid.UUID]struct{}, 2)
 	timeout := time.After(15 * time.Second)
 
-	for receivedCount < 2 {
+	for len(receivedUIDs) < 2 {
 		select {
 		case received := <-receivedMessages:
 			assert.Equal(t, currentServerID, received.Target, "Should only receive messages for current server")
-
-			receivedCount++
-			if receivedCount == 2 {
-				assert.Equal(t, expectedAgentUID, received.Payload.TargetAgentInstanceUIDs[0])
-			}
+			require.Len(t, received.Payload.TargetAgentInstanceUIDs, 1)
+			receivedUIDs[received.Payload.TargetAgentInstanceUIDs[0]] = struct{}{}
 		case <-timeout:
-			t.Fatalf("Timeout: received %d/2 messages", receivedCount)
+			t.Fatalf("Timeout: received %d/2 messages", len(receivedUIDs))
 		}
 	}
+
+	assert.Contains(t, receivedUIDs, currentAgentUID1, "first current-server message should be received")
+	assert.Contains(t, receivedUIDs, currentAgentUID2, "second current-server message should be received")
+	assert.NotContains(t, receivedUIDs, otherAgentUID, "other-server message must be filtered out")
 
 	// Ensure no more messages are received (the one for other server should be filtered)
 	select {

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/clone.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/clone.go
@@ -267,6 +267,11 @@ func cloneUser(user *usermodel.User) *usermodel.User {
 	cloned.Status.Conditions = slices.Clone(user.Status.Conditions)
 	cloned.Status.Roles = slices.Clone(user.Status.Roles)
 
+	if user.Spec.BasicAuth != nil {
+		basicAuth := *user.Spec.BasicAuth
+		cloned.Spec.BasicAuth = &basicAuth
+	}
+
 	return &cloned
 }
 

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/user.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/user.go
@@ -44,6 +44,19 @@ func (r *UserRepository) GetUserByEmailIncludingDeleted(_ context.Context, email
 	return r.findByEmail(email, true)
 }
 
+// GetUserByUsername implements userport.UserPersistencePort.
+// Soft-deleted records are excluded. The username is matched exactly (case-sensitive).
+func (r *UserRepository) GetUserByUsername(_ context.Context, username string) (*usermodel.User, error) {
+	users := r.store.snapshot(false, func(user *usermodel.User) bool {
+		return user.Spec.Username == username
+	})
+	if len(users) == 0 {
+		return nil, errResourceNotExist()
+	}
+
+	return users[0], nil
+}
+
 // PutUser implements userport.UserPersistencePort.
 func (r *UserRepository) PutUser(_ context.Context, user *usermodel.User) (*usermodel.User, error) {
 	r.store.put(user.Metadata.UID, user)

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/user.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/user.go
@@ -47,6 +47,13 @@ func (r *UserRepository) GetUserByEmailIncludingDeleted(_ context.Context, email
 // GetUserByUsername implements userport.UserPersistencePort.
 // Soft-deleted records are excluded. The username is matched exactly (case-sensitive).
 func (r *UserRepository) GetUserByUsername(_ context.Context, username string) (*usermodel.User, error) {
+	// Mirror the MongoDB adapter: a username that fails the strict allowlist cannot have been
+	// created, so it is treated as not-found.
+	err := usermodel.ValidateUsername(username)
+	if err != nil {
+		return nil, errResourceNotExist()
+	}
+
 	users := r.store.snapshot(false, func(user *usermodel.User) bool {
 		return user.Spec.Username == username
 	})

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/entity/user.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/entity/user.go
@@ -36,10 +36,17 @@ type UserMetadata struct {
 
 // UserSpec represents the specification of a user.
 type UserSpec struct {
-	Email      string         `bson:"email"`
-	Username   string         `bson:"username"`
-	IsActive   bool           `bson:"isActive"`
-	Identities []UserIdentity `bson:"identities,omitempty"`
+	Email      string               `bson:"email"`
+	Username   string               `bson:"username"`
+	IsActive   bool                 `bson:"isActive"`
+	Identities []UserIdentity       `bson:"identities,omitempty"`
+	BasicAuth  *BasicAuthCredential `bson:"basicAuth,omitempty"`
+}
+
+// BasicAuthCredential represents a user's basic-auth password credential in MongoDB.
+// The hash is sensitive server-side material and is never projected into API responses.
+type BasicAuthCredential struct {
+	PasswordHash string `bson:"passwordHash"`
 }
 
 // UserIdentity represents a linked external identity provider account in MongoDB.
@@ -88,11 +95,17 @@ func (s *UserSpec) toDomain() usermodel.UserSpec {
 		}
 	})
 
+	var basicAuth *usermodel.BasicAuthCredential
+	if s.BasicAuth != nil {
+		basicAuth = &usermodel.BasicAuthCredential{PasswordHash: s.BasicAuth.PasswordHash}
+	}
+
 	return usermodel.UserSpec{
 		Email:      s.Email,
 		Username:   s.Username,
 		IsActive:   s.IsActive,
 		Identities: identities,
+		BasicAuth:  basicAuth,
 	}
 }
 
@@ -141,11 +154,17 @@ func userSpecFromDomain(spec usermodel.UserSpec) UserSpec {
 		}
 	})
 
+	var basicAuth *BasicAuthCredential
+	if spec.BasicAuth != nil {
+		basicAuth = &BasicAuthCredential{PasswordHash: spec.BasicAuth.PasswordHash}
+	}
+
 	return UserSpec{
 		Email:      spec.Email,
 		Username:   spec.Username,
 		IsActive:   spec.IsActive,
 		Identities: identities,
+		BasicAuth:  basicAuth,
 	}
 }
 

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/mongodb.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/mongodb.go
@@ -203,6 +203,11 @@ var (
 					// authenticated request's user resolution — otherwise they full-scan users.
 					Options: options.Index().SetCollation(emailCollation),
 				},
+				{
+					// Backs GetUserByUsername (exact, case-sensitive), used by basic-auth login.
+					Keys:    bson.D{{Key: "spec.username", Value: 1}},
+					Options: nil,
+				},
 			},
 		},
 	}

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/user.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/user.go
@@ -94,6 +94,40 @@ func (a *UserMongoAdapter) GetUserByEmailIncludingDeleted(
 	return a.findUserByEmail(ctx, email, true)
 }
 
+// GetUserByUsername implements userport.UserPersistencePort.
+// Soft-deleted records are excluded. The username is matched exactly (case-sensitive).
+func (a *UserMongoAdapter) GetUserByUsername(
+	ctx context.Context, username string,
+) (*usermodel.User, error) {
+	if username == "" {
+		return nil, fmt.Errorf("empty username: %w", port.ErrResourceNotExist)
+	}
+
+	// username is used only as an exact-match value (not a query operator), so the BSON driver
+	// encodes it as a plain string and a caller-supplied string cannot inject an operator.
+	filter := bson.M{"spec.username": username, "metadata.deletedAt": nil}
+
+	result := a.common.collection.FindOne(ctx, filter)
+
+	err := result.Err()
+	if err != nil {
+		if errors.Is(err, mongo.ErrNoDocuments) {
+			return nil, port.ErrResourceNotExist
+		}
+
+		return nil, fmt.Errorf("get user by username: %w", err)
+	}
+
+	var userEntity entity.User
+
+	err = result.Decode(&userEntity)
+	if err != nil {
+		return nil, fmt.Errorf("decode user by username: %w", err)
+	}
+
+	return userEntity.ToDomain(), nil
+}
+
 // PutUser implements userport.UserPersistencePort.
 func (a *UserMongoAdapter) PutUser(
 	ctx context.Context, user *usermodel.User,

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/user.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/user.go
@@ -99,17 +99,21 @@ func (a *UserMongoAdapter) GetUserByEmailIncludingDeleted(
 func (a *UserMongoAdapter) GetUserByUsername(
 	ctx context.Context, username string,
 ) (*usermodel.User, error) {
-	if username == "" {
-		return nil, fmt.Errorf("empty username: %w", port.ErrResourceNotExist)
+	// Validate against a strict allowlist before the value reaches the query. A username that
+	// fails validation cannot have been created (creation enforces the same rule), so it is
+	// treated as not-found. This also guards the query: only allowlisted strings reach the
+	// filter, and the mongo driver binds the value as a BSON string literal (never a query
+	// operator), so a caller-supplied username cannot inject an operator.
+	err := usermodel.ValidateUsername(username)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", port.ErrResourceNotExist, err)
 	}
 
-	// username is used only as an exact-match value (not a query operator), so the BSON driver
-	// encodes it as a plain string and a caller-supplied string cannot inject an operator.
 	filter := bson.M{"spec.username": username, "metadata.deletedAt": nil}
 
 	result := a.common.collection.FindOne(ctx, filter)
 
-	err := result.Err()
+	err = result.Err()
 	if err != nil {
 		if errors.Is(err, mongo.ErrNoDocuments) {
 			return nil, port.ErrResourceNotExist

--- a/pkg/apiserver/application/helper/mapper.go
+++ b/pkg/apiserver/application/helper/mapper.go
@@ -407,10 +407,13 @@ func (mapper *Mapper) MapUserToAPI(domain *usermodel.User) *v1.User {
 			DeletedAt: mapDeletedAtPtrToAPI(domain.Metadata.DeletedAt),
 			Labels:    labels,
 		},
+		// Password/basic-auth credential material is intentionally never mapped out: the
+		// write-only Password field stays empty and the stored password hash is never exposed.
 		Spec: v1.UserSpec{
 			Email:    domain.Spec.Email,
 			Username: domain.Spec.Username,
 			IsActive: domain.Spec.IsActive,
+			Password: "", // never expose password material in responses
 		},
 		Status: v1.UserStatus{
 			Conditions: mapper.mapConditionsToAPI(domain.Status.Conditions),

--- a/pkg/apiserver/application/service/user/service.go
+++ b/pkg/apiserver/application/service/user/service.go
@@ -4,6 +4,7 @@ package user
 import (
 	"cmp"
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -16,8 +17,10 @@ import (
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/application/helper"
 	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/port"
 	usermodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/model"
 	userport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/port"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/security"
 )
 
 var _ applicationport.UserManageUsecase = (*Service)(nil)
@@ -29,6 +32,7 @@ type Service struct {
 	roleBindingPersistencePort userport.RoleBindingPersistencePort
 	rbacEnforcerPort           userport.RBACEnforcerPort
 	rbacUsecase                userport.RBACUsecase
+	passwordHasher             *security.PasswordHasher
 	mapper                     *helper.Mapper
 	logger                     *slog.Logger
 }
@@ -40,6 +44,7 @@ func New(
 	roleBindingPersistencePort userport.RoleBindingPersistencePort,
 	rbacEnforcerPort userport.RBACEnforcerPort,
 	rbacUsecase userport.RBACUsecase,
+	passwordHasher *security.PasswordHasher,
 	logger *slog.Logger,
 ) *Service {
 	return &Service{
@@ -48,6 +53,7 @@ func New(
 		roleBindingPersistencePort: roleBindingPersistencePort,
 		rbacEnforcerPort:           rbacEnforcerPort,
 		rbacUsecase:                rbacUsecase,
+		passwordHasher:             passwordHasher,
 		mapper:                     helper.NewMapper(clock.RealClock{}, 0),
 		logger:                     logger,
 	}
@@ -97,11 +103,21 @@ func (s *Service) ListUsers(
 }
 
 // CreateUser implements [applicationport.UserManageUsecase].
+// When a password is supplied, the user is provisioned for basic (username/password) login:
+// the plaintext is hashed (peppered + salted) and only the hash is persisted, and a "basic"
+// identity + login-type label is attached so RBAC default-role enrollment works.
 func (s *Service) CreateUser(ctx context.Context, apiUser *v1.User) (*v1.User, error) {
 	domainUser := usermodel.NewUser(apiUser.Spec.Email, apiUser.Spec.Username)
 
 	for key, value := range apiUser.Metadata.Labels {
 		domainUser.SetLabel(key, value)
+	}
+
+	if apiUser.Spec.Password != "" {
+		err := s.applyBasicAuth(ctx, domainUser, apiUser.Spec.Username, apiUser.Spec.Email, apiUser.Spec.Password)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	err := s.userUsecase.SaveUser(ctx, domainUser)
@@ -196,6 +212,63 @@ func (s *Service) buildRoleEntries(ctx context.Context, user *usermodel.User) ([
 	slices.SortFunc(entries, compareEntries)
 
 	return entries, nil
+}
+
+// applyBasicAuth validates the request, hashes the plaintext password, and attaches the basic
+// credential, a "basic" identity, and the login-type label to the domain user.
+// Basic-auth login is keyed on username and identified by email, so both must be present and the
+// username must be unique among active users. Bad input (empty email/username, duplicate username,
+// or basic auth disabled because no pepper is configured) is wrapped in [port.ErrInvalidArgument]
+// so the controller surfaces it as a 400.
+func (s *Service) applyBasicAuth(ctx context.Context, user *usermodel.User, username, email, password string) error {
+	if username == "" {
+		return fmt.Errorf("%w: username is required for a basic-auth user", port.ErrInvalidArgument)
+	}
+
+	if email == "" {
+		return fmt.Errorf("%w: email is required for a basic-auth user", port.ErrInvalidArgument)
+	}
+
+	err := s.ensureUsernameAvailable(ctx, username)
+	if err != nil {
+		return err
+	}
+
+	hash, err := s.passwordHasher.Hash(password)
+	if err != nil {
+		if errors.Is(err, security.ErrBasicAuthDisabled) {
+			return fmt.Errorf("%w: %w", port.ErrInvalidArgument, err)
+		}
+
+		return fmt.Errorf("failed to hash password: %w", err)
+	}
+
+	user.SetPasswordHash(hash)
+	user.AddIdentity(usermodel.UserIdentity{
+		Provider:       usermodel.IdentityProviderBasic,
+		ProviderUserID: username,
+		Email:          email,
+		DisplayName:    username,
+	})
+	user.SetLabel(usermodel.LabelLoginType, usermodel.IdentityProviderBasic)
+
+	return nil
+}
+
+// ensureUsernameAvailable returns [port.ErrInvalidArgument] when an active user already has the
+// given username. Basic-auth login resolves a user by username, so duplicates would make login
+// ambiguous (and could shadow a legitimate user). A not-found lookup means the username is free.
+func (s *Service) ensureUsernameAvailable(ctx context.Context, username string) error {
+	_, err := s.userUsecase.GetUserByUsername(ctx, username)
+	if err == nil {
+		return fmt.Errorf("%w: username %q is already in use", port.ErrInvalidArgument, username)
+	}
+
+	if !errors.Is(err, port.ErrResourceNotExist) {
+		return fmt.Errorf("failed to check username availability: %w", err)
+	}
+
+	return nil
 }
 
 func (s *Service) resolveRole(ctx context.Context, raw string) (*usermodel.Role, error) {

--- a/pkg/apiserver/application/service/user/service.go
+++ b/pkg/apiserver/application/service/user/service.go
@@ -221,8 +221,9 @@ func (s *Service) buildRoleEntries(ctx context.Context, user *usermodel.User) ([
 // or basic auth disabled because no pepper is configured) is wrapped in [port.ErrInvalidArgument]
 // so the controller surfaces it as a 400.
 func (s *Service) applyBasicAuth(ctx context.Context, user *usermodel.User, username, email, password string) error {
-	if username == "" {
-		return fmt.Errorf("%w: username is required for a basic-auth user", port.ErrInvalidArgument)
+	usernameErr := usermodel.ValidateUsername(username)
+	if usernameErr != nil {
+		return fmt.Errorf("%w: %w", port.ErrInvalidArgument, usernameErr)
 	}
 
 	if email == "" {

--- a/pkg/apiserver/docs/docs.go
+++ b/pkg/apiserver/docs/docs.go
@@ -4560,6 +4560,10 @@ const docTemplate = `{
                     "description": "IsActive indicates whether the user is active.",
                     "type": "boolean"
                 },
+                "password": {
+                    "description": "Password is the plaintext password for basic (username/password) authentication.\nIt is WRITE-ONLY: it is read when creating a user and is never returned in any\nresponse. The server stores only a one-way hash of it; the hash is never exposed.",
+                    "type": "string"
+                },
                 "username": {
                     "description": "Username is the username of the user.",
                     "type": "string"

--- a/pkg/apiserver/docs/swagger.json
+++ b/pkg/apiserver/docs/swagger.json
@@ -4552,6 +4552,10 @@
                     "description": "IsActive indicates whether the user is active.",
                     "type": "boolean"
                 },
+                "password": {
+                    "description": "Password is the plaintext password for basic (username/password) authentication.\nIt is WRITE-ONLY: it is read when creating a user and is never returned in any\nresponse. The server stores only a one-way hash of it; the hash is never exposed.",
+                    "type": "string"
+                },
                 "username": {
                     "description": "Username is the username of the user.",
                     "type": "string"

--- a/pkg/apiserver/docs/swagger.yaml
+++ b/pkg/apiserver/docs/swagger.yaml
@@ -1177,6 +1177,12 @@ definitions:
       isActive:
         description: IsActive indicates whether the user is active.
         type: boolean
+      password:
+        description: |-
+          Password is the plaintext password for basic (username/password) authentication.
+          It is WRITE-ONLY: it is read when creating a user and is never returned in any
+          response. The server stores only a one-way hash of it; the hash is never exposed.
+        type: string
       username:
         description: Username is the username of the user.
         type: string

--- a/pkg/apiserver/domain/port/port.go
+++ b/pkg/apiserver/domain/port/port.go
@@ -8,4 +8,6 @@ var (
 	ErrResourceNotExist = errors.New("resource does not exist")
 	// ErrMultipleResourceExist is an error that indicates that multiple resources exist.
 	ErrMultipleResourceExist = errors.New("multiple resources exist")
+	// ErrInvalidArgument indicates the caller supplied an invalid argument; it maps to HTTP 400.
+	ErrInvalidArgument = errors.New("invalid argument")
 )

--- a/pkg/apiserver/domain/user/model/user.go
+++ b/pkg/apiserver/domain/user/model/user.go
@@ -31,6 +31,18 @@ type UserSpec struct {
 	Username   string
 	IsActive   bool
 	Identities []UserIdentity
+	// BasicAuth holds the basic-auth credential for this user, when one is set.
+	// It is nil for users that authenticate only through external identity providers.
+	// The credential is sensitive server-side material and is never exposed through the API.
+	BasicAuth *BasicAuthCredential
+}
+
+// BasicAuthCredential holds a user's password credential for username/password (basic) login.
+// PasswordHash is a one-way hash (the per-user salt is embedded in the hash string); the
+// plaintext password is never stored. This value must never be serialized into an API response.
+type BasicAuthCredential struct {
+	// PasswordHash is the encoded one-way password hash (e.g. a bcrypt string).
+	PasswordHash string
 }
 
 // UserIdentity represents a linked external identity provider account.
@@ -65,6 +77,7 @@ func NewUser(email, username string) *User {
 			Username:   username,
 			IsActive:   true,
 			Identities: []UserIdentity{},
+			BasicAuth:  nil,
 		},
 		Status: UserStatus{
 			Conditions: []model.Condition{},
@@ -133,6 +146,31 @@ func (u *User) GetIdentity(provider string) *UserIdentity {
 	}
 
 	return nil
+}
+
+// SetPasswordHash sets the user's basic-auth password hash, enabling username/password login.
+// The caller is responsible for hashing the plaintext password beforehand.
+func (u *User) SetPasswordHash(hash string) {
+	u.Spec.BasicAuth = &BasicAuthCredential{PasswordHash: hash}
+}
+
+// HasBasicAuth reports whether the user has a basic-auth password credential set.
+func (u *User) HasBasicAuth() bool {
+	return u.Spec.BasicAuth != nil && u.Spec.BasicAuth.PasswordHash != ""
+}
+
+// PasswordHash returns the user's basic-auth password hash, or "" if none is set.
+func (u *User) PasswordHash() string {
+	if u.Spec.BasicAuth == nil {
+		return ""
+	}
+
+	return u.Spec.BasicAuth.PasswordHash
+}
+
+// ClearPasswordHash removes the user's basic-auth credential, disabling username/password login.
+func (u *User) ClearPasswordHash() {
+	u.Spec.BasicAuth = nil
 }
 
 // SetLabel sets a label on the user's metadata.

--- a/pkg/apiserver/domain/user/model/validation.go
+++ b/pkg/apiserver/domain/user/model/validation.go
@@ -1,0 +1,39 @@
+package usermodel
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+)
+
+// MaxUsernameLength bounds a basic-auth username.
+const MaxUsernameLength = 128
+
+// ErrInvalidUsername is returned when a username is empty, too long, or contains characters
+// outside the allowed set.
+var ErrInvalidUsername = errors.New("invalid username")
+
+// usernamePattern is the allowlist for basic-auth usernames: ASCII letters, digits, and a small
+// set of separators commonly found in usernames and email-style logins. It deliberately excludes
+// whitespace, quotes, and structural characters ('{', '}', '$', etc.), so a username can never
+// carry anything that could be mistaken for a query operator or control sequence.
+var usernamePattern = regexp.MustCompile(`^[A-Za-z0-9._%+@-]+$`)
+
+// ValidateUsername reports whether username is acceptable for a basic-auth user.
+// It enforces a strict allowlist and a length bound; everything else is rejected.
+func ValidateUsername(username string) error {
+	if username == "" {
+		return fmt.Errorf("%w: must not be empty", ErrInvalidUsername)
+	}
+
+	if len(username) > MaxUsernameLength {
+		return fmt.Errorf("%w: must be at most %d characters", ErrInvalidUsername, MaxUsernameLength)
+	}
+
+	if !usernamePattern.MatchString(username) {
+		return fmt.Errorf("%w: only letters, digits and the characters . _ %% + @ - are allowed",
+			ErrInvalidUsername)
+	}
+
+	return nil
+}

--- a/pkg/apiserver/domain/user/model/validation_test.go
+++ b/pkg/apiserver/domain/user/model/validation_test.go
@@ -1,0 +1,32 @@
+package usermodel_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	usermodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/model"
+)
+
+func TestValidateUsername(t *testing.T) {
+	t.Parallel()
+
+	valid := []string{"guest", "admin", "alice.bob", "user_1", "a+b", "user@example.com", "a-b%c"}
+	for _, u := range valid {
+		require.NoError(t, usermodel.ValidateUsername(u), "want %q valid", u)
+	}
+
+	invalid := []string{
+		"",                       // empty
+		"a b",                    // space
+		"name\twith\ttabs",       // whitespace
+		`{"$ne": null}`,          // mongo operator document text
+		"bob$gt",                 // structural char
+		"quote'or'1",             // quote
+		strings.Repeat("a", 129), // too long
+	}
+	for _, u := range invalid {
+		require.ErrorIs(t, usermodel.ValidateUsername(u), usermodel.ErrInvalidUsername, "want %q invalid", u)
+	}
+}

--- a/pkg/apiserver/domain/user/port/in.go
+++ b/pkg/apiserver/domain/user/port/in.go
@@ -18,6 +18,8 @@ type UserUsecase interface {
 	// GetUserByEmailIncludingDeleted retrieves a user by their email, including soft-deleted records.
 	// Used by the login flow to avoid recreating a user that was deliberately deleted.
 	GetUserByEmailIncludingDeleted(ctx context.Context, email string) (*usermodel.User, error)
+	// GetUserByUsername retrieves a user by their username, excluding soft-deleted records.
+	GetUserByUsername(ctx context.Context, username string) (*usermodel.User, error)
 	// ListUsers lists all users.
 	ListUsers(ctx context.Context, options *model.ListOptions) (*model.ListResponse[*usermodel.User], error)
 	// SaveUser saves the user.

--- a/pkg/apiserver/domain/user/port/out.go
+++ b/pkg/apiserver/domain/user/port/out.go
@@ -18,6 +18,9 @@ type UserPersistencePort interface {
 	// GetUserByEmailIncludingDeleted retrieves a user by their email, including soft-deleted records.
 	// Used by the login flow to avoid recreating a user that was deliberately deleted.
 	GetUserByEmailIncludingDeleted(ctx context.Context, email string) (*usermodel.User, error)
+	// GetUserByUsername retrieves a user by their username, excluding soft-deleted records.
+	// Used by the basic-auth login flow to resolve credentials.
+	GetUserByUsername(ctx context.Context, username string) (*usermodel.User, error)
 	// PutUser saves or updates a user.
 	PutUser(ctx context.Context, user *usermodel.User) (*usermodel.User, error)
 	// ListUsers retrieves a list of users with pagination options.

--- a/pkg/apiserver/domain/user/service/user.go
+++ b/pkg/apiserver/domain/user/service/user.go
@@ -58,6 +58,19 @@ func (s *UserService) GetUserByEmail(
 	return user, nil
 }
 
+// GetUserByUsername implements [userport.UserUsecase].
+func (s *UserService) GetUserByUsername(
+	ctx context.Context,
+	username string,
+) (*usermodel.User, error) {
+	user, err := s.userPersistencePort.GetUserByUsername(ctx, username)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get user by username from persistence: %w", err)
+	}
+
+	return user, nil
+}
+
 // GetUserByEmailIncludingDeleted implements [userport.UserUsecase].
 func (s *UserService) GetUserByEmailIncludingDeleted(
 	ctx context.Context,

--- a/pkg/apiserver/ginutil/errormiddleware.go
+++ b/pkg/apiserver/ginutil/errormiddleware.go
@@ -88,6 +88,25 @@ func HandleDomainError(ctx *gin.Context, err error, fallbackMessage string) {
 		return
 	}
 
+	if errors.Is(err, port.ErrInvalidArgument) {
+		ctx.JSON(http.StatusBadRequest, &api.ErrorModel{
+			Type:     baseURL,
+			Title:    "Bad Request",
+			Status:   http.StatusBadRequest,
+			Detail:   err.Error(),
+			Instance: ctx.Request.URL.String(),
+			Errors: []*api.ErrorDetail{
+				{
+					Message:  err.Error(),
+					Location: "server",
+					Value:    nil,
+				},
+			},
+		})
+
+		return
+	}
+
 	// Default to internal server error
 	InternalServerError(ctx, err, fallbackMessage)
 }

--- a/pkg/apiserver/internal/module/helper/module.go
+++ b/pkg/apiserver/internal/module/helper/module.go
@@ -13,6 +13,7 @@ func NewModule() fx.Option {
 		fx.Provide(
 			// Security
 			security.New,
+			security.NewPasswordHasher,
 		),
 	)
 }

--- a/pkg/apiserver/internal/module/infrastructure/bootstrap.go
+++ b/pkg/apiserver/internal/module/infrastructure/bootstrap.go
@@ -362,6 +362,11 @@ func applyUser(ctx context.Context, doc manifestDoc, deps bootstrapDeps) error {
 		return fmt.Errorf("%w: %q", errEmptyUserName, doc.source)
 	}
 
+	usernameErr := usermodel.ValidateUsername(username)
+	if usernameErr != nil {
+		return fmt.Errorf("user manifest %q: %w", doc.source, usernameErr)
+	}
+
 	email := apiUser.Spec.Email
 	if email == "" {
 		return fmt.Errorf("%w: %q", errEmptyUserEmail, doc.source)

--- a/pkg/apiserver/internal/module/infrastructure/bootstrap.go
+++ b/pkg/apiserver/internal/module/infrastructure/bootstrap.go
@@ -26,6 +26,7 @@ import (
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/port"
 	usermodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/model"
 	userport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/port"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/security"
 	"github.com/minuk-dev/opampcommander/pkg/utils/clock"
 )
 
@@ -41,11 +42,13 @@ var errUnsupportedKind = errors.New("unsupported manifest kind")
 // bootstrap reconciler does not understand.
 var errUnsupportedAPIVersion = errors.New("unsupported manifest apiVersion")
 
-// errEmptyNamespaceName / errEmptyRoleName are returned when a manifest omits the
-// identifying name field.
+// errEmptyNamespaceName / errEmptyRoleName / errEmptyUser* are returned when a manifest
+// omits a required identifying field.
 var (
 	errEmptyNamespaceName = errors.New("namespace manifest has empty metadata.name")
 	errEmptyRoleName      = errors.New("role manifest has empty spec.displayName")
+	errEmptyUserName      = errors.New("user manifest has empty spec.username")
+	errEmptyUserEmail     = errors.New("user manifest has empty spec.email")
 )
 
 // bootstrapUIDNamespace is a fixed UUID namespace used to derive deterministic UIDs
@@ -66,6 +69,10 @@ func builtinPermissionUID(name string) uuid.UUID {
 	return uuid.NewSHA1(uuid.MustParse(bootstrapUIDNamespace), []byte("permission/"+name))
 }
 
+func builtinUserUID(username string) uuid.UUID {
+	return uuid.NewSHA1(uuid.MustParse(bootstrapUIDNamespace), []byte("user/"+username))
+}
+
 // bootstrapDeps bundles the filesystem and persistence ports the manifest appliers
 // reconcile into. fs is abstracted via afero so tests run against an in-memory
 // filesystem instead of the real OS, and production uses afero.NewOsFs().
@@ -74,6 +81,8 @@ type bootstrapDeps struct {
 	namespaceUsecase          agentport.NamespaceUsecase
 	rolePersistencePort       userport.RolePersistencePort
 	permissionPersistencePort userport.PermissionPersistencePort
+	userPersistencePort       userport.UserPersistencePort
+	passwordHasher            *security.PasswordHasher
 	clk                       clock.PassiveClock
 	logger                    *slog.Logger
 }
@@ -199,6 +208,8 @@ func applyManifests(ctx context.Context, docs []manifestDoc, deps bootstrapDeps)
 			err = applyNamespace(ctx, doc, deps)
 		case v1.RoleKind:
 			err = applyRole(ctx, doc, deps)
+		case v1.UserKind:
+			err = applyUser(ctx, doc, deps)
 		default:
 			return fmt.Errorf("%w: kind %q in %q", errUnsupportedKind, doc.kind, doc.source)
 		}
@@ -328,6 +339,154 @@ func applyRole(ctx context.Context, doc manifestDoc, deps bootstrapDeps) error {
 	return nil
 }
 
+// applyUser upserts a basic-auth user (username + password). The user is granted only the
+// built-in default role — that happens automatically because SyncPolicies (run after bootstrap)
+// grants the default role to every persisted user in the default namespace, so no role binding
+// is needed here.
+//
+// The manifest's spec.password is the source of truth: on a fresh DB the user is created with a
+// peppered+salted hash; on later startups the stored hash is re-checked and only rewritten when
+// it no longer matches (so identical passwords don't churn the record with a new salt each boot).
+// When no pepper is configured, basic auth is disabled — the user cannot be hashed or logged in,
+// so seeding is skipped with a warning rather than failing startup.
+func applyUser(ctx context.Context, doc manifestDoc, deps bootstrapDeps) error {
+	var apiUser v1.User
+
+	err := json.Unmarshal(doc.json, &apiUser)
+	if err != nil {
+		return fmt.Errorf("decode User from %q: %w", doc.source, err)
+	}
+
+	username := apiUser.Spec.Username
+	if username == "" {
+		return fmt.Errorf("%w: %q", errEmptyUserName, doc.source)
+	}
+
+	email := apiUser.Spec.Email
+	if email == "" {
+		return fmt.Errorf("%w: %q", errEmptyUserEmail, doc.source)
+	}
+
+	if apiUser.Spec.Password == "" {
+		return fmt.Errorf("user manifest %q for %q has empty spec.password: %w",
+			doc.source, username, port.ErrResourceNotExist)
+	}
+
+	if deps.passwordHasher == nil || !deps.passwordHasher.Enabled() {
+		deps.logger.Warn("bootstrap: skipping user seed because basic auth is disabled (no pepper configured)",
+			slog.String("username", username),
+			slog.String("source", doc.source),
+		)
+
+		return nil
+	}
+
+	existing, err := deps.userPersistencePort.GetUserByUsername(ctx, username)
+	if err != nil && !errors.Is(err, port.ErrResourceNotExist) {
+		return fmt.Errorf("check user %q: %w", username, err)
+	}
+
+	if errors.Is(err, port.ErrResourceNotExist) {
+		return createBootstrapUser(ctx, username, email, apiUser.Spec.Password, deps)
+	}
+
+	return reconcileBootstrapUser(ctx, existing, username, email, apiUser.Spec.Password, deps)
+}
+
+// createBootstrapUser creates a new basic-auth user with a deterministic UID (so concurrent
+// fresh-DB startups converge on one record), a hashed password, and the basic identity + label.
+func createBootstrapUser(ctx context.Context, username, email, password string, deps bootstrapDeps) error {
+	hash, err := deps.passwordHasher.Hash(password)
+	if err != nil {
+		return fmt.Errorf("hash password for user %q: %w", username, err)
+	}
+
+	deps.logger.Info("bootstrap: creating user", slog.String("username", username))
+
+	user := usermodel.NewUser(email, username)
+	user.Metadata.UID = builtinUserUID(username)
+	setBootstrapBasicAuth(user, hash, username, email)
+
+	_, err = deps.userPersistencePort.PutUser(ctx, user)
+	if err != nil {
+		return fmt.Errorf("save user %q: %w", username, err)
+	}
+
+	return nil
+}
+
+// reconcileBootstrapUser brings an existing seeded user back in line with the manifest: it
+// re-activates it, ensures the basic identity + login-type label, and rewrites the password hash
+// only when the current one no longer verifies against the manifest password. It skips the write
+// entirely when nothing changed, to avoid churning the record on every startup.
+func reconcileBootstrapUser(
+	ctx context.Context,
+	user *usermodel.User,
+	username, email, password string,
+	deps bootstrapDeps,
+) error {
+	changed := false
+
+	if !user.Spec.IsActive {
+		user.Spec.IsActive = true
+		changed = true
+	}
+
+	if user.GetIdentity(usermodel.IdentityProviderBasic) == nil {
+		user.AddIdentity(usermodel.UserIdentity{
+			Provider:       usermodel.IdentityProviderBasic,
+			ProviderUserID: username,
+			Email:          email,
+			DisplayName:    username,
+		})
+
+		changed = true
+	}
+
+	if v, ok := user.GetLabel(usermodel.LabelLoginType); !ok || v != usermodel.IdentityProviderBasic {
+		user.SetLabel(usermodel.LabelLoginType, usermodel.IdentityProviderBasic)
+
+		changed = true
+	}
+
+	if deps.passwordHasher.Verify(password, user.PasswordHash()) != nil {
+		hash, err := deps.passwordHasher.Hash(password)
+		if err != nil {
+			return fmt.Errorf("hash password for user %q: %w", username, err)
+		}
+
+		user.SetPasswordHash(hash)
+
+		changed = true
+	}
+
+	if !changed {
+		return nil
+	}
+
+	user.Metadata.UpdatedAt = deps.clk.Now()
+
+	_, err := deps.userPersistencePort.PutUser(ctx, user)
+	if err != nil {
+		return fmt.Errorf("save user %q: %w", username, err)
+	}
+
+	return nil
+}
+
+// setBootstrapBasicAuth attaches the password hash, the basic identity, and the login-type label
+// to a user so it can authenticate via username/password and be picked up by RBAC default-role sync.
+func setBootstrapBasicAuth(user *usermodel.User, hash, username, email string) {
+	user.SetPasswordHash(hash)
+	user.AddIdentity(usermodel.UserIdentity{
+		Provider:       usermodel.IdentityProviderBasic,
+		ProviderUserID: username,
+		Email:          email,
+		DisplayName:    username,
+	})
+	user.SetLabel(usermodel.LabelLoginType, usermodel.IdentityProviderBasic)
+}
+
 // ensurePermission creates the built-in permission object for name ("resource:action")
 // if it does not already exist. Permissions are immutable once created.
 func ensurePermission(ctx context.Context, name string, deps bootstrapDeps) error {
@@ -367,6 +526,8 @@ func registerBootstrapHook(
 	namespaceUsecase agentport.NamespaceUsecase,
 	rolePersistencePort userport.RolePersistencePort,
 	permissionPersistencePort userport.PermissionPersistencePort,
+	userPersistencePort userport.UserPersistencePort,
+	passwordHasher *security.PasswordHasher,
 	settings *config.ServerSettings,
 	logger *slog.Logger,
 ) {
@@ -375,6 +536,8 @@ func registerBootstrapHook(
 		namespaceUsecase:          namespaceUsecase,
 		rolePersistencePort:       rolePersistencePort,
 		permissionPersistencePort: permissionPersistencePort,
+		userPersistencePort:       userPersistencePort,
+		passwordHasher:            passwordHasher,
 		clk:                       clock.NewRealClock(),
 		logger:                    logger,
 	}

--- a/pkg/apiserver/internal/module/infrastructure/bootstrap_internal_test.go
+++ b/pkg/apiserver/internal/module/infrastructure/bootstrap_internal_test.go
@@ -12,6 +12,8 @@ import (
 
 	inmemory "github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/secondary/persistence/inmemory"
 	agentservice "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/service"
+	usermodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/model"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/security"
 	"github.com/minuk-dev/opampcommander/pkg/utils/clock"
 )
 
@@ -52,16 +54,27 @@ type fixedClock struct{ now time.Time }
 func (c fixedClock) Now() time.Time                  { return c.now }
 func (c fixedClock) Since(t time.Time) time.Duration { return c.now.Sub(t) }
 
+// testPepper is a fixed pepper so the test hasher is enabled (basic auth on).
+const testPepper = "test-pepper"
+
 func newTestDeps() (bootstrapDeps, *inmemory.RoleRepository, *inmemory.PermissionRepository) {
 	roleRepo := inmemory.NewRoleRepository()
 	permRepo := inmemory.NewPermissionRepository()
+	userRepo := inmemory.NewUserRepository()
 	nsService := agentservice.NewNamespaceService(inmemory.NewNamespaceRepository())
+
+	//exhaustruct:ignore
+	hasher := security.NewPasswordHasher(&security.Config{
+		BasicAuthSettings: security.BasicAuthSettings{Pepper: testPepper},
+	})
 
 	return bootstrapDeps{
 		fs:                        afero.NewMemMapFs(),
 		namespaceUsecase:          nsService,
 		rolePersistencePort:       roleRepo,
 		permissionPersistencePort: permRepo,
+		userPersistencePort:       userRepo,
+		passwordHasher:            hasher,
 		clk:                       clock.NewRealClock(),
 		logger:                    slog.Default(),
 	}, roleRepo, permRepo
@@ -168,6 +181,131 @@ func TestApplyManifests_AssignsDeterministicUIDsToBuiltins(t *testing.T) {
 	assert.Equal(t, role1, role2, "default role UID must be deterministic across startups")
 	assert.Equal(t, builtinPermissionUID("agent:GET"), perm1)
 	assert.Equal(t, perm1, perm2, "permission UID must be deterministic across startups")
+}
+
+const guestUserManifest = `kind: User
+apiVersion: v1
+spec:
+  username: guest
+  email: guest@guest
+  isActive: true
+  password: guest
+`
+
+func TestApplyManifests_SeedsBasicAuthUser(t *testing.T) {
+	t.Parallel()
+
+	deps, _, _ := newTestDeps()
+	dir := writeManifests(t, deps.fs, map[string]string{"20-user.yaml": guestUserManifest})
+
+	docs, err := loadManifestDocs(deps.fs, dir)
+	require.NoError(t, err)
+
+	require.NoError(t, applyManifests(t.Context(), docs, deps))
+
+	user, err := deps.userPersistencePort.GetUserByUsername(t.Context(), "guest")
+	require.NoError(t, err)
+	assert.Equal(t, "guest@guest", user.Spec.Email)
+	assert.True(t, user.Spec.IsActive)
+	assert.Equal(t, builtinUserUID("guest"), user.Metadata.UID, "user UID must be deterministic")
+	assert.True(t, user.HasBasicAuth())
+	require.NotNil(t, user.GetIdentity(usermodel.IdentityProviderBasic))
+
+	loginType, ok := user.GetLabel(usermodel.LabelLoginType)
+	assert.True(t, ok)
+	assert.Equal(t, usermodel.IdentityProviderBasic, loginType)
+
+	// The seeded hash must verify against the manifest password (and not store the plaintext).
+	require.NoError(t, deps.passwordHasher.Verify("guest", user.PasswordHash()))
+	assert.NotContains(t, user.PasswordHash(), "guest", "hash must not embed the plaintext")
+}
+
+func TestApplyManifests_UserIdempotentNoWriteWhenUnchanged(t *testing.T) {
+	t.Parallel()
+
+	deps, _, _ := newTestDeps()
+	dir := writeManifests(t, deps.fs, map[string]string{"20-user.yaml": guestUserManifest})
+
+	docs, err := loadManifestDocs(deps.fs, dir)
+	require.NoError(t, err)
+	require.NoError(t, applyManifests(t.Context(), docs, deps))
+
+	user, err := deps.userPersistencePort.GetUserByUsername(t.Context(), "guest")
+	require.NoError(t, err)
+
+	originalUpdatedAt := user.Metadata.UpdatedAt
+
+	// Re-apply with a clock pinned in the future: a spurious re-hash/write would move UpdatedAt.
+	deps.clk = fixedClock{now: time.Date(2100, 1, 1, 0, 0, 0, 0, time.UTC)}
+	require.NoError(t, applyManifests(t.Context(), docs, deps))
+
+	user, err = deps.userPersistencePort.GetUserByUsername(t.Context(), "guest")
+	require.NoError(t, err)
+	assert.Equal(t, originalUpdatedAt, user.Metadata.UpdatedAt,
+		"an unchanged user (password already matches) must not be re-written")
+}
+
+func TestApplyManifests_UserPasswordResetToManifest(t *testing.T) {
+	t.Parallel()
+
+	deps, _, _ := newTestDeps()
+	dir := writeManifests(t, deps.fs, map[string]string{"20-user.yaml": guestUserManifest})
+
+	docs, err := loadManifestDocs(deps.fs, dir)
+	require.NoError(t, err)
+	require.NoError(t, applyManifests(t.Context(), docs, deps))
+
+	// Simulate the password being changed out-of-band to something other than the manifest's.
+	user, err := deps.userPersistencePort.GetUserByUsername(t.Context(), "guest")
+	require.NoError(t, err)
+
+	otherHash, err := deps.passwordHasher.Hash("changed")
+	require.NoError(t, err)
+	user.SetPasswordHash(otherHash)
+	_, err = deps.userPersistencePort.PutUser(t.Context(), user)
+	require.NoError(t, err)
+
+	// Re-applying the manifest must reset the password back to the declared one.
+	require.NoError(t, applyManifests(t.Context(), docs, deps))
+
+	user, err = deps.userPersistencePort.GetUserByUsername(t.Context(), "guest")
+	require.NoError(t, err)
+	require.NoError(t, deps.passwordHasher.Verify("guest", user.PasswordHash()),
+		"manifest password must be the source of truth")
+}
+
+func TestApplyManifests_UserSkippedWhenBasicAuthDisabled(t *testing.T) {
+	t.Parallel()
+
+	deps, _, _ := newTestDeps()
+	//exhaustruct:ignore
+	deps.passwordHasher = security.NewPasswordHasher(&security.Config{}) // empty pepper => disabled
+
+	dir := writeManifests(t, deps.fs, map[string]string{"20-user.yaml": guestUserManifest})
+
+	docs, err := loadManifestDocs(deps.fs, dir)
+	require.NoError(t, err)
+
+	// Disabled basic auth must skip the user seed, not fail startup.
+	require.NoError(t, applyManifests(t.Context(), docs, deps))
+
+	_, err = deps.userPersistencePort.GetUserByUsername(t.Context(), "guest")
+	require.Error(t, err, "user must not be seeded when basic auth is disabled")
+}
+
+func TestApplyManifests_UserRequiresPassword(t *testing.T) {
+	t.Parallel()
+
+	deps, _, _ := newTestDeps()
+	dir := writeManifests(t, deps.fs, map[string]string{
+		"20-user.yaml": "kind: User\napiVersion: v1\nspec:\n  username: nopass\n  email: nopass@x\n",
+	})
+
+	docs, err := loadManifestDocs(deps.fs, dir)
+	require.NoError(t, err)
+
+	err = applyManifests(t.Context(), docs, deps)
+	require.Error(t, err, "a user manifest without a password must be rejected")
 }
 
 func TestApplyManifests_UnknownKindFails(t *testing.T) {

--- a/pkg/apiserver/security/authorization_test.go
+++ b/pkg/apiserver/security/authorization_test.go
@@ -15,7 +15,13 @@ import (
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/security"
 )
 
-func TestMain(m *testing.M) { goleak.VerifyTestMain(m) }
+func TestMain(m *testing.M) {
+	// memguard starts a single process-lifetime daemon (the Coffer rekeying goroutine) the
+	// first time an enclave is created; it never exits by design, so it is not a leak.
+	goleak.VerifyTestMain(m,
+		goleak.IgnoreTopFunction("github.com/awnumar/memguard/core.NewCoffer.func1"),
+	)
+}
 
 const adminEmail = "admin@example.com"
 

--- a/pkg/apiserver/security/basicauth_test.go
+++ b/pkg/apiserver/security/basicauth_test.go
@@ -1,0 +1,96 @@
+package security_test
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/secondary/persistence/inmemory"
+	usermodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/model"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/security"
+)
+
+func newBasicAuthService(t *testing.T, pepper string, repo *inmemory.UserRepository) *security.Service {
+	t.Helper()
+
+	//exhaustruct:ignore
+	cfg := &security.Config{
+		BasicAuthSettings: security.BasicAuthSettings{Pepper: pepper},
+		//exhaustruct:ignore
+		JWTSettings: security.JWTSettings{
+			SigningKey: "test-signing-key",
+			Issuer:     "test",
+			Expiration: time.Minute,
+		},
+		AdminSettings: security.AdminSettings{Username: "admin", Password: "adminpass", Email: "admin@x"},
+	}
+
+	return security.New(slog.Default(), cfg, http.DefaultClient, security.NewPasswordHasher(cfg), repo)
+}
+
+// Regression: when no pepper is configured, a failed/non-admin basic login must surface as
+// ErrInvalidUsernameOrPassword (→ HTTP 401), not ErrBasicAuthDisabled (→ HTTP 500).
+func TestBasicAuth_DisabledPepper_FailedLoginIsInvalidCredentials(t *testing.T) {
+	t.Parallel()
+
+	svc := newBasicAuthService(t, "", inmemory.NewUserRepository())
+
+	_, err := svc.BasicAuth(context.Background(), "someone", "whatever")
+	require.ErrorIs(t, err, security.ErrInvalidUsernameOrPassword)
+	require.NotErrorIs(t, err, security.ErrBasicAuthDisabled)
+}
+
+func TestBasicAuth_DBUser(t *testing.T) {
+	t.Parallel()
+
+	repo := inmemory.NewUserRepository()
+	svc := newBasicAuthService(t, "test-pepper", repo)
+
+	hasher := security.NewPasswordHasher(&security.Config{
+		BasicAuthSettings: security.BasicAuthSettings{Pepper: "test-pepper"},
+	})
+
+	hash, err := hasher.Hash("s3cret")
+	require.NoError(t, err)
+
+	user := usermodel.NewUser("bob@example.com", "bob")
+	user.SetPasswordHash(hash)
+	_, err = repo.PutUser(context.Background(), user)
+	require.NoError(t, err)
+
+	result, err := svc.BasicAuth(context.Background(), "bob", "s3cret")
+	require.NoError(t, err)
+	assert.Equal(t, "bob@example.com", result.Email)
+	assert.NotEmpty(t, result.Token)
+
+	_, err = svc.BasicAuth(context.Background(), "bob", "wrong")
+	require.ErrorIs(t, err, security.ErrInvalidUsernameOrPassword)
+}
+
+func TestBasicAuth_InactiveDBUserRejected(t *testing.T) {
+	t.Parallel()
+
+	repo := inmemory.NewUserRepository()
+	svc := newBasicAuthService(t, "test-pepper", repo)
+
+	hasher := security.NewPasswordHasher(&security.Config{
+		BasicAuthSettings: security.BasicAuthSettings{Pepper: "test-pepper"},
+	})
+
+	hash, err := hasher.Hash("s3cret")
+	require.NoError(t, err)
+
+	user := usermodel.NewUser("carol@example.com", "carol")
+	user.SetPasswordHash(hash)
+	user.Spec.IsActive = false
+	_, err = repo.PutUser(context.Background(), user)
+	require.NoError(t, err)
+
+	_, err = svc.BasicAuth(context.Background(), "carol", "s3cret")
+	require.ErrorIs(t, err, security.ErrInvalidUsernameOrPassword)
+}

--- a/pkg/apiserver/security/config.go
+++ b/pkg/apiserver/security/config.go
@@ -10,8 +10,18 @@ type Config struct {
 	JWTSettings JWTSettings
 	// AdminSettings holds the configuration settings for admin authentication.
 	AdminSettings AdminSettings
+	// BasicAuthSettings holds the configuration settings for DB-backed basic-auth users.
+	BasicAuthSettings BasicAuthSettings
 	// OAuthSettings holds the configuration settings for OAuth2 authentication.
 	OAuthSettings *OAuthSettings
+}
+
+// BasicAuthSettings holds the configuration settings for DB-backed basic-auth users.
+type BasicAuthSettings struct {
+	// Pepper is a server-side secret mixed into every basic-auth password hash.
+	// It must be a long, random value set once and kept stable for the lifetime of the
+	// stored credentials. When empty, basic-auth user creation and password login are disabled.
+	Pepper string
 }
 
 // AdminSettings holds the configuration settings for admin authentication.

--- a/pkg/apiserver/security/errors.go
+++ b/pkg/apiserver/security/errors.go
@@ -17,6 +17,9 @@ var (
 	ErrTokenExpired = errors.New("token has expired")
 	// ErrInvalidUsernameOrPassword is returned when the provided username or password is invalid.
 	ErrInvalidUsernameOrPassword = errors.New("invalid username or password")
+	// ErrBasicAuthDisabled is returned when basic-auth password operations are attempted but no
+	// pepper is configured, which disables DB-backed basic-auth user creation and login.
+	ErrBasicAuthDisabled = errors.New("basic auth is disabled: no password pepper configured")
 	// ErrNoPrimaryEmailFound is returned when no primary email is found in the user's emails.
 	ErrNoPrimaryEmailFound = errors.New("no primary verified email found")
 	// ErrOAuth2ClientCreationFailed is returned when the OAuth2 client creation fails.

--- a/pkg/apiserver/security/password.go
+++ b/pkg/apiserver/security/password.go
@@ -1,0 +1,99 @@
+package security
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+
+	"github.com/awnumar/memguard"
+	"golang.org/x/crypto/bcrypt"
+)
+
+// PasswordHasher hashes and verifies basic-auth passwords.
+//
+// Each password is first combined with a server-side pepper via HMAC-SHA256 and then hashed
+// with bcrypt (which adds a per-user random salt). The pepper is held in a memguard Enclave so
+// the secret is kept in locked, encrypted memory and only decrypted transiently during an
+// operation. When no pepper is configured the hasher is disabled and every operation returns
+// [ErrBasicAuthDisabled].
+type PasswordHasher struct {
+	// pepper is nil when basic auth is disabled (no pepper configured).
+	pepper *memguard.Enclave
+}
+
+// NewPasswordHasher builds a PasswordHasher from the security config.
+// When the configured pepper is empty the returned hasher is disabled: Hash and Verify
+// return [ErrBasicAuthDisabled]. The plaintext pepper is sealed into a memguard Enclave and
+// the caller-visible config string is the only remaining plaintext copy.
+func NewPasswordHasher(cfg *Config) *PasswordHasher {
+	pepper := cfg.BasicAuthSettings.Pepper
+	if pepper == "" {
+		return &PasswordHasher{pepper: nil}
+	}
+
+	return &PasswordHasher{pepper: memguard.NewEnclave([]byte(pepper))}
+}
+
+// Enabled reports whether basic-auth password operations are available (a pepper is configured).
+func (h *PasswordHasher) Enabled() bool {
+	return h.pepper != nil
+}
+
+// Hash returns a one-way hash of the password, peppered and salted, suitable for persistence.
+// Returns [ErrBasicAuthDisabled] when no pepper is configured.
+func (h *PasswordHasher) Hash(password string) (string, error) {
+	peppered, err := h.pepperedPassword(password)
+	if err != nil {
+		return "", err
+	}
+
+	hash, err := bcrypt.GenerateFromPassword(peppered, bcrypt.DefaultCost)
+	if err != nil {
+		return "", fmt.Errorf("failed to hash password: %w", err)
+	}
+
+	return string(hash), nil
+}
+
+// Verify checks a plaintext password against a stored hash.
+// It returns nil on a match, [ErrBasicAuthDisabled] when no pepper is configured, and a
+// non-nil error otherwise (including a wrong password).
+func (h *PasswordHasher) Verify(password, hash string) error {
+	peppered, err := h.pepperedPassword(password)
+	if err != nil {
+		return err
+	}
+
+	err = bcrypt.CompareHashAndPassword([]byte(hash), peppered)
+	if err != nil {
+		return fmt.Errorf("password verification failed: %w", err)
+	}
+
+	return nil
+}
+
+// pepperedPassword returns base64(HMAC-SHA256(password, pepper)).
+// base64 encoding keeps the result free of NUL bytes (bcrypt truncates at the first NUL) and
+// at a fixed 44-byte length, well within bcrypt's 72-byte input limit.
+// The pepper is opened from the enclave only for the duration of the HMAC and then destroyed.
+func (h *PasswordHasher) pepperedPassword(password string) ([]byte, error) {
+	if h.pepper == nil {
+		return nil, ErrBasicAuthDisabled
+	}
+
+	buf, err := h.pepper.Open()
+	if err != nil {
+		return nil, fmt.Errorf("failed to open pepper enclave: %w", err)
+	}
+	defer buf.Destroy()
+
+	mac := hmac.New(sha256.New, buf.Bytes())
+	_, _ = mac.Write([]byte(password)) // hash.Hash.Write never returns an error
+	sum := mac.Sum(nil)
+
+	encoded := make([]byte, base64.StdEncoding.EncodedLen(len(sum)))
+	base64.StdEncoding.Encode(encoded, sum)
+
+	return encoded, nil
+}

--- a/pkg/apiserver/security/password_test.go
+++ b/pkg/apiserver/security/password_test.go
@@ -1,0 +1,82 @@
+package security_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/security"
+)
+
+func newHasher(t *testing.T, pepper string) *security.PasswordHasher {
+	t.Helper()
+
+	//exhaustruct:ignore
+	cfg := &security.Config{
+		BasicAuthSettings: security.BasicAuthSettings{Pepper: pepper},
+	}
+
+	return security.NewPasswordHasher(cfg)
+}
+
+func TestPasswordHasher_HashAndVerify(t *testing.T) {
+	t.Parallel()
+
+	hasher := newHasher(t, "super-secret-pepper")
+	require.True(t, hasher.Enabled())
+
+	hash, err := hasher.Hash("correct horse battery staple")
+	require.NoError(t, err)
+	assert.NotEmpty(t, hash)
+	assert.NotContains(t, hash, "correct horse battery staple", "hash must not contain the plaintext")
+
+	require.NoError(t, hasher.Verify("correct horse battery staple", hash))
+
+	err = hasher.Verify("wrong password", hash)
+	require.Error(t, err, "wrong password must not verify")
+}
+
+func TestPasswordHasher_DistinctSaltsPerHash(t *testing.T) {
+	t.Parallel()
+
+	hasher := newHasher(t, "pepper")
+
+	first, err := hasher.Hash("same-password")
+	require.NoError(t, err)
+
+	second, err := hasher.Hash("same-password")
+	require.NoError(t, err)
+
+	assert.NotEqual(t, first, second, "per-user salt must make identical passwords hash differently")
+	require.NoError(t, hasher.Verify("same-password", first))
+	require.NoError(t, hasher.Verify("same-password", second))
+}
+
+func TestPasswordHasher_PepperMatters(t *testing.T) {
+	t.Parallel()
+
+	hasherA := newHasher(t, "pepper-a")
+	hasherB := newHasher(t, "pepper-b")
+
+	hash, err := hasherA.Hash("password")
+	require.NoError(t, err)
+
+	require.NoError(t, hasherA.Verify("password", hash))
+
+	err = hasherB.Verify("password", hash)
+	require.Error(t, err, "a different pepper must fail verification")
+}
+
+func TestPasswordHasher_DisabledWhenNoPepper(t *testing.T) {
+	t.Parallel()
+
+	hasher := newHasher(t, "")
+	assert.False(t, hasher.Enabled())
+
+	_, err := hasher.Hash("password")
+	require.ErrorIs(t, err, security.ErrBasicAuthDisabled)
+
+	err = hasher.Verify("password", "irrelevant")
+	require.ErrorIs(t, err, security.ErrBasicAuthDisabled)
+}

--- a/pkg/apiserver/security/security.go
+++ b/pkg/apiserver/security/security.go
@@ -4,6 +4,7 @@ package security
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -13,6 +14,9 @@ import (
 	"github.com/golang-jwt/jwt/v5"
 	"golang.org/x/oauth2"
 	oauth2github "golang.org/x/oauth2/github"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/port"
+	userport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/port"
 )
 
 // Token type values stored in the OPAMPClaims.TokenType claim.
@@ -48,7 +52,7 @@ type Usecase interface {
 // AdminUsecase defines the use case for admin authentication.
 type AdminUsecase interface {
 	// BasicAuth authenticates the user using basic authentication with username and password.
-	BasicAuth(username, password string) (LoginResult, error)
+	BasicAuth(ctx context.Context, username, password string) (LoginResult, error)
 }
 
 // OAuth2Usecase defines the use case for OAuth2 authentication.
@@ -75,6 +79,8 @@ type Service struct {
 	tokenSettings        JWTSettings
 	httpClient           *http.Client
 	allowedRedirectHosts []string
+	passwordHasher       *PasswordHasher
+	userPort             userport.UserPersistencePort
 }
 
 // AllowedRedirectHosts returns the configured extra hosts that the
@@ -99,6 +105,8 @@ func New(
 	logger *slog.Logger,
 	settings *Config,
 	httpClient *http.Client,
+	passwordHasher *PasswordHasher,
+	userPort userport.UserPersistencePort,
 ) *Service {
 	var oauth2Cfg *oauth2.Config
 
@@ -123,6 +131,8 @@ func New(
 		tokenSettings:        settings.JWTSettings,
 		httpClient:           httpClient,
 		allowedRedirectHosts: allowedRedirectHosts,
+		passwordHasher:       passwordHasher,
+		userPort:             userPort,
 	}
 }
 
@@ -192,14 +202,56 @@ func (s *Service) CLIRedirectFromState(state string) (string, error) {
 }
 
 // BasicAuth authenticates the user using basic authentication with username and password.
-func (s *Service) BasicAuth(username, password string) (LoginResult, error) {
-	if username != s.adminSettings.Username || password != s.adminSettings.Password {
-		return LoginResult{}, ErrInvalidUsernameOrPassword
+// It first checks the config-provided admin credentials, then falls back to DB-backed
+// basic-auth users (verified against their stored password hash with the configured pepper).
+func (s *Service) BasicAuth(ctx context.Context, username, password string) (LoginResult, error) {
+	if username == s.adminSettings.Username && password == s.adminSettings.Password {
+		return s.issueBasicAuthLogin(username, s.adminSettings.Email)
 	}
 
+	email, err := s.verifyDBUserPassword(ctx, username, password)
+	if err != nil {
+		return LoginResult{}, err
+	}
+
+	return s.issueBasicAuthLogin(username, email)
+}
+
+// verifyDBUserPassword resolves a DB-backed basic-auth user by username and verifies the password.
+// It returns the user's email on success. Everything that is not a successful match — basic auth
+// disabled (no pepper), a wrong username, an inactive user, a user without a basic credential, and
+// a wrong password — collapses to [ErrInvalidUsernameOrPassword] so a failed login is always a 401
+// and callers cannot distinguish the cases.
+func (s *Service) verifyDBUserPassword(ctx context.Context, username, password string) (string, error) {
+	if s.userPort == nil || s.passwordHasher == nil || !s.passwordHasher.Enabled() {
+		return "", ErrInvalidUsernameOrPassword
+	}
+
+	user, err := s.userPort.GetUserByUsername(ctx, username)
+	if err != nil {
+		if errors.Is(err, port.ErrResourceNotExist) {
+			return "", ErrInvalidUsernameOrPassword
+		}
+
+		return "", fmt.Errorf("failed to look up basic-auth user: %w", err)
+	}
+
+	if !user.Spec.IsActive || !user.HasBasicAuth() {
+		return "", ErrInvalidUsernameOrPassword
+	}
+
+	verifyErr := s.passwordHasher.Verify(password, user.PasswordHash())
+	if verifyErr != nil {
+		return "", ErrInvalidUsernameOrPassword
+	}
+
+	return user.Spec.Email, nil
+}
+
+func (s *Service) issueBasicAuthLogin(username, email string) (LoginResult, error) {
 	s.logger.Debug("Authenticated user with basic auth", slog.String("username", username))
 
-	result, err := s.issueLoginResult(s.adminSettings.Email)
+	result, err := s.issueLoginResult(email)
 	if err != nil {
 		return LoginResult{}, err
 	}

--- a/pkg/cmd/apiserver/apiserver.go
+++ b/pkg/cmd/apiserver/apiserver.go
@@ -79,6 +79,9 @@ type CommandOption struct {
 			Password string `mapstructure:"password"`
 			Email    string `mapstructure:"email"`
 		} `mapstructure:"admin"`
+		Basic struct {
+			Pepper string `mapstructure:"pepper"`
+		} `mapstructure:"basic"`
 		JWT struct {
 			Issuer        string        `mapstructure:"issuer"`
 			Expire        time.Duration `mapstructure:"expire"`
@@ -194,6 +197,9 @@ func NewCommand(opt CommandOption) *cobra.Command {
 	cmd.Flags().String("auth.admin.username", "admin", "admin username")
 	cmd.Flags().String("auth.admin.password", "admin", "admin password")
 	cmd.Flags().String("auth.admin.email", "admin@admin", "admin email")
+	cmd.Flags().String("auth.basic.pepper", "",
+		"server-side secret mixed into basic-auth password hashes; "+
+			"set a long random value to enable DB-backed basic-auth users (empty disables them)")
 	cmd.Flags().String("auth.jwt.issuer", "opampcommander", "JWT issuer")
 	//nolint:mnd
 	cmd.Flags().Duration("auth.jwt.expire", 30*time.Minute, "JWT access token expiration duration")
@@ -303,6 +309,9 @@ func (opt *CommandOption) Prepare(_ *cobra.Command, _ []string) error {
 				Username: opt.Auth.Admin.Username,
 				Password: opt.Auth.Admin.Password,
 				Email:    opt.Auth.Admin.Email,
+			},
+			BasicAuthSettings: security.BasicAuthSettings{
+				Pepper: opt.Auth.Basic.Pepper,
 			},
 			JWTSettings: security.JWTSettings{
 				Issuer:            opt.Auth.JWT.Issuer,


### PR DESCRIPTION
## What

Adds DB-backed **basic-auth users** (username + password) that can log in to the REST API. Passwords are stored only as one-way hashes; neither the plaintext nor the hash is ever returned by the API.

## How

- **Hashing** — `HMAC-SHA256(password, pepper)` → bcrypt (per-user salt). The server pepper comes from config (`auth.basic.pepper`) and is held in a `memguard` enclave, opened transiently per operation. An empty pepper disables basic-auth user creation and login.
- **Domain** — the `User` aggregate gains an optional `BasicAuthCredential{PasswordHash}`, persisted by both the MongoDB and in-memory repositories. `GetUserByUsername` added to the user ports, plus a `spec.username` index.
- **API** — write-only `UserSpec.password` on create; `MapUserToAPI` never emits password material (the hash field does not exist in `api/v1`). Invalid input maps to HTTP 400 via `port.ErrInvalidArgument`.
- **Login** — `security.Service.BasicAuth` checks the config admin first, then DB users; every non-success collapses to **401** (invalid username or password). `BasicAuth` now takes a `context.Context`.
- **Create-time validation** — basic users require a non-empty email and a unique username (login resolves by username, so duplicates are rejected).

## Config

```yaml
auth:
  basic:
    pepper: "<long random secret; empty disables basic-auth users>"
```

## Tests

- `password_test.go` — hash/verify round-trip, distinct salts, pepper-matters, disabled-without-pepper.
- `basicauth_test.go` — disabled-pepper failed login → 401 (not 500), DB-user success + wrong-password, inactive user rejected.
- `make unittest` and `make lint` pass.

## Follow-ups

The `opampctl create user` command and the web create-dialog field are split into separate PRs that depend on the `api/v1.UserSpec.password` field added here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)