### PR TITLE
feat(apiserver): add API to list agent groups containing an agent

### DIFF
--- a/pkg/apiserver/adapter/primary/http/v1/agentgroup/controller.go
+++ b/pkg/apiserver/adapter/primary/http/v1/agentgroup/controller.go
@@ -2,12 +2,14 @@
 package agentgroup
 
 import (
+	"errors"
 	"log/slog"
 	"net/http"
 
 	"github.com/gin-gonic/gin"
 
 	v1 "github.com/minuk-dev/opampcommander/api/v1"
+	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/ginutil"
 )
@@ -45,6 +47,12 @@ func (c *Controller) RoutesInfo() gin.RoutesInfo {
 			Path:        "/api/v1/namespaces/:namespace/agentgroups/:name/agents",
 			Handler:     "http.v1.agentgroup.GetAgentByAgentGroup",
 			HandlerFunc: c.ListAgentsByAgentGroup,
+		},
+		{
+			Method:      http.MethodGet,
+			Path:        "/api/v1/namespaces/:namespace/agents/:id/agentgroups",
+			Handler:     "http.v1.agentgroup.ListAgentGroupsByAgent",
+			HandlerFunc: c.ListAgentGroupsByAgent,
 		},
 		{
 			Method:      http.MethodGet,
@@ -222,6 +230,52 @@ func (c *Controller) ListAgentsByAgentGroup(ctx *gin.Context) {
 	}
 
 	ctx.JSON(http.StatusOK, agents)
+}
+
+// ListAgentGroupsByAgent retrieves the agent groups that contain a specific agent.
+//
+// @Summary List Agent Groups by Agent
+// @Tags agentgroup
+// @Description Retrieve the agent groups in the namespace whose selector matches the given agent.
+// @Accept json
+// @Produce json
+// @Success 200 {object} v1.ListResponse[v1.AgentGroup]
+// @Param namespace path string true "Namespace"
+// @Param id path string true "Instance UID of the agent"
+// @Failure 400 {object} map[string]any
+// @Failure 404 {object} map[string]any
+// @Failure 500 {object} map[string]any
+// @Router /api/v1/namespaces/{namespace}/agents/{id}/agentgroups [get].
+func (c *Controller) ListAgentGroupsByAgent(ctx *gin.Context) {
+	namespace, err := ginutil.ParseString(ctx, "namespace", true)
+	if err != nil {
+		ginutil.HandleValidationError(ctx, "namespace", ctx.Param("namespace"), err, true)
+
+		return
+	}
+
+	instanceUID, err := ginutil.ParseUUID(ctx, "id")
+	if err != nil {
+		ginutil.HandleValidationError(ctx, "id", ctx.Param("id"), err, true)
+
+		return
+	}
+
+	agentGroups, err := c.agentGroupUsecase.ListAgentGroupsByAgent(ctx.Request.Context(), namespace, instanceUID)
+	if err != nil {
+		if errors.Is(err, applicationport.ErrAgentNamespaceMismatch) {
+			ginutil.ResourceNotFoundError(ctx, "agent", ctx.Param("id"))
+
+			return
+		}
+
+		c.logger.Error("failed to list agent groups by agent", "error", err.Error())
+		ginutil.HandleDomainError(ctx, err, "An error occurred while retrieving the agent groups for the agent.")
+
+		return
+	}
+
+	ctx.JSON(http.StatusOK, agentGroups)
 }
 
 // Create creates a new agent group.

--- a/pkg/apiserver/adapter/primary/http/v1/agentgroup/controller_test.go
+++ b/pkg/apiserver/adapter/primary/http/v1/agentgroup/controller_test.go
@@ -18,6 +18,7 @@ import (
 	v1 "github.com/minuk-dev/opampcommander/api/v1"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/primary/http/v1/agentgroup"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/primary/http/v1/agentgroup/usecasemock"
+	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/port"
 	"github.com/minuk-dev/opampcommander/pkg/testutil"
 )
