### PR TITLE
ci(docs): pin Hugo to 0.151.0 to fix PostCSS build failure

### DIFF
--- a/.github/workflows/deploy-docs.yaml
+++ b/.github/workflows/deploy-docs.yaml
@@ -34,7 +34,11 @@ jobs:
       - name: Setup Hugo
         uses: peaceiris/actions-hugo@v3
         with:
-          hugo-version: 'latest'
+          # Pinned: Hugo 0.158+ regressed the Node-based PostCSS pipeline used
+          # by the Docsy theme, failing with "node: bad option: --permission".
+          # 0.151.0 builds these docs cleanly. Bump deliberately once the
+          # upstream regression is resolved.
+          hugo-version: '0.151.0'
           extended: true
 
       - name: Setup Node


### PR DESCRIPTION
## Problem

The **Deploy Documentation** workflow started failing on `main` in the Docsy theme's PostCSS step:

```
POSTCSS: failed to transform "/scss/main.css" (text/css):
/opt/.../node: bad option: --permission
```

The workflow used `hugo-version: 'latest'`, which resolved to **0.163.2**. Hugo 0.158+ regressed the Node-based asset pipeline that Docsy uses for SCSS/PostCSS (the build run also emits the `v0.158.0` `LanguageDirection` deprecation), so node is invoked with `--permission` in a context it rejects.

## Fix

Pin `hugo-version` to **0.151.0**, which builds the site cleanly.

## Verification

Reproduced locally with Hugo 0.151.0 (extended) against the current `docs/` content and Docsy 0.12.0:

```
hugo --gc --minify --baseURL "/"
→ Pages: 22, Static files: 38, Total in ~1.8s  (no PostCSS error)
```

Bump the pin deliberately once the upstream Hugo regression is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)