### PR TITLE
feat(opampctl): add endpoint create/get/delete commands

### DIFF
--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -24,6 +24,7 @@ type Client struct {
 	AgentGroupService        *AgentGroupService
 	AgentPackageService      *AgentPackageService
 	AgentRemoteConfigService *AgentRemoteConfigService
+	EndpointService          *EndpointService
 	CertificateService       *CertificateService
 	ConnectionService        *ConnectionService
 	AuthService              *AuthService
@@ -53,6 +54,7 @@ func New(endpoint string, opt ...Option) *Client {
 		AgentGroupService:        nil,
 		AgentPackageService:      nil,
 		AgentRemoteConfigService: nil,
+		EndpointService:          nil,
 		CertificateService:       nil,
 		ConnectionService:        nil,
 		AuthService:              nil,
@@ -74,6 +76,7 @@ func New(endpoint string, opt ...Option) *Client {
 	client.AgentGroupService = NewAgentGroupService(&service)
 	client.AgentPackageService = NewAgentPackageService(&service)
 	client.AgentRemoteConfigService = NewAgentRemoteConfigService(&service)
+	client.EndpointService = NewEndpointService(&service)
 	client.CertificateService = NewCertificateService(&service)
 	client.NamespaceService = NewNamespaceService(&service)
 	client.HostService = NewHostService(&service)

--- a/pkg/client/endpoint.go
+++ b/pkg/client/endpoint.go
@@ -1,0 +1,192 @@
+//nolint:dupl // Similar structure to other resource services is intentional
+package client
+
+import (
+	"context"
+	"fmt"
+
+	v1 "github.com/minuk-dev/opampcommander/api/v1"
+)
+
+const (
+	// ListEndpointURL is the path to list all endpoints.
+	ListEndpointURL = "/api/v1/namespaces/{namespace}/endpoints"
+	// GetEndpointURL is the path to get an endpoint by name.
+	GetEndpointURL = "/api/v1/namespaces/{namespace}/endpoints/{id}"
+	// CreateEndpointURL is the path to create a new endpoint.
+	CreateEndpointURL = "/api/v1/namespaces/{namespace}/endpoints"
+	// UpdateEndpointURL is the path to update an existing endpoint.
+	UpdateEndpointURL = "/api/v1/namespaces/{namespace}/endpoints/{id}"
+	// DeleteEndpointURL is the path to delete an endpoint.
+	DeleteEndpointURL = "/api/v1/namespaces/{namespace}/endpoints/{id}"
+)
+
+// EndpointService provides methods to interact with endpoints.
+type EndpointService struct {
+	service *service
+}
+
+// NewEndpointService creates a new EndpointService.
+func NewEndpointService(service *service) *EndpointService {
+	return &EndpointService{
+		service: service,
+	}
+}
+
+// GetEndpoint retrieves an endpoint by its namespace and name.
+func (s *EndpointService) GetEndpoint(
+	ctx context.Context,
+	namespace string,
+	name string,
+	opts ...GetOption,
+) (*v1.Endpoint, error) {
+	getSettings := newGetSettings(opts)
+
+	var endpoint v1.Endpoint
+
+	req := s.service.Resty.R().
+		SetContext(ctx).
+		SetResult(&endpoint).
+		SetPathParam("namespace", namespace).
+		SetPathParam("id", name)
+	getSettings.applyTo(req)
+
+	res, err := req.Get(GetEndpointURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get endpoint(restyError): %w", err)
+	}
+
+	if res.IsError() {
+		return nil, fmt.Errorf("failed to get endpoint(responseError): %w",
+			&ResponseError{
+				StatusCode:   res.StatusCode(),
+				ErrorMessage: res.String(),
+			},
+		)
+	}
+
+	return &endpoint, nil
+}
+
+// EndpointListResponse represents a list of endpoints with metadata.
+type EndpointListResponse = v1.ListResponse[v1.Endpoint]
+
+// ListEndpoints lists all endpoints in a namespace.
+func (s *EndpointService) ListEndpoints(
+	ctx context.Context,
+	namespace string,
+	opts ...ListOption,
+) (*EndpointListResponse, error) {
+	listSettings := newListSettings(opts)
+
+	var listResponse EndpointListResponse
+
+	req := s.service.Resty.R().
+		SetContext(ctx).
+		SetResult(&listResponse).
+		SetPathParam("namespace", namespace)
+	listSettings.applyTo(req)
+
+	res, err := req.Get(ListEndpointURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list endpoints(restyError): %w", err)
+	}
+
+	if res.IsError() {
+		return nil, fmt.Errorf("failed to list endpoints(responseError): %w",
+			&ResponseError{
+				StatusCode:   res.StatusCode(),
+				ErrorMessage: res.String(),
+			},
+		)
+	}
+
+	return &listResponse, nil
+}
+
+// CreateEndpoint creates a new endpoint.
+func (s *EndpointService) CreateEndpoint(
+	ctx context.Context,
+	namespace string,
+	createRequest *v1.Endpoint,
+) (*v1.Endpoint, error) {
+	var result v1.Endpoint
+
+	res, err := s.service.Resty.R().
+		SetContext(ctx).
+		SetPathParam("namespace", namespace).
+		SetBody(createRequest).
+		SetResult(&result).
+		Post(CreateEndpointURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create endpoint(restyError): %w", err)
+	}
+
+	if res.IsError() {
+		return nil, fmt.Errorf("failed to create endpoint(responseError): %w",
+			&ResponseError{
+				StatusCode:   res.StatusCode(),
+				ErrorMessage: res.String(),
+			},
+		)
+	}
+
+	return &result, nil
+}
+
+// UpdateEndpoint updates an existing endpoint.
+func (s *EndpointService) UpdateEndpoint(
+	ctx context.Context,
+	updateRequest *v1.Endpoint,
+) (*v1.Endpoint, error) {
+	var result v1.Endpoint
+
+	res, err := s.service.Resty.R().
+		SetContext(ctx).
+		SetPathParam("namespace", updateRequest.Metadata.Namespace).
+		SetPathParam("id", updateRequest.Metadata.Name).
+		SetBody(updateRequest).
+		SetResult(&result).
+		Put(UpdateEndpointURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update endpoint(restyError): %w", err)
+	}
+
+	if res.IsError() {
+		return nil, fmt.Errorf("failed to update endpoint(responseError): %w",
+			&ResponseError{
+				StatusCode:   res.StatusCode(),
+				ErrorMessage: res.String(),
+			},
+		)
+	}
+
+	return &result, nil
+}
+
+// DeleteEndpoint deletes an endpoint by namespace and name.
+func (s *EndpointService) DeleteEndpoint(
+	ctx context.Context,
+	namespace string,
+	name string,
+) error {
+	res, err := s.service.Resty.R().
+		SetContext(ctx).
+		SetPathParam("namespace", namespace).
+		SetPathParam("id", name).
+		Delete(DeleteEndpointURL)
+	if err != nil {
+		return fmt.Errorf("failed to delete endpoint(restyError): %w", err)
+	}
+
+	if res.IsError() {
+		return fmt.Errorf("failed to delete endpoint(responseError): %w",
+			&ResponseError{
+				StatusCode:   res.StatusCode(),
+				ErrorMessage: res.String(),
+			},
+		)
+	}
+
+	return nil
+}

--- a/pkg/clientutil/list.go
+++ b/pkg/clientutil/list.go
@@ -229,6 +229,42 @@ func ListAgentRemoteConfigFully(
 	}
 }
 
+// ListEndpointFully lists all endpoints in a namespace.
+// It continues to fetch endpoints until there are no more to fetch.
+func ListEndpointFully(
+	ctx context.Context,
+	cli *client.Client,
+	namespace string,
+	opts ...client.ListOption,
+) ([]v1.Endpoint, error) {
+	var endpoints []v1.Endpoint
+	// Initialize the continue token to an empty string
+	continueToken := ""
+
+	for {
+		// Build options for each request
+		requestOpts := append([]client.ListOption{
+			client.WithContinueToken(continueToken),
+			client.WithLimit(ChunkSize),
+		}, opts...)
+
+		// List endpoints with the current continue token
+		resp, err := cli.EndpointService.ListEndpoints(ctx, namespace, requestOpts...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to list endpoints: %w", err)
+		}
+
+		// Iterate over each endpoint in the response
+		if len(resp.Items) == 0 {
+			return endpoints, nil // No endpoints found, exit the loop
+		}
+
+		endpoints = append(endpoints, resp.Items...)
+
+		continueToken = resp.Metadata.Continue // Update the continue token for the next iteration
+	}
+}
+
 // ListCertificateFully lists all certificates in a namespace.
 // It continues to fetch certificates until there are no more to fetch.
 func ListCertificateFully(

--- a/pkg/cmd/opampctl/create/create.go
+++ b/pkg/cmd/opampctl/create/create.go
@@ -8,6 +8,7 @@ import (
 	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/create/agentpackage"
 	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/create/agentremoteconfig"
 	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/create/certificate"
+	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/create/endpoint"
 	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/create/namespace"
 	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/create/role"
 	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/create/rolebinding"
@@ -39,6 +40,9 @@ func NewCommand(options CommandOptions) *cobra.Command {
 		GlobalConfig: options.GlobalConfig,
 	}))
 	cmd.AddCommand(certificate.NewCommand(certificate.CommandOptions{
+		GlobalConfig: options.GlobalConfig,
+	}))
+	cmd.AddCommand(endpoint.NewCommand(endpoint.CommandOptions{
 		GlobalConfig: options.GlobalConfig,
 	}))
 	cmd.AddCommand(namespace.NewCommand(namespace.CommandOptions{

--- a/pkg/cmd/opampctl/create/endpoint/endpoint.go
+++ b/pkg/cmd/opampctl/create/endpoint/endpoint.go
@@ -1,0 +1,186 @@
+// Package endpoint provides the create endpoint command for opampctl.
+package endpoint
+
+import (
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	v1 "github.com/minuk-dev/opampcommander/api/v1"
+	"github.com/minuk-dev/opampcommander/pkg/client"
+	"github.com/minuk-dev/opampcommander/pkg/clientutil"
+	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/create/internal/yamlfile"
+	"github.com/minuk-dev/opampcommander/pkg/formatter"
+	"github.com/minuk-dev/opampcommander/pkg/opampctl/config"
+)
+
+// ErrNameRequired is returned when --name is missing and --file is not used.
+var ErrNameRequired = errors.New("--name is required (or use --file)")
+
+// CommandOptions contains the options for the create endpoint command.
+type CommandOptions struct {
+	*config.GlobalConfig
+
+	// Flags
+	name       string
+	namespace  string
+	attributes map[string]string
+	url        string
+	protocol   string
+	metrics    bool
+	logs       bool
+	traces     bool
+	file       string
+	formatType string
+
+	// internal state
+	client *client.Client
+}
+
+// NewCommand creates a new create endpoint command.
+func NewCommand(options CommandOptions) *cobra.Command {
+	//exhaustruct:ignore
+	cmd := &cobra.Command{
+		Use:   "endpoint",
+		Short: "create endpoint",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := options.Prepare(cmd, args)
+			if err != nil {
+				return err
+			}
+
+			err = options.Run(cmd, args)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVar(&options.name, "name", "", "Name of the endpoint (required unless --file is used)")
+	cmd.Flags().StringVarP(&options.namespace, "namespace", "n", "default", "Namespace")
+	cmd.Flags().StringToStringVar(&options.attributes, "attributes", nil, "Attributes of the endpoint (key=value)")
+	cmd.Flags().StringVar(&options.url, "url", "", "Destination URL of the telemetry backend")
+	cmd.Flags().StringVar(&options.protocol, "protocol", "",
+		"Export protocol (e.g. otlp, otlphttp, prometheusremotewrite)")
+	cmd.Flags().BoolVar(&options.metrics, "metrics", false, "Endpoint supports the metrics signal")
+	cmd.Flags().BoolVar(&options.logs, "logs", false, "Endpoint supports the logs signal")
+	cmd.Flags().BoolVar(&options.traces, "traces", false, "Endpoint supports the traces signal")
+	cmd.Flags().StringVarP(&options.file, "file", "f", "",
+		"Path to an endpoint YAML/JSON definition (use for multi-tenant endpoints)")
+	cmd.Flags().StringVarP(&options.formatType, "output", "o", "text", "Output format (text, json, yaml)")
+
+	return cmd
+}
+
+// Prepare prepares the create endpoint command.
+func (opt *CommandOptions) Prepare(*cobra.Command, []string) error {
+	client, err := clientutil.NewClient(opt.GlobalConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create authenticated client: %w", err)
+	}
+
+	opt.client = client
+
+	return nil
+}
+
+// Run executes the create endpoint command.
+func (opt *CommandOptions) Run(cmd *cobra.Command, _ []string) error {
+	createRequest, namespace, err := opt.buildRequest()
+	if err != nil {
+		return err
+	}
+
+	endpoint, err := opt.client.EndpointService.CreateEndpoint(cmd.Context(), namespace, createRequest)
+	if err != nil {
+		return fmt.Errorf("failed to create endpoint: %w", err)
+	}
+
+	err = formatter.Format(cmd.OutOrStdout(), toFormattedEndpoint(endpoint), formatter.FormatType(opt.formatType))
+	if err != nil {
+		return fmt.Errorf("failed to format output: %w", err)
+	}
+
+	return nil
+}
+
+func (opt *CommandOptions) buildRequest() (*v1.Endpoint, string, error) {
+	if opt.file != "" {
+		//exhaustruct:ignore
+		req := &v1.Endpoint{}
+
+		err := yamlfile.Load(opt.file, req)
+		if err != nil {
+			return nil, "", fmt.Errorf("load endpoint from %s: %w", opt.file, err)
+		}
+
+		namespace := req.Metadata.Namespace
+		if namespace == "" {
+			namespace = opt.namespace
+		}
+
+		return req, namespace, nil
+	}
+
+	if opt.name == "" {
+		return nil, "", ErrNameRequired
+	}
+
+	//exhaustruct:ignore
+	return &v1.Endpoint{
+		Metadata: v1.EndpointMetadata{
+			Name:       opt.name,
+			Namespace:  opt.namespace,
+			Attributes: opt.attributes,
+		},
+		Spec: v1.EndpointSpec{
+			URL:      opt.url,
+			Protocol: opt.protocol,
+			Signals: v1.EndpointSignals{
+				Metrics: opt.metrics,
+				Logs:    opt.logs,
+				Traces:  opt.traces,
+			},
+		},
+	}, opt.namespace, nil
+}
+
+type formattedEndpoint struct {
+	Name       string            `json:"name"       short:"name"      text:"name"      yaml:"name"`
+	Attributes map[string]string `json:"attributes" short:"-"         text:"-"         yaml:"attributes"`
+	URL        string            `json:"url"        short:"url"       text:"url"       yaml:"url"`
+	Protocol   string            `json:"protocol"   short:"protocol"  text:"protocol"  yaml:"protocol"`
+	CreatedAt  time.Time         `json:"createdAt"  short:"createdAt" text:"createdAt" yaml:"createdAt"`
+	CreatedBy  string            `json:"createdBy"  short:"createdBy" text:"createdBy" yaml:"createdBy"`
+}
+
+func toFormattedEndpoint(endpoint *v1.Endpoint) *formattedEndpoint {
+	var (
+		createdAt time.Time
+		createdBy string
+	)
+
+	for _, condition := range endpoint.Status.Conditions {
+		if condition.Type == v1.ConditionTypeCreated && condition.Status == v1.ConditionStatusTrue {
+			createdAt = condition.LastTransitionTime.Time
+			createdBy = condition.Reason
+		}
+	}
+
+	if createdAt.IsZero() {
+		createdAt = endpoint.Metadata.CreatedAt.Time
+	}
+
+	return &formattedEndpoint{
+		Name:       endpoint.Metadata.Name,
+		Attributes: endpoint.Metadata.Attributes,
+		URL:        endpoint.Spec.URL,
+		Protocol:   endpoint.Spec.Protocol,
+		CreatedAt:  createdAt,
+		CreatedBy:  createdBy,
+	}
+}

--- a/pkg/cmd/opampctl/deletecmd/delete.go
+++ b/pkg/cmd/opampctl/deletecmd/delete.go
@@ -10,6 +10,7 @@ import (
 	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/deletecmd/agentpackage"
 	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/deletecmd/agentremoteconfig"
 	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/deletecmd/certificate"
+	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/deletecmd/endpoint"
 	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/deletecmd/namespace"
 	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/deletecmd/role"
 	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/deletecmd/rolebinding"
@@ -43,6 +44,9 @@ func NewCommand(options CommandOptions) *cobra.Command {
 		GlobalConfig: options.GlobalConfig,
 	}))
 	cmd.AddCommand(certificate.NewCommand(certificate.CommandOptions{
+		GlobalConfig: options.GlobalConfig,
+	}))
+	cmd.AddCommand(endpoint.NewCommand(endpoint.CommandOptions{
 		GlobalConfig: options.GlobalConfig,
 	}))
 	cmd.AddCommand(namespace.NewCommand(namespace.CommandOptions{

--- a/pkg/cmd/opampctl/deletecmd/endpoint/endpoint.go
+++ b/pkg/cmd/opampctl/deletecmd/endpoint/endpoint.go
@@ -1,0 +1,146 @@
+// Package endpoint implements the 'opampctl delete endpoint' command.
+package endpoint
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/samber/lo"
+	"github.com/spf13/cobra"
+
+	v1 "github.com/minuk-dev/opampcommander/api/v1"
+	"github.com/minuk-dev/opampcommander/pkg/client"
+	"github.com/minuk-dev/opampcommander/pkg/clientutil"
+	"github.com/minuk-dev/opampcommander/pkg/opampctl/config"
+)
+
+const (
+	// MinToComplete is the minimum number of characters to start completing.
+	MinToComplete = 3
+)
+
+// ErrEndpointNameRequired is returned when the target endpoint name is not provided.
+var ErrEndpointNameRequired = errors.New("endpoint name is required")
+
+// CommandOptions contains the options for the 'opampctl delete endpoint' command.
+type CommandOptions struct {
+	*config.GlobalConfig
+
+	// flags
+	namespace string
+
+	// internal
+	client *client.Client
+}
+
+// NewCommand creates a new 'opampctl delete endpoint' command.
+func NewCommand(options CommandOptions) *cobra.Command {
+	//exhaustruct:ignore
+	cmd := &cobra.Command{
+		Use:               "endpoint",
+		Short:             "delete endpoint",
+		ValidArgsFunction: options.ValidArgsFunction,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := options.Prepare(cmd, args)
+			if err != nil {
+				return err
+			}
+
+			err = options.Run(cmd, args)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+
+	cmd.Flags().StringVarP(
+		&options.namespace, "namespace", "n", "default", "Namespace",
+	)
+
+	return cmd
+}
+
+// Prepare prepares the internal state before running the command.
+func (o *CommandOptions) Prepare(_ *cobra.Command, args []string) error {
+	if len(args) < 1 {
+		return ErrEndpointNameRequired
+	}
+
+	client, err := clientutil.NewClient(o.GlobalConfig)
+	if err != nil {
+		return fmt.Errorf("failed to create authenticated client: %w", err)
+	}
+
+	o.client = client
+
+	return nil
+}
+
+// Run runs the command.
+func (o *CommandOptions) Run(cmd *cobra.Command, names []string) error {
+	type deleteResult struct {
+		name string
+		err  error
+	}
+
+	results := lo.Map(names, func(name string, _ int) deleteResult {
+		return deleteResult{
+			name: name,
+			err: o.client.EndpointService.DeleteEndpoint(
+				cmd.Context(), o.namespace, name,
+			),
+		}
+	})
+
+	successfullyDeleted := lo.FilterMap(results, func(r deleteResult, _ int) (string, bool) {
+		return r.name, r.err == nil
+	})
+	failedToDelete := lo.FilterMap(results, func(r deleteResult, _ int) (string, bool) {
+		return r.name, r.err != nil
+	})
+
+	cmd.Printf("Successfully deleted %d endpoint(s): %s\n",
+		len(successfullyDeleted), strings.Join(successfullyDeleted, ", "))
+
+	if len(failedToDelete) > 0 {
+		cmd.PrintErrf("Failed to delete %d endpoint(s): %s\n",
+			len(failedToDelete), strings.Join(failedToDelete, ", "))
+	}
+
+	return nil
+}
+
+// ValidArgsFunction provides dynamic completion for endpoint names.
+func (o *CommandOptions) ValidArgsFunction(
+	cmd *cobra.Command, _ []string, toComplete string,
+) ([]string, cobra.ShellCompDirective) {
+	// unfortunately, we don't use o.client because this function is called without Prepare.
+	client, err := clientutil.NewClient(o.GlobalConfig)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	if len(toComplete) < MinToComplete {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+
+	endpoints, err := clientutil.ListEndpointFully(
+		cmd.Context(), client, o.namespace,
+	)
+	if err != nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+
+	matched := lo.Filter(endpoints, func(e v1.Endpoint, _ int) bool {
+		return strings.Contains(strings.ToLower(e.Metadata.Name), strings.ToLower(toComplete))
+	})
+
+	names := lo.Map(matched, func(e v1.Endpoint, _ int) string {
+		return e.Metadata.Name
+	})
+
+	return names, cobra.ShellCompDirectiveNoFileComp
+}

--- a/pkg/cmd/opampctl/get/endpoint/endpoint.go
+++ b/pkg/cmd/opampctl/get/endpoint/endpoint.go
@@ -1,0 +1,290 @@
+// Package endpoint implements the 'opampctl get endpoint' command.
+package endpoint
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/samber/lo"
+	"github.com/spf13/cobra"
+
+	v1 "github.com/minuk-dev/opampcommander/api/v1"
+	"github.com/minuk-dev/opampcommander/pkg/client"
+	"github.com/minuk-dev/opampcommander/pkg/clientutil"
+	"github.com/minuk-dev/opampcommander/pkg/formatter"
+	"github.com/minuk-dev/opampcommander/pkg/opampctl/config"
+)
+
+var (
+	// ErrCommandExecutionFailed is returned when the command execution fails.
+	ErrCommandExecutionFailed = errors.New("command execution failed")
+)
+
+// CommandOptions contains the options for the endpoint command.
+type CommandOptions struct {
+	*config.GlobalConfig
+
+	// flags
+	formatType     string
+	includeDeleted bool
+	namespace      string
+	allNamespaces  bool
+
+	// internal
+	client *client.Client
+}
+
+// NewCommand creates a new endpoint command.
+func NewCommand(options CommandOptions) *cobra.Command {
+	//exhaustruct:ignore
+	cmd := &cobra.Command{
+		Use:   "endpoint",
+		Short: "endpoint",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			err := options.Prepare(cmd, args)
+			if err != nil {
+				return err
+			}
+
+			err = options.Run(cmd, args)
+			if err != nil {
+				return err
+			}
+
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&options.formatType, "output", "o", "short", "Output format (short, text, json, yaml)")
+	cmd.Flags().BoolVar(&options.includeDeleted, "include-deleted", false, "Include soft-deleted endpoints")
+	cmd.Flags().StringVarP(&options.namespace, "namespace", "n", "default", "Namespace")
+	cmd.Flags().BoolVarP(&options.allNamespaces, "all-namespaces", "A", false, "List resources across all namespaces")
+
+	return cmd
+}
+
+// Prepare prepares the command to run.
+func (opt *CommandOptions) Prepare(*cobra.Command, []string) error {
+	config := opt.GlobalConfig
+
+	client, err := clientutil.NewClient(config)
+	if err != nil {
+		return fmt.Errorf("failed to create authenticated client: %w", err)
+	}
+
+	opt.client = client
+
+	return nil
+}
+
+// Run runs the command.
+func (opt *CommandOptions) Run(cmd *cobra.Command, args []string) error {
+	if len(args) == 0 {
+		err := opt.List(cmd)
+		if err != nil {
+			return fmt.Errorf("list failed: %w", err)
+		}
+
+		return nil
+	}
+
+	names := args
+
+	err := opt.Get(cmd, names)
+	if err != nil {
+		return fmt.Errorf("get failed: %w", err)
+	}
+
+	return nil
+}
+
+// List retrieves the list of endpoints.
+func (opt *CommandOptions) List(cmd *cobra.Command) error {
+	listOpts := []client.ListOption{client.WithIncludeDeleted(opt.includeDeleted)}
+
+	var (
+		endpoints []v1.Endpoint
+		err       error
+	)
+
+	if opt.allNamespaces {
+		endpoints, err = opt.listAllNamespaces(cmd, listOpts...)
+	} else {
+		endpoints, err = clientutil.ListEndpointFully(
+			cmd.Context(), opt.client, opt.namespace, listOpts...,
+		)
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to list endpoints: %w", err)
+	}
+
+	displayed := make([]formattedEndpoint, len(endpoints))
+	for idx, endpoint := range endpoints {
+		displayed[idx] = toFormattedEndpoint(endpoint)
+	}
+
+	err = formatter.Format(cmd.OutOrStdout(), displayed, formatter.FormatType(opt.formatType))
+	if err != nil {
+		return fmt.Errorf("failed to format endpoint: %w", err)
+	}
+
+	return nil
+}
+
+// Get retrieves the endpoint information for the given names.
+func (opt *CommandOptions) Get(cmd *cobra.Command, names []string) error {
+	type endpointWithErr struct {
+		Endpoint *v1.Endpoint
+		Err      error
+	}
+
+	getOpts := []client.GetOption{client.WithGetIncludeDeleted(opt.includeDeleted)}
+
+	endpointsWithErr := lo.Map(names, func(name string, _ int) endpointWithErr {
+		endpoint, err := opt.client.EndpointService.GetEndpoint(
+			cmd.Context(), opt.namespace, name, getOpts...)
+
+		return endpointWithErr{
+			Endpoint: endpoint,
+			Err:      err,
+		}
+	})
+
+	endpoints := lo.Filter(endpointsWithErr, func(e endpointWithErr, _ int) bool {
+		return e.Err == nil
+	})
+	if len(endpoints) == 0 {
+		cmd.Println("No endpoints found or all specified endpoints could not be retrieved.")
+
+		return nil
+	}
+
+	displayed := lo.Map(endpoints, func(e endpointWithErr, _ int) formattedEndpoint {
+		return toFormattedEndpoint(*e.Endpoint)
+	})
+
+	err := formatter.Format(cmd.OutOrStdout(), displayed, formatter.FormatType(opt.formatType))
+	if err != nil {
+		return fmt.Errorf("failed to format endpoints: %w", err)
+	}
+
+	errs := lo.Filter(endpointsWithErr, func(e endpointWithErr, _ int) bool {
+		return e.Err != nil
+	})
+	if len(errs) > 0 {
+		errMessages := lo.Map(errs, func(e endpointWithErr, _ int) string {
+			return e.Err.Error()
+		})
+
+		cmd.PrintErrf("Some endpoints could not be retrieved: %s", strings.Join(errMessages, ", "))
+	}
+
+	return nil
+}
+
+func (opt *CommandOptions) listAllNamespaces(
+	cmd *cobra.Command, listOpts ...client.ListOption,
+) ([]v1.Endpoint, error) {
+	endpoints, err := clientutil.ListAcrossNamespaces(
+		cmd.Context(), opt.client,
+		func(ctx context.Context, namespace string) ([]v1.Endpoint, error) {
+			return clientutil.ListEndpointFully(ctx, opt.client, namespace, listOpts...)
+		},
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list endpoints across all namespaces: %w", err)
+	}
+
+	return endpoints, nil
+}
+
+//nolint:lll
+type formattedEndpoint struct {
+	Namespace  string            `json:"namespace"           short:"namespace" text:"namespace"           yaml:"namespace"`
+	Name       string            `json:"name"                short:"name"      text:"name"                yaml:"name"`
+	URL        string            `json:"url"                 short:"url"       text:"url"                 yaml:"url"`
+	Protocol   string            `json:"protocol"            short:"protocol"  text:"protocol"            yaml:"protocol"`
+	Signals    string            `json:"signals"             short:"signals"   text:"signals"             yaml:"signals"`
+	Tenants    int               `json:"tenants"             short:"tenants"   text:"tenants"             yaml:"tenants"`
+	Attributes map[string]string `json:"attributes"          short:"-"         text:"-"                   yaml:"attributes"`
+	CreatedAt  time.Time         `json:"createdAt"           short:"createdAt" text:"createdAt"           yaml:"createdAt"`
+	CreatedBy  string            `json:"createdBy"           short:"createdBy" text:"createdBy"           yaml:"createdBy"`
+	DeletedAt  *time.Time        `json:"deletedAt,omitempty" short:"-"         text:"deletedAt,omitempty" yaml:"deletedAt,omitempty"`
+	DeletedBy  *string           `json:"deletedBy,omitempty" short:"-"         text:"deletedBy,omitempty" yaml:"deletedBy,omitempty"`
+}
+
+func extractConditionInfo(conditions []v1.Condition) (time.Time, string, *time.Time, *string) {
+	var (
+		createdAt time.Time
+		createdBy string
+		deletedAt *time.Time
+		deletedBy *string
+	)
+
+	for _, condition := range conditions {
+		switch condition.Type { //nolint:exhaustive // Only handle Created and Deleted conditions
+		case v1.ConditionTypeCreated:
+			if condition.Status == v1.ConditionStatusTrue {
+				createdAt = condition.LastTransitionTime.Time
+				createdBy = condition.Reason
+			}
+		case v1.ConditionTypeDeleted:
+			if condition.Status == v1.ConditionStatusTrue {
+				t := condition.LastTransitionTime.Time
+				deletedAt = &t
+				deletedBy = &condition.Reason
+			}
+		}
+	}
+
+	return createdAt, createdBy, deletedAt, deletedBy
+}
+
+// signalsString renders the supported signals as a compact, stable string such
+// as "metrics,traces"; it returns "-" when no signal is supported.
+func signalsString(signals v1.EndpointSignals) string {
+	enabled := make([]string, 0)
+	if signals.Metrics {
+		enabled = append(enabled, "metrics")
+	}
+
+	if signals.Logs {
+		enabled = append(enabled, "logs")
+	}
+
+	if signals.Traces {
+		enabled = append(enabled, "traces")
+	}
+
+	if len(enabled) == 0 {
+		return "-"
+	}
+
+	return strings.Join(enabled, ",")
+}
+
+func toFormattedEndpoint(endpoint v1.Endpoint) formattedEndpoint {
+	createdAt := endpoint.Metadata.CreatedAt.Time
+
+	condCreatedAt, createdBy, deletedAt, deletedBy := extractConditionInfo(endpoint.Status.Conditions)
+	if createdAt.IsZero() {
+		createdAt = condCreatedAt
+	}
+
+	return formattedEndpoint{
+		Namespace:  endpoint.Metadata.Namespace,
+		Name:       endpoint.Metadata.Name,
+		URL:        endpoint.Spec.URL,
+		Protocol:   endpoint.Spec.Protocol,
+		Signals:    signalsString(endpoint.Spec.Signals),
+		Tenants:    len(endpoint.Spec.Tenants),
+		Attributes: endpoint.Metadata.Attributes,
+		CreatedAt:  createdAt,
+		CreatedBy:  createdBy,
+		DeletedAt:  deletedAt,
+		DeletedBy:  deletedBy,
+	}
+}

--- a/pkg/cmd/opampctl/get/get.go
+++ b/pkg/cmd/opampctl/get/get.go
@@ -11,6 +11,7 @@ import (
 	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/get/certificate"
 	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/get/connection"
 	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/get/container"
+	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/get/endpoint"
 	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/get/host"
 	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/get/namespace"
 	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/get/role"
@@ -45,6 +46,9 @@ func NewCommand(options CommandOptions) *cobra.Command {
 		GlobalConfig: options.GlobalConfig,
 	}))
 	cmd.AddCommand(agentremoteconfig.NewCommand(agentremoteconfig.CommandOptions{
+		GlobalConfig: options.GlobalConfig,
+	}))
+	cmd.AddCommand(endpoint.NewCommand(endpoint.CommandOptions{
 		GlobalConfig: options.GlobalConfig,
 	}))
 	cmd.AddCommand(certificate.NewCommand(certificate.CommandOptions{


### PR DESCRIPTION
## What

Adds `opampctl` commands and a client-library service for the **Endpoint** resource (added in #435).

### Commands (mirror the agentremoteconfig set)
- `opampctl get endpoint [names...]` — list (namespace-scoped; `-A` for all namespaces) or get by name. Short output shows `url`, `protocol`, `signals` (e.g. `metrics,traces`), and tenant count.
- `opampctl create endpoint` — scalar flags for the common case (`--url`, `--protocol`, `--metrics`, `--logs`, `--traces`, `--attributes`), or `-f <file>` to apply a full YAML/JSON `Endpoint` (multi-tenant endpoints with per-tenant headers/tags).
- `opampctl delete endpoint <names...>` — with dynamic name completion.

### Library
- `pkg/client/endpoint.go`: `EndpointService` (Get/List/Create/Update/Delete) wired into `client.Client`.
- `pkg/clientutil`: `ListEndpointFully` pagination helper.

## Notes
- Originally developed as a stacked PR on top of #435; #435 has since merged to `main`, so this now targets `main` directly.

## Testing
- `go build ./...`, `make lint` (0 issues).
- Manual end-to-end against a local standalone apiserver (in-memory, basic auth):
  - `create endpoint` via flags and via `-f` (multi-tenant) → both 201.
  - `get endpoint` list shows signals + tenant count; `get <name> -o yaml` round-trips.
  - `delete endpoint a b` → both deleted; subsequent list empty.

🤖 Generated with [Claude Code](https://claude.com/claude-code)