### PR TITLE
feat(web): set a basic-auth password when creating a user

### DIFF
--- a/web/public/samples/users.yaml
+++ b/web/public/samples/users.yaml
@@ -15,3 +15,17 @@
     spec:
       email: alice@example.com
       username: alice
+
+- label: New basic-auth user
+  description: Email + username + password (write-only; stored only as a one-way hash, never returned)
+  value:
+    kind: User
+    apiVersion: v1
+    metadata:
+      uid: ""
+      createdAt: "{{now}}"
+      updatedAt: "{{now}}"
+    spec:
+      email: bob@example.com
+      username: bob
+      password: change-me

--- a/web/src/entities/user/model/types.ts
+++ b/web/src/entities/user/model/types.ts
@@ -14,6 +14,9 @@ export interface UserSpec {
   email: string;
   username: string;
   isActive: boolean;
+  // Write-only: plaintext password for basic (username/password) auth. Sent only when creating a
+  // user; the server stores only a one-way hash and never returns it, so responses omit this field.
+  password?: string;
 }
 
 export interface User {

--- a/web/src/views/users/ui/UsersPage.tsx
+++ b/web/src/views/users/ui/UsersPage.tsx
@@ -16,7 +16,7 @@ function emptyUser(): User {
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     },
-    spec: { email: '', username: '', isActive: true },
+    spec: { email: '', username: '', isActive: true, password: '' },
   };
 }
 
@@ -54,7 +54,7 @@ export default function UsersPage() {
           <JsonEditorDialog
             open={open}
             title="Create user"
-            description="Set spec.email, spec.username, spec.isActive."
+            description="Set spec.email, spec.username, spec.isActive. Set spec.password to enable basic (username/password) login — it is stored only as a one-way hash and is never returned."
             initialValue={emptyUser()}
             samplesUrl="/samples/users.yaml"
             onClose={onClose}


### PR DESCRIPTION
## What

Adds a write-only `spec.password` field to the user **create** dialog (and a "New basic-auth user" sample). When set, the API provisions a basic (username/password) login; the server stores only a one-way hash and never returns it, so list/detail views are unchanged.

## Notes

- Purely client-side (TypeScript), so it builds against `main` on its own.
- Functionally depends on the apiserver change (#424) accepting `api/v1.UserSpec.password` for the field to take effect end-to-end.
- Checks: `tsc --noEmit`, `eslint`, `vitest`, `next build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)