@@ -224,6 +225,82 @@ func TestAgentGroupController_Get_InternalError(t *testing.T) {
 	require.NoError(t, err)
 	router.ServeHTTP(recorder, req)
 	assert.Equal(t, http.StatusInternalServerError, recorder.Code)
+}
+
+func TestAgentGroupController_ListAgentGroupsByAgent(t *testing.T) {
+	t.Parallel()
+
+	agentID := uuid.New()
+
+	t.Run("happycase", func(t *testing.T) {
+		t.Parallel()
+		ctrlBase := testutil.NewBase(t).ForController()
+		usecase := usecasemock.NewMockUsecase(t)
+		controller := agentgroup.NewController(usecase, ctrlBase.Logger)
+		ctrlBase.SetupRouter(controller)
+		router := ctrlBase.Router
+
+		usecase.EXPECT().
+			ListAgentGroupsByAgent(mock.Anything, "default", agentID).
+			Return(&v1.ListResponse[v1.AgentGroup]{
+				Kind:       "AgentGroup",
+				APIVersion: "v1",
+				Metadata:   v1.ListMeta{Continue: "", RemainingItemCount: 0},
+				Items: []v1.AgentGroup{
+					{Metadata: v1.Metadata{Namespace: "default", Name: "g1"}},
+				},
+			}, nil)
+
+		recorder := httptest.NewRecorder()
+		req, err := http.NewRequestWithContext(
+			t.Context(), http.MethodGet,
+			"/api/v1/namespaces/default/agents/"+agentID.String()+"/agentgroups", nil,
+		)
+		require.NoError(t, err)
+		router.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusOK, recorder.Code)
+		assert.Equal(t, int64(1), gjson.Get(recorder.Body.String(), "items.#").Int())
+	})
+
+	t.Run("invalid id", func(t *testing.T) {
+		t.Parallel()
+		ctrlBase := testutil.NewBase(t).ForController()
+		usecase := usecasemock.NewMockUsecase(t)
+		controller := agentgroup.NewController(usecase, ctrlBase.Logger)
+		ctrlBase.SetupRouter(controller)
+		router := ctrlBase.Router
+
+		recorder := httptest.NewRecorder()
+		req, err := http.NewRequestWithContext(
+			t.Context(), http.MethodGet,
+			"/api/v1/namespaces/default/agents/not-a-uuid/agentgroups", nil,
+		)
+		require.NoError(t, err)
+		router.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusBadRequest, recorder.Code)
+	})
+
+	t.Run("agent in another namespace returns 404", func(t *testing.T) {
+		t.Parallel()
+		ctrlBase := testutil.NewBase(t).ForController()
+		usecase := usecasemock.NewMockUsecase(t)
+		controller := agentgroup.NewController(usecase, ctrlBase.Logger)
+		ctrlBase.SetupRouter(controller)
+		router := ctrlBase.Router
+
+		usecase.EXPECT().
+			ListAgentGroupsByAgent(mock.Anything, "default", agentID).
+			Return(nil, applicationport.ErrAgentNamespaceMismatch)
+
+		recorder := httptest.NewRecorder()
+		req, err := http.NewRequestWithContext(
+			t.Context(), http.MethodGet,
+			"/api/v1/namespaces/default/agents/"+agentID.String()+"/agentgroups", nil,
+		)
+		require.NoError(t, err)
+		router.ServeHTTP(recorder, req)
+		assert.Equal(t, http.StatusNotFound, recorder.Code)
+	})
 }
 
 func TestAgentGroupController_Create(t *testing.T) {

--- a/pkg/apiserver/adapter/primary/http/v1/agentgroup/usecasemock/mocks.go
+++ b/pkg/apiserver/adapter/primary/http/v1/agentgroup/usecasemock/mocks.go
@@ -7,6 +7,7 @@ package usecasemock
 import (
 	"context"
 
+	"github.com/google/uuid"
 	"github.com/minuk-dev/opampcommander/api/v1"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
 	mock "github.com/stretchr/testify/mock"
@@ -314,6 +315,80 @@ func (_c *MockUsecase_ListAgentGroups_Call) Return(listResponse *v1.ListResponse
 }
 
 func (_c *MockUsecase_ListAgentGroups_Call) RunAndReturn(run func(ctx context.Context, options *model.ListOptions) (*v1.ListResponse[v1.AgentGroup], error)) *MockUsecase_ListAgentGroups_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// ListAgentGroupsByAgent provides a mock function for the type MockUsecase
+func (_mock *MockUsecase) ListAgentGroupsByAgent(ctx context.Context, namespace string, instanceUID uuid.UUID) (*v1.ListResponse[v1.AgentGroup], error) {
+	ret := _mock.Called(ctx, namespace, instanceUID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ListAgentGroupsByAgent")
+	}
+
+	var r0 *v1.ListResponse[v1.AgentGroup]
+	var r1 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, uuid.UUID) (*v1.ListResponse[v1.AgentGroup], error)); ok {
+		return returnFunc(ctx, namespace, instanceUID)
+	}
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, uuid.UUID) *v1.ListResponse[v1.AgentGroup]); ok {
+		r0 = returnFunc(ctx, namespace, instanceUID)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*v1.ListResponse[v1.AgentGroup])
+		}
+	}
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, uuid.UUID) error); ok {
+		r1 = returnFunc(ctx, namespace, instanceUID)
+	} else {
+		r1 = ret.Error(1)
+	}
+	return r0, r1
+}
+
+// MockUsecase_ListAgentGroupsByAgent_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ListAgentGroupsByAgent'
+type MockUsecase_ListAgentGroupsByAgent_Call struct {
+	*mock.Call
+}
+
+// ListAgentGroupsByAgent is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespace string
+//   - instanceUID uuid.UUID
+func (_e *MockUsecase_Expecter) ListAgentGroupsByAgent(ctx interface{}, namespace interface{}, instanceUID interface{}) *MockUsecase_ListAgentGroupsByAgent_Call {
+	return &MockUsecase_ListAgentGroupsByAgent_Call{Call: _e.mock.On("ListAgentGroupsByAgent", ctx, namespace, instanceUID)}
+}
+
+func (_c *MockUsecase_ListAgentGroupsByAgent_Call) Run(run func(ctx context.Context, namespace string, instanceUID uuid.UUID)) *MockUsecase_ListAgentGroupsByAgent_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 uuid.UUID
+		if args[2] != nil {
+			arg2 = args[2].(uuid.UUID)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockUsecase_ListAgentGroupsByAgent_Call) Return(listResponse *v1.ListResponse[v1.AgentGroup], err error) *MockUsecase_ListAgentGroupsByAgent_Call {
+	_c.Call.Return(listResponse, err)
+	return _c
+}
+
+func (_c *MockUsecase_ListAgentGroupsByAgent_Call) RunAndReturn(run func(ctx context.Context, namespace string, instanceUID uuid.UUID) (*v1.ListResponse[v1.AgentGroup], error)) *MockUsecase_ListAgentGroupsByAgent_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/apiserver/application/port/in.go
+++ b/pkg/apiserver/application/port/in.go
@@ -89,6 +89,13 @@ type AgentGroupManageUsecase interface {
 		agentGroupName string,
 		options *model.ListOptions,
 	) (*v1.ListResponse[v1.Agent], error)
