### PR TITLE
fix(docs): make site work under a baseURL path prefix

### DIFF
--- a/docs/content/en/docs/getting-started/_index.md
+++ b/docs/content/en/docs/getting-started/_index.md
@@ -63,7 +63,7 @@ By default the server listens on:
 - `localhost:8080` — REST API and the OpAMP WebSocket endpoint (`/api/v1/opamp`)
 - `localhost:9090` — management endpoints (`/healthz`, `/readyz`, metrics, pprof)
 
-See the [Configuration guide](/en/docs/configuration/) for every available option.
+See the [Configuration guide](/docs/configuration/) for every available option.
 
 ## Install opampctl
 
@@ -85,7 +85,7 @@ opampctl whoami
 opampctl get agent
 ```
 
-See the [CLI reference](/en/docs/cli/) for the full command set.
+See the [CLI reference](/docs/cli/) for the full command set.
 
 ## Connect an agent
 
@@ -104,6 +104,6 @@ The agent's `service.namespace` resource attribute determines its namespace
 
 ## Next steps
 
-- Configure the server in the [Configuration guide](/en/docs/configuration/)
-- Explore the [REST API](/en/docs/api/)
-- Learn the [CLI commands](/en/docs/cli/)
+- Configure the server in the [Configuration guide](/docs/configuration/)
+- Explore the [REST API](/docs/api/)
+- Learn the [CLI commands](/docs/cli/)

--- a/docs/content/en/docs/overview/_index.md
+++ b/docs/content/en/docs/overview/_index.md
@@ -116,5 +116,5 @@ sequenceDiagram
 
 ## Getting started
 
-Ready to start? See the [Getting Started Guide](/en/docs/getting-started/) for
+Ready to start? See the [Getting Started Guide](/docs/getting-started/) for
 installation and setup.

--- a/docs/content/en/docs/web/_index.md
+++ b/docs/content/en/docs/web/_index.md
@@ -61,7 +61,7 @@ Remote configs hold reusable agent configuration payloads that groups can refere
 The Agents page lists the collectors connected to the server with their connection
 type and reported health. Agents appear here once an OpAMP-capable collector connects
 to the server's `/api/v1/opamp` endpoint — see
-[Getting Started](/en/docs/getting-started/#connect-an-agent).
+[Getting Started](/docs/getting-started/#connect-an-agent).
 
 ![Agents](/images/screenshots/agents.png)
 

--- a/docs/hugo.toml
+++ b/docs/hugo.toml
@@ -6,6 +6,10 @@ languageCode = "en-us"
 defaultContentLanguage = "en"
 defaultContentLanguageInSubdir = false
 
+# Canonicalize root-relative URLs (images, links, menus) against baseURL so the
+# site works when served under a path prefix (e.g. /opampcommander/ on GitHub Pages).
+canonifyURLs = true
+
 # Highlight settings
 pygmentsCodeFences = true
 pygmentsUseClasses = true
@@ -91,7 +95,7 @@ disableKinds = ["taxonomy"]
   [[menu.main]]
     name = "Documentation"
     weight = 10
-    url = "/en/docs/"
+    url = "/docs/"
     
   [[menu.main]]
     name = "GitHub"
@@ -104,3 +108,6 @@ disableKinds = ["taxonomy"]
     title = "OpAMP Commander"
     languageName = "English"
     weight = 1
+    # Serve the content under content/en at the site root (no /en/ URL segment),
+    # since defaultContentLanguageInSubdir is false.
+    contentDir = "content/en"


### PR DESCRIPTION
## Problem

The docs site is served under a path prefix — `https://minuk.dev/opampcommander/` — but root-relative URLs in content were emitted verbatim and resolved against the **domain root**, so they 404'd:

- Screenshot images rendered as `<img src=/images/screenshots/...>` → browser requested `minuk.dev/images/...` (missing `/opampcommander/`)
- Internal doc links `/en/docs/...` had the same problem
- URLs also carried a stray `/en/` segment because `content/en/` wasn't configured as the language content root

## Fix

- **`canonifyURLs = true`** — canonicalizes root-relative URLs (images, links, menus) against `baseURL`, so they respect the path prefix. Verified the theme's own `relURL`-generated assets are **not** double-prefixed.
- **`contentDir = "content/en"`** on `[languages.en]` — serves the default language at the site root, dropping `/en/` (`/docs/overview/` instead of `/en/docs/overview/`).
- Update the `Documentation` menu and internal markdown links from `/en/docs/...` to `/docs/...`.

## Verification

Built with the production base URL and confirmed every URL carries the prefix exactly once:

```
hugo --gc --minify --baseURL "https://minuk.dev/opampcommander/"
```

| Check | Result |
|---|---|
| `opampcommander/opampcommander` (double prefix) | none |
| Image src | `https://minuk.dev/opampcommander/images/screenshots/…` |
| Internal doc link | `https://minuk.dev/opampcommander/docs/configuration/` |
| Theme CSS | `https://minuk.dev/opampcommander/scss/main.min.…css` |
| Menu link | `https://minuk.dev/opampcommander/docs/` |
| Page output path | `public/docs/overview/` (no `/en/`) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)