### PR TITLE
feat(web): add a dedicated password field to the create-user form

### DIFF
--- a/web/src/features/user-create/index.ts
+++ b/web/src/features/user-create/index.ts
@@ -1,0 +1,1 @@
+export { default as UserCreateDialog } from './ui/UserCreateDialog';

--- a/web/src/features/user-create/ui/UserCreateDialog.test.tsx
+++ b/web/src/features/user-create/ui/UserCreateDialog.test.tsx
@@ -1,0 +1,76 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import UserCreateDialog from './UserCreateDialog';
+import { api } from '@shared/api';
+
+vi.mock('@shared/api', () => ({
+  api: { post: vi.fn() },
+}));
+
+const post = vi.mocked(api.post);
+
+describe('UserCreateDialog', () => {
+  beforeEach(() => {
+    post.mockReset();
+    post.mockResolvedValue(undefined as never);
+  });
+
+  it('posts the entered password in spec.password when creating a basic-auth user', async () => {
+    const user = userEvent.setup();
+    const onSaved = vi.fn();
+    render(<UserCreateDialog open onClose={() => {}} onSaved={onSaved} />);
+
+    await user.type(screen.getByLabelText(/Email/), 'bob@example.com');
+    await user.type(screen.getByLabelText(/Username/), 'bob');
+    await user.type(screen.getByLabelText(/^Password/), 'change-me');
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    expect(post).toHaveBeenCalledTimes(1);
+    const [path, body] = post.mock.calls[0];
+    expect(path).toBe('/api/v1/users');
+    expect(body).toMatchObject({
+      kind: 'User',
+      spec: { email: 'bob@example.com', username: 'bob', isActive: true, password: 'change-me' },
+    });
+    expect(onSaved).toHaveBeenCalledTimes(1);
+  });
+
+  it('omits spec.password when no password is entered', async () => {
+    const user = userEvent.setup();
+    render(<UserCreateDialog open onClose={() => {}} onSaved={() => {}} />);
+
+    await user.type(screen.getByLabelText(/Email/), 'alice@example.com');
+    await user.type(screen.getByLabelText(/Username/), 'alice');
+    await user.click(screen.getByRole('button', { name: 'Create' }));
+
+    const [, body] = post.mock.calls[0];
+    expect(body).toMatchObject({ spec: { email: 'alice@example.com', username: 'alice' } });
+    expect((body as { spec: Record<string, unknown> }).spec).not.toHaveProperty('password');
+  });
+
+  it('disables Create until both email and username are provided', async () => {
+    const user = userEvent.setup();
+    render(<UserCreateDialog open onClose={() => {}} onSaved={() => {}} />);
+
+    const create = screen.getByRole('button', { name: 'Create' });
+    expect(create).toBeDisabled();
+
+    await user.type(screen.getByLabelText(/Email/), 'alice@example.com');
+    expect(create).toBeDisabled();
+
+    await user.type(screen.getByLabelText(/Username/), 'alice');
+    expect(create).toBeEnabled();
+  });
+
+  it('toggles password visibility', async () => {
+    const user = userEvent.setup();
+    render(<UserCreateDialog open onClose={() => {}} onSaved={() => {}} />);
+
+    const password = screen.getByLabelText(/^Password/);
+    expect(password).toHaveAttribute('type', 'password');
+
+    await user.click(screen.getByRole('button', { name: 'Show password' }));
+    expect(password).toHaveAttribute('type', 'text');
+  });
+});

--- a/web/src/features/user-create/ui/UserCreateDialog.tsx
+++ b/web/src/features/user-create/ui/UserCreateDialog.tsx
@@ -12,7 +12,10 @@ import {
   Stack,
   TextField,
 } from '@mui/material';
-import { Visibility as VisibilityIcon, VisibilityOff as VisibilityOffIcon } from '@mui/icons-material';
+import {
+  Visibility as VisibilityIcon,
+  VisibilityOff as VisibilityOffIcon,
+} from '@mui/icons-material';
 import { useState } from 'react';
 import { api } from '@shared/api';
 import type { User } from '@entities/user';