+	// ListAgentGroupsByAgent lists the agent groups in the given namespace whose selector
+	// matches the agent identified by instanceUID.
+	ListAgentGroupsByAgent(
+		ctx context.Context,
+		namespace string,
+		instanceUID uuid.UUID,
+	) (*v1.ListResponse[v1.AgentGroup], error)
 	CreateAgentGroup(ctx context.Context, agentGroup *v1.AgentGroup) (*v1.AgentGroup, error)
 	UpdateAgentGroup(ctx context.Context, namespace string, name string,
 		agentGroup *v1.AgentGroup) (*v1.AgentGroup, error)

--- a/pkg/apiserver/application/service/agentgroup/agentgroup_manage_service.go
+++ b/pkg/apiserver/application/service/agentgroup/agentgroup_manage_service.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/google/uuid"
 	"github.com/samber/lo"
 
 	v1 "github.com/minuk-dev/opampcommander/api/v1"
@@ -117,6 +118,41 @@ func (s *ManageService) ListAgentsByAgentGroup(
 		},
 		Items: lo.Map(domainResp.Items, func(agent *agentmodel.Agent, _ int) v1.Agent {
 			return *s.mapper.MapAgentToAPI(agent)
+		}),
+	}, nil
+}
+
+// ListAgentGroupsByAgent lists the agent groups in the given namespace whose selector matches
+// the agent identified by instanceUID. It returns port.ErrAgentNamespaceMismatch when the agent
+// exists but in a different namespace, so the HTTP layer can map that to a 404.
+func (s *ManageService) ListAgentGroupsByAgent(
+	ctx context.Context,
+	namespace string,
+	instanceUID uuid.UUID,
+) (*v1.ListResponse[v1.AgentGroup], error) {
+	agent, err := s.agentUsecase.GetAgent(ctx, instanceUID)
+	if err != nil {
+		return nil, fmt.Errorf("get agent: %w", err)
+	}
+
+	if agent.Metadata.Namespace != namespace {
+		return nil, fmt.Errorf("list agent groups by agent: %w", port.ErrAgentNamespaceMismatch)
+	}
+
+	groups, err := s.agentgroupUsecase.GetAgentGroupsForAgent(ctx, agent)
+	if err != nil {
+		return nil, fmt.Errorf("get agent groups for agent: %w", err)
+	}
+
+	return &v1.ListResponse[v1.AgentGroup]{
+		Kind:       v1.AgentGroupKind,
+		APIVersion: v1.APIVersion,
+		Metadata: v1.ListMeta{
+			Continue:           "",
+			RemainingItemCount: 0,
+		},
+		Items: lo.Map(groups, func(agentGroup *agentmodel.AgentGroup, _ int) v1.AgentGroup {
+			return *s.mapper.MapAgentGroupToAPI(agentGroup)
 		}),
 	}, nil
 }

