### PR TITLE
feat(opampctl): add --agent flag to find agent groups containing an agent

### DIFF
--- a/pkg/client/agentgroup.go
+++ b/pkg/client/agentgroup.go
@@ -12,6 +12,8 @@ const (
 	ListAgentGroupURL = "/api/v1/namespaces/{namespace}/agentgroups"
 	// ListAgentsByAgentGroupURL is the path to list all agents in an agent group.
 	ListAgentsByAgentGroupURL = "/api/v1/namespaces/{namespace}/agentgroups/{name}/agents"
+	// ListAgentGroupsByAgentURL is the path to list all agent groups that contain an agent.
+	ListAgentGroupsByAgentURL = "/api/v1/namespaces/{namespace}/agents/{id}/agentgroups"
 	// GetAgentGroupURL is the path to get an agent group by namespace and name.
 	GetAgentGroupURL = "/api/v1/namespaces/{namespace}/agentgroups/{id}"
 	// CreateAgentGroupURL is the path to create a new agent group.
@@ -133,6 +135,35 @@ func (s *AgentGroupService) ListAgentsByAgentGroup(
 
 	if res.Result() == nil {
 		return nil, fmt.Errorf("failed to list resources: %w", ErrEmptyResponse)
+	}
+
+	return &listResponse, nil
+}
+
+// ListAgentGroupsByAgent lists the agent groups in the namespace whose selector matches
+// the agent identified by agentID.
+func (s *AgentGroupService) ListAgentGroupsByAgent(
+	ctx context.Context,
+	namespace string,
+	agentID string,
+) (*AgentGroupListResponse, error) {
+	var listResponse AgentGroupListResponse
+
+	res, err := s.service.Resty.R().
+		SetContext(ctx).
+		SetResult(&listResponse).
+		SetPathParam("namespace", namespace).
+		SetPathParam("id", agentID).
+		Get(ListAgentGroupsByAgentURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list agent groups by agent(restyError): %w", err)
+	}
+
+	if res.IsError() {
+		return nil, fmt.Errorf("failed to list agent groups by agent(responseError): %w", &ResponseError{
+			StatusCode:   res.StatusCode(),
+			ErrorMessage: res.String(),
+		})
 	}
 
 	return &listResponse, nil

--- a/pkg/cmd/opampctl/get/agentgroup/agentgroup.go
+++ b/pkg/cmd/opampctl/get/agentgroup/agentgroup.go
@@ -32,6 +32,7 @@ type CommandOptions struct {
 	includeDeleted bool
 	namespace      string
 	allNamespaces  bool
+	agent          string
 
 	// internal
 	client *client.Client
@@ -61,6 +62,8 @@ func NewCommand(options CommandOptions) *cobra.Command {
 	cmd.Flags().BoolVar(&options.includeDeleted, "include-deleted", false, "Include soft-deleted agent groups")
 	cmd.Flags().StringVarP(&options.namespace, "namespace", "n", "default", "Namespace of the agent group")
 	cmd.Flags().BoolVarP(&options.allNamespaces, "all-namespaces", "A", false, "List resources across all namespaces")
+	cmd.Flags().StringVar(&options.agent, "agent", "",
+		"List only the agent groups that contain the agent with this instance UID")
 
 	return cmd
 }
@@ -81,6 +84,15 @@ func (opt *CommandOptions) Prepare(*cobra.Command, []string) error {
 
 // Run runs the command.
 func (opt *CommandOptions) Run(cmd *cobra.Command, args []string) error {
+	if opt.agent != "" {
+		err := opt.ListByAgent(cmd)
+		if err != nil {
+			return fmt.Errorf("list by agent failed: %w", err)
+		}
+
+		return nil
+	}
+
 	if len(args) == 0 {
 		err := opt.List(cmd)
 		if err != nil {
@@ -125,6 +137,26 @@ func (opt *CommandOptions) List(cmd *cobra.Command) error {
 	}
 
 	err = formatter.Format(cmd.OutOrStdout(), displayedAgents, formatter.FormatType(opt.formatType))
+	if err != nil {
+		return fmt.Errorf("failed to format agentgroup: %w", err)
+	}
+
+	return nil
+}
+
+// ListByAgent retrieves the agent groups that contain the agent given by the --agent flag.
+func (opt *CommandOptions) ListByAgent(cmd *cobra.Command) error {
+	resp, err := opt.client.AgentGroupService.ListAgentGroupsByAgent(cmd.Context(), opt.namespace, opt.agent)
+	if err != nil {
+		return fmt.Errorf("failed to list agent groups for agent %q: %w", opt.agent, err)
+	}
+
+	displayedAgentGroups := make([]formattedAgentGroup, len(resp.Items))
+	for idx, agentgroup := range resp.Items {
+		displayedAgentGroups[idx] = opt.toFormattedAgentGroup(agentgroup)
+	}
+
+	err = formatter.Format(cmd.OutOrStdout(), displayedAgentGroups, formatter.FormatType(opt.formatType))
 	if err != nil {
 		return fmt.Errorf("failed to format agentgroup: %w", err)
 	}

--- a/pkg/cmd/opampctl/get/agentgroup/agentgroup.go
+++ b/pkg/cmd/opampctl/get/agentgroup/agentgroup.go
@@ -21,6 +21,9 @@ import (
 var (
 	// ErrCommandExecutionFailed is returned when the command execution fails.
 	ErrCommandExecutionFailed = errors.New("command execution failed")
+	// ErrAgentWithAllNamespaces is returned when --agent is combined with --all-namespaces.
+	// An agent is looked up within a single namespace, so the two flags are mutually exclusive.
+	ErrAgentWithAllNamespaces = errors.New("--agent cannot be combined with --all-namespaces")
 )
 
 // CommandOptions contains the options for the agent command.
@@ -85,6 +88,10 @@ func (opt *CommandOptions) Prepare(*cobra.Command, []string) error {
 // Run runs the command.
 func (opt *CommandOptions) Run(cmd *cobra.Command, args []string) error {
 	if opt.agent != "" {
+		if opt.allNamespaces {
+			return ErrAgentWithAllNamespaces
+		}
+
 		err := opt.ListByAgent(cmd)
 		if err != nil {
 			return fmt.Errorf("list by agent failed: %w", err)
@@ -148,7 +155,10 @@ func (opt *CommandOptions) List(cmd *cobra.Command) error {
 func (opt *CommandOptions) ListByAgent(cmd *cobra.Command) error {
 	resp, err := opt.client.AgentGroupService.ListAgentGroupsByAgent(cmd.Context(), opt.namespace, opt.agent)
 	if err != nil {
-		return fmt.Errorf("failed to list agent groups for agent %q: %w", opt.agent, err)
+		// The lookup is scoped to --namespace; surface it so a 404 caused by the agent
+		// living in another namespace is actionable (the fix is usually `-n <namespace>`).
+		return fmt.Errorf("failed to list agent groups for agent %q in namespace %q: %w",
+			opt.agent, opt.namespace, err)
 	}
 
 	displayedAgentGroups := make([]formattedAgentGroup, len(resp.Items))


### PR DESCRIPTION
## Summary
- Adds an `--agent <instanceUID>` flag to `opampctl get agentgroup`. With it set, the command lists the agent groups whose selector matches the given agent (the groups that *contain* it) instead of listing all groups:

  ```
  opampctl get agentgroup --agent <instanceUID> -n <namespace>
  ```

- Adds `AgentGroupService.ListAgentGroupsByAgent` to the client library, calling `GET /api/v1/namespaces/{namespace}/agents/{id}/agentgroups`.

## Depends on
The server endpoint added in #433. This PR is code-independent (the client talks HTTP), but the flag only returns results against a server that has #433 deployed.

## Notes
Output reuses the existing `formattedAgentGroup` renderer, so `-o short|text|json|yaml` all work as for the plain list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)