--- a/web/src/features/user-create/ui/UserCreateDialog.tsx
+++ b/web/src/features/user-create/ui/UserCreateDialog.tsx
@@ -1,0 +1,120 @@
+'use client';
+
+import {
+  Alert,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogTitle,
+  IconButton,
+  InputAdornment,
+  Stack,
+  TextField,
+} from '@mui/material';
+import { Visibility as VisibilityIcon, VisibilityOff as VisibilityOffIcon } from '@mui/icons-material';
+import { useState } from 'react';
+import { api } from '@shared/api';
+import type { User } from '@entities/user';
+
+interface Props {
+  open: boolean;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+export default function UserCreateDialog({ open, onClose, onSaved }: Props) {
+  const [email, setEmail] = useState('');
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const save = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const now = new Date().toISOString();
+      const body: User = {
+        kind: 'User',
+        apiVersion: 'v1',
+        metadata: { uid: '', createdAt: now, updatedAt: now },
+        // CreateUser always provisions an active user (spec.isActive is ignored
+        // on POST). Password is optional: set it to enable basic
+        // (username/password) login. It is write-only — the server stores only a
+        // one-way hash and never returns it — so we send it only when non-empty.
+        spec: {
+          email,
+          username,
+          isActive: true,
+          ...(password ? { password } : {}),
+        },
+      };
+      await api.post('/api/v1/users', body);
+      onSaved();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to create user');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>Create user</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} mt={1}>
+          {error && <Alert severity="error">{error}</Alert>}
+          <TextField
+            label="Email"
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            fullWidth
+            required
+          />
+          <TextField
+            label="Username"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            fullWidth
+            required
+          />
+          <TextField
+            label="Password"
+            type={showPassword ? 'text' : 'password'}
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            fullWidth
+            autoComplete="new-password"
+            helperText="Optional. Set it to enable basic (username/password) login. Stored only as a one-way hash and never returned."
+            slotProps={{
+              input: {
+                endAdornment: (
+                  <InputAdornment position="end">
+                    <IconButton
+                      aria-label={showPassword ? 'Hide password' : 'Show password'}
+                      onClick={() => setShowPassword((v) => !v)}
+                      edge="end"
+                    >
+                      {showPassword ? <VisibilityOffIcon /> : <VisibilityIcon />}
+                    </IconButton>
+                  </InputAdornment>
+                ),
+              },
+            }}
+          />
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={busy}>
+          Cancel
+        </Button>
+        <Button variant="contained" onClick={save} disabled={busy || !email || !username}>
+          Create
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/web/src/views/users/ui/UsersPage.tsx
+++ b/web/src/views/users/ui/UsersPage.tsx
@@ -4,25 +4,13 @@ import { Box, Chip } from '@mui/material';
 import { ResourceListPage } from '@widgets/resource-list-page';
 import dynamic from 'next/dynamic';
 import { TimeDisplay } from '@shared/preferences';
-import { api } from '@shared/api';
 import type { User } from '@entities/user';
 
-// Lazy-loaded: the JSON editor pulls in js-yaml, only needed once a
-// create/edit dialog opens — keep it out of the initial route bundle.
-const JsonEditorDialog = dynamic(() => import('@shared/ui/JsonEditorDialog'));
-
-function emptyUser(): User {
-  return {
-    kind: 'User',
-    apiVersion: 'v1',
-    metadata: {
-      uid: '',
-      createdAt: new Date().toISOString(),
-      updatedAt: new Date().toISOString(),
-    },
-    spec: { email: '', username: '', isActive: true, password: '' },
-  };
-}
+// Lazy-loaded: the dialog and its form fields are only needed once the user
+// opens the create flow — keep them out of the initial route bundle.
+const UserCreateDialog = dynamic(() =>
+  import('@features/user-create').then((m) => m.UserCreateDialog),
+);
 
 export default function UsersPage() {
   return (
@@ -55,18 +43,7 @@ export default function UsersPage() {
           { header: 'Created', render: (u) => <TimeDisplay value={u.metadata.createdAt} /> },
         ]}
         renderCreate={({ open, onClose, onSaved }) => (
-          <JsonEditorDialog
-            open={open}
-            title="Create user"
-            description="Set spec.email, spec.username, spec.isActive. Set spec.password to enable basic (username/password) login — it is stored only as a one-way hash and is never returned."
-            initialValue={emptyUser()}
-            samplesUrl="/samples/users.yaml"
-            onClose={onClose}
-            onSave={async (parsed) => {
-              await api.post('/api/v1/users', parsed as User);
-              onSaved();
-            }}
-          />
+          <UserCreateDialog open={open} onClose={onClose} onSaved={onSaved} />
         )}
       />
     </Box>


### PR DESCRIPTION
## What

Replaces the raw JSON-editor **Create user** dialog with a purpose-built form
that has dedicated **Email**, **Username**, and **Password** fields.

Previously the only way to set a password when creating a user in the web UI
was to hand-edit the JSON resource (or load the `New basic-auth user` sample
from the editor's dropdown, added in #426). The password field was easy to
miss. This makes creating a basic-auth user a first-class, discoverable action.

## Details

- New `features/user-create` FSD slice with `UserCreateDialog`.
- Password is **optional**: set it to enable basic (username/password) login.
  It's masked by default with a show/hide toggle, and only sent in
  `spec.password` when non-empty — the server stores it as a one-way hash and
  never returns it.
- `Create` is disabled until both email and username are provided.
- The dialog is lazy-loaded (`next/dynamic`) so it stays out of the initial
  `/users` route bundle, matching the previous behavior.
- `UsersPage` no longer uses `JsonEditorDialog` for creation.

## Testing

- `npx tsc --noEmit`, `npm run lint`, `npm test` (60 passing, incl. 4 new
  `UserCreateDialog` tests covering password sent/omitted, Create
  enable/disable, and visibility toggle), and `npm run build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)