--- a/pkg/apiserver/docs/docs.go
+++ b/pkg/apiserver/docs/docs.go
@@ -1502,6 +1502,66 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/namespaces/{namespace}/agents/{id}/agentgroups": {
+            "get": {
+                "description": "Retrieve the agent groups in the namespace whose selector matches the given agent.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "agentgroup"
+                ],
+                "summary": "List Agent Groups by Agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Namespace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Instance UID of the agent",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/ListResponse-AgentGroup"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/namespaces/{namespace}/certificates": {
             "get": {
                 "description": "Retrieve a list of certificates.",

--- a/pkg/apiserver/docs/swagger.json
+++ b/pkg/apiserver/docs/swagger.json
@@ -1494,6 +1494,66 @@
                 }
             }
         },
+        "/api/v1/namespaces/{namespace}/agents/{id}/agentgroups": {
+            "get": {
+                "description": "Retrieve the agent groups in the namespace whose selector matches the given agent.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "agentgroup"
+                ],
+                "summary": "List Agent Groups by Agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Namespace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Instance UID of the agent",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/ListResponse-AgentGroup"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/namespaces/{namespace}/certificates": {
             "get": {
                 "description": "Retrieve a list of certificates.",

--- a/pkg/apiserver/docs/swagger.yaml
+++ b/pkg/apiserver/docs/swagger.yaml
@@ -2263,6 +2263,48 @@ paths:
       summary: Update Agent
       tags:
       - agent
+  /api/v1/namespaces/{namespace}/agents/{id}/agentgroups:
+    get:
+      consumes:
+      - application/json
+      description: Retrieve the agent groups in the namespace whose selector matches
+        the given agent.
+      parameters:
+      - description: Namespace
+        in: path
+        name: namespace
+        required: true
+        type: string
+      - description: Instance UID of the agent
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/ListResponse-AgentGroup'
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      summary: List Agent Groups by Agent
+      tags:
+      - agentgroup
   /api/v1/namespaces/{namespace}/agents/search:
     get:
       consumes:

--- a/pkg/apiserver/domain/agent/service/agentgroup.go
+++ b/pkg/apiserver/domain/agent/service/agentgroup.go
@@ -238,11 +238,18 @@ func (s *AgentGroupService) GetAgentGroupsForAgent(
 		return nil, fmt.Errorf("failed to list agent groups: %w", err)
 	}
 
-	// Filter groups that match the agent
+	// Filter groups that match the agent. An agent group only governs agents in its own
+	// namespace, so groups from other namespaces are skipped even when their selector would
+	// otherwise match — without this scoping a group in namespace "foo" would (incorrectly)
+	// apply its remote config to an agent in "default".
 	var matchingGroups []*agentmodel.AgentGroup
 
 	for _, group := range allGroups.Items {
 		if group.IsDeleted() {
+			continue
+		}
+
+		if group.Metadata.Namespace != agent.Metadata.Namespace {
 			continue
 		}
 

--- a/pkg/apiserver/domain/agent/service/agentgroup_internal_test.go
+++ b/pkg/apiserver/domain/agent/service/agentgroup_internal_test.go
@@ -960,7 +960,8 @@ func TestUpdateAgentsByAgentGroup(t *testing.T) {
 
 		agentGroup := &agentmodel.AgentGroup{
 			Metadata: agentmodel.AgentGroupMetadata{
-				Name: "production",
+				Namespace: "default",
+				Name:      "production",
 			},
 			Spec: agentmodel.AgentGroupSpec{
 				Selector: agentmodel.AgentSelector{
@@ -984,7 +985,7 @@ func TestUpdateAgentsByAgentGroup(t *testing.T) {
 		// (ApplyMatchingAgentGroupsToAgent), which calls GetAgentGroupsForAgent → ListAgentGroups.
 		mockPersistence.On("ListAgentGroups", mock.Anything, (*model.ListOptions)(nil)).
 			Return(&model.ListResponse[*agentmodel.AgentGroup]{Items: []*agentmodel.AgentGroup{agentGroup}}, nil)
-		mockRemoteConfigPort.On("GetAgentRemoteConfig", mock.Anything, "", refName, (*model.GetOptions)(nil)).
+		mockRemoteConfigPort.On("GetAgentRemoteConfig", mock.Anything, "default", refName, (*model.GetOptions)(nil)).
 			Return(referencedConfig, nil)
 		// updateAgentsByAgentGroup records the RemoteConfigApplied condition on the group;
 		// recordRemoteConfigCondition re-reads it first, then persists.
@@ -1024,7 +1025,8 @@ func TestUpdateAgentsByAgentGroup(t *testing.T) {
 		inlineName := "inline-config"
 		agentGroup := &agentmodel.AgentGroup{
 			Metadata: agentmodel.AgentGroupMetadata{
-				Name: "staging",
+				Namespace: "default",
+				Name:      "staging",
 			},
 			Spec: agentmodel.AgentGroupSpec{
 				Selector: agentmodel.AgentSelector{

--- a/pkg/apiserver/domain/agent/service/agentgroup_test.go
+++ b/pkg/apiserver/domain/agent/service/agentgroup_test.go
@@ -477,7 +477,8 @@ func TestAgentGroupService_GetAgentGroupsForAgent(t *testing.T) {
 
 		matchingGroup := &agentmodel.AgentGroup{
 			Metadata: agentmodel.AgentGroupMetadata{
-				Name: "matching-group",
+				Namespace: "default",
+				Name:      "matching-group",
 			},
 			Spec: agentmodel.AgentGroupSpec{
 				Selector: agentmodel.AgentSelector{
@@ -490,7 +491,8 @@ func TestAgentGroupService_GetAgentGroupsForAgent(t *testing.T) {
 
 		nonMatchingGroup := &agentmodel.AgentGroup{
 			Metadata: agentmodel.AgentGroupMetadata{
-				Name: "non-matching-group",
+				Namespace: "default",
+				Name:      "non-matching-group",
 			},
 			Spec: agentmodel.AgentGroupSpec{
 				Selector: agentmodel.AgentSelector{
@@ -501,8 +503,24 @@ func TestAgentGroupService_GetAgentGroupsForAgent(t *testing.T) {
 			},
 		}
 
+		// Selector matches the agent, but the group lives in a different namespace,
+		// so it must NOT be returned: an agent group only governs agents in its own namespace.
+		otherNamespaceGroup := &agentmodel.AgentGroup{
+			Metadata: agentmodel.AgentGroupMetadata{
+				Namespace: "other",
+				Name:      "other-namespace-group",
+			},
+			Spec: agentmodel.AgentGroupSpec{
+				Selector: agentmodel.AgentSelector{
+					IdentifyingAttributes: map[string]string{
+						"service.name": "my-service",
+					},
+				},
+			},
+		}
+
 		allGroups := &model.ListResponse[*agentmodel.AgentGroup]{
-			Items:              []*agentmodel.AgentGroup{matchingGroup, nonMatchingGroup},
+			Items:              []*agentmodel.AgentGroup{matchingGroup, nonMatchingGroup, otherNamespaceGroup},
 			Continue:           "",
 			RemainingItemCount: 0,
 		}


### PR DESCRIPTION
## Summary
- Adds `GET /api/v1/namespaces/{namespace}/agents/{id}/agentgroups`, which returns the agent groups whose selector matches the given agent (i.e. the groups that *contain* that agent).
- Wires it through the application layer (`AgentGroupManageUsecase.ListAgentGroupsByAgent`) and the agentgroup HTTP controller, reusing the existing domain `GetAgentGroupsForAgent`.
- An agent in another namespace maps to `404` (consistent with the agent endpoints).

## Bugfix
`GetAgentGroupsForAgent` matched groups purely by selector, **across all namespaces** — a group in namespace `foo` would incorrectly apply its remote config to an agent in `default`. Matching is now scoped to the agent's own namespace. This also corrects group→agent remote-config propagation, not just the new read endpoint.

## Tests
- New controller tests for the endpoint (happy path, invalid UID → 400, cross-namespace agent → 404).
- Domain test updated to assert namespace scoping (a selector-matching group in another namespace is excluded).
- `make generate` re-ran for mocks + swagger.

## Follow-up
The `opampctl` command to query this endpoint ships in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)