### PR TITLE
Potential fix for code scanning alert no. 8: DOM text reinterpreted as HTML

### DIFF
--- a/docs/assets/js/offline-search.js
+++ b/docs/assets/js/offline-search.js
@@ -148,7 +148,11 @@
           $('<div>')
             .addClass('text-center py-4')
             .append(
-              $('<p>').addClass('mb-2').html(`<strong>No results found for "${searchQuery}"</strong>`)
+              $('<p>')
+                .addClass('mb-2')
+                .append(
+                  $('<strong>').text(`No results found for "${searchQuery}"`)
+                )
             )
             .append(
               $('<small>').addClass('text-muted').text('Try using different keywords or check spelling')


### PR DESCRIPTION
Potential fix for [https://github.com/minuk-dev/opampcommander/security/code-scanning/8](https://github.com/minuk-dev/opampcommander/security/code-scanning/8)

Use DOM-safe APIs so untrusted text is inserted as text, not HTML.

Best fix (without changing functionality): replace the `.html(\`<strong>...\</strong>\`)` construction with explicit element creation:
- Create a `<p>` as before.
- Append a `<strong>` child.
- Set the strong element’s content with `.text(...)`, including `searchQuery`.

This preserves visual formatting (`<strong>`) and message content while removing HTML parsing of `searchQuery`.

Change needed in:
- `docs/assets/js/offline-search.js` around line 151 (the “no results” branch).

No new imports or external dependencies are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
