### PR TITLE
Potential fix for code scanning alert no. 22: Database query built from user-controlled sources

### DIFF
--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/role.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/role.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/google/uuid"
 	"go.mongodb.org/mongo-driver/v2/bson"
@@ -68,6 +69,11 @@ func (a *RoleMongoAdapter) GetRole(
 func (a *RoleMongoAdapter) GetRoleByName(
 	ctx context.Context, displayName string,
 ) (*usermodel.Role, error) {
+	displayName = strings.TrimSpace(displayName)
+	if displayName == "" || strings.HasPrefix(displayName, "$") {
+		return nil, fmt.Errorf("get role by name: invalid display name")
+	}
+
 	filter := bson.M{
 		"spec.displayName":   displayName,
 		"metadata.deletedAt": nil,

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/role.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/role.go
@@ -24,6 +24,9 @@ const (
 	roleCollectionName = "roles"
 )
 
+// errInvalidDisplayName is returned when a role display name is empty or malformed.
+var errInvalidDisplayName = errors.New("invalid display name")
+
 // RoleMongoAdapter is a struct that implements the RolePersistencePort interface.
 type RoleMongoAdapter struct {
 	common commonEntityAdapter[entity.Role, string]
@@ -71,7 +74,7 @@ func (a *RoleMongoAdapter) GetRoleByName(
 ) (*usermodel.Role, error) {
 	displayName = strings.TrimSpace(displayName)
 	if displayName == "" || strings.HasPrefix(displayName, "$") {
-		return nil, fmt.Errorf("get role by name: invalid display name")
+		return nil, fmt.Errorf("get role by name: %w", errInvalidDisplayName)
 	}
 
 	filter := bson.M{


### PR DESCRIPTION
Potential fix for [https://github.com/minuk-dev/opampcommander/security/code-scanning/22](https://github.com/minuk-dev/opampcommander/security/code-scanning/22)

To fix this safely without changing existing functionality, validate `displayName` in `GetRoleByName` before constructing the Mongo filter. Reject empty/whitespace-only values and disallow Mongo operator-like prefixes (e.g., `$`) as a defense-in-depth rule for query-bound user input.

Best single-place fix:
- **File:** `pkg/apiserver/adapter/secondary/persistence/mongodb/role.go`
- **Region:** `GetRoleByName` method
- Add:
  - `strings` import.
  - normalization/validation logic (`strings.TrimSpace`, prefix check) before `filter := bson.M{...}`.
- Return a regular error on invalid input (`fmt.Errorf("get role by name: invalid display name")`), preserving existing error style and avoiding broader API changes.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
