### PR TITLE
feat(web): add Endpoints management page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@ docs/public
 coverage.txt
 coverage.out
 .claude
+
+# macOS
+.DS_Store

--- a/web/app/endpoints/page.tsx
+++ b/web/app/endpoints/page.tsx
@@ -1,0 +1,1 @@
+export { default } from '@views/endpoints';

--- a/web/public/samples/endpoints.yaml
+++ b/web/public/samples/endpoints.yaml
@@ -1,0 +1,62 @@
+# Endpoint samples. An Endpoint is a telemetry backend/destination a collector
+# exports to. spec.signals declares which signals it supports; spec.tenants lets
+# the same destination be managed differently per tenant via headers/tags.
+
+- label: OTLP backend (all signals)
+  description: A single OTLP/gRPC destination accepting metrics, logs and traces
+  value:
+    metadata:
+      name: central-otlp
+      namespace: "{{namespace}}"
+      attributes: {}
+      createdAt: "{{now}}"
+    spec:
+      url: https://otlp.example.com:4317
+      protocol: otlp
+      signals:
+        metrics: true
+        logs: true
+        traces: true
+
+- label: Mimir (multi-tenant metrics)
+  description: Prometheus remote-write to Mimir with per-tenant X-Scope-OrgID headers
+  value:
+    metadata:
+      name: mimir
+      namespace: "{{namespace}}"
+      attributes: {}
+      createdAt: "{{now}}"
+    spec:
+      url: https://mimir.example.com/api/v1/push
+      protocol: prometheusremotewrite
+      signals:
+        metrics: true
+        logs: false
+        traces: false
+      tenants:
+        - name: team-a
+          headers:
+            X-Scope-OrgID: team-a
+          tags:
+            tier: gold
+        - name: team-b
+          headers:
+            X-Scope-OrgID: team-b
+          tags:
+            tier: silver
+
+- label: Tempo (traces only)
+  description: A Tempo destination supporting only the traces signal
+  value:
+    metadata:
+      name: tempo
+      namespace: "{{namespace}}"
+      attributes: {}
+      createdAt: "{{now}}"
+    spec:
+      url: https://tempo.example.com:4317
+      protocol: otlp
+      signals:
+        metrics: false
+        logs: false
+        traces: true

--- a/web/src/entities/endpoint/index.ts
+++ b/web/src/entities/endpoint/index.ts
@@ -1,0 +1,1 @@
+export * from './model/types';

--- a/web/src/entities/endpoint/model/types.ts
+++ b/web/src/entities/endpoint/model/types.ts
@@ -1,0 +1,14 @@
+import type { Attributes, Condition, EndpointSpec } from '@shared/api';
+
+export interface EndpointMetadata {
+  name: string;
+  namespace: string;
+  attributes?: Attributes;
+  createdAt: string;
+}
+
+export interface Endpoint {
+  metadata: EndpointMetadata;
+  spec: EndpointSpec;
+  status?: { conditions?: Condition[] };
+}

--- a/web/src/shared/api/model/types.ts
+++ b/web/src/shared/api/model/types.ts
@@ -57,3 +57,27 @@ export interface AgentRemoteConfigSpec {
   value: string;
   contentType: string;
 }
+
+// Telemetry signals an Endpoint (or one of its tenants) supports.
+export interface EndpointSignals {
+  metrics: boolean;
+  logs: boolean;
+  traces: boolean;
+}
+
+// A tenant of an Endpoint: lets the same destination be managed differently per
+// tenant via per-tenant headers (e.g. X-Scope-OrgID) and tags.
+export interface EndpointTenant {
+  name: string;
+  headers?: Record<string, string>;
+  tags?: Record<string, string>;
+  signals?: EndpointSignals;
+}
+
+// Spec for the Endpoint entity (a telemetry backend/destination).
+export interface EndpointSpec {
+  url: string;
+  protocol: string;
+  signals: EndpointSignals;
+  tenants?: EndpointTenant[];
+}

--- a/web/src/views/endpoints/index.ts
+++ b/web/src/views/endpoints/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ui/EndpointsPage';

--- a/web/src/views/endpoints/ui/EndpointsPage.tsx
+++ b/web/src/views/endpoints/ui/EndpointsPage.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import { useNamespace } from '@entities/namespace';
+import dynamic from 'next/dynamic';
+import { ResourceListPage } from '@widgets/resource-list-page';
+import { TimeDisplay } from '@shared/preferences';
+import { api } from '@shared/api';
+import type { EndpointSignals } from '@shared/api';
+import type { Endpoint } from '@entities/endpoint';
+
+// Lazy-loaded: the JSON editor pulls in js-yaml — load only when a create/edit
+// dialog is opened, not in the initial route bundle.
+const JsonEditorDialog = dynamic(() => import('@shared/ui/JsonEditorDialog'));
+
+function signalsLabel(signals?: EndpointSignals): string {
+  if (!signals) return '-';
+  const enabled = [
+    signals.metrics ? 'metrics' : null,
+    signals.logs ? 'logs' : null,
+    signals.traces ? 'traces' : null,
+  ].filter(Boolean);
+  return enabled.length > 0 ? enabled.join(', ') : '-';
+}
+
+function emptyEndpoint(namespace: string): Endpoint {
+  return {
+    metadata: {
+      name: '',
+      namespace,
+      attributes: {},
+      createdAt: new Date().toISOString(),
+    },
+    spec: {
+      url: '',
+      protocol: 'otlp',
+      signals: { metrics: false, logs: false, traces: false },
+      tenants: [],
+    },
+  };
+}
+
+export default function EndpointsPage() {
+  const { namespace } = useNamespace();
+  const basePath = `/api/v1/namespaces/${namespace}/endpoints`;
+  return (
+    <ResourceListPage<Endpoint>
+      title="Endpoints"
+      subtitle={`Namespace: ${namespace}`}
+      listPath={basePath}
+      itemPath={(e) => `${basePath}/${e.metadata.name}`}
+      itemName={(e) => e.metadata.name}
+      deps={[namespace]}
+      canEdit
+      canDelete
+      columns={[
+        { header: 'Name', render: (e) => e.metadata.name },
+        { header: 'URL', render: (e) => e.spec.url || '-' },
+        { header: 'Protocol', render: (e) => e.spec.protocol || '-' },
+        { header: 'Signals', render: (e) => signalsLabel(e.spec.signals) },
+        { header: 'Tenants', render: (e) => String(e.spec.tenants?.length ?? 0) },
+        { header: 'Created', render: (e) => <TimeDisplay value={e.metadata.createdAt} /> },
+      ]}
+      renderCreate={({ open, onClose, onSaved }) => (
+        <JsonEditorDialog
+          open={open}
+          title="Create endpoint"
+          description="metadata.name + spec.url + spec.protocol + spec.signals (metrics/logs/traces). Use spec.tenants for multi-tenant headers/tags."
+          initialValue={emptyEndpoint(namespace)}
+          samplesUrl="/samples/endpoints.yaml"
+          samplesVars={{ namespace }}
+          onClose={onClose}
+          onSave={async (parsed) => {
+            await api.post(basePath, parsed as Endpoint);
+            onSaved();
+          }}
+        />
+      )}
+      renderEdit={({ open, row, onClose, onSaved }) => (
+        <JsonEditorDialog
+          open={open}
+          title={`Edit ${row.metadata.name}`}
+          initialValue={row}
+          samplesUrl="/samples/endpoints.yaml"
+          samplesVars={{ namespace }}
+          onClose={onClose}
+          onSave={async (parsed) => {
+            await api.put(`${basePath}/${row.metadata.name}`, parsed as Endpoint);
+            onSaved();
+          }}
+        />
+      )}
+    />
+  );
+}

--- a/web/src/widgets/app-layout/ui/AppLayout.tsx
+++ b/web/src/widgets/app-layout/ui/AppLayout.tsx
@@ -30,6 +30,7 @@ import {
   Dns as DnsIcon,
   Inventory2 as PackageIcon,
   Tune as TuneIcon,
+  Hub as HubIcon,
   VerifiedUser as CertIcon,
   PeopleAlt as PeopleIcon,
   AdminPanelSettings as RoleIcon,
@@ -115,6 +116,12 @@ const sections: NavSection[] = [
         icon: <TuneIcon />,
         href: '/agentremoteconfigs',
         requires: { resource: 'agentremoteconfig', action: 'LIST' },
+      },
+      {
+        text: 'Endpoints',
+        icon: <HubIcon />,
+        href: '/endpoints',
+        requires: { resource: 'endpoint', action: 'LIST' },
       },
       {
         text: 'Certificates',


### PR DESCRIPTION
## What

Adds a frontend CRUD page for the **Endpoint** resource (telemetry backends), completing the web side of the Endpoint feature (API in #435, opampctl in #439).

- **entities/endpoint**: `Endpoint` types; `EndpointSpec` / `EndpointSignals` / `EndpointTenant` added to `shared/api`.
- **views/endpoints**: `EndpointsPage` built on the existing `ResourceListPage` widget + lazy `JsonEditorDialog` (list / create / edit / delete). Columns show url, protocol, supported signals (e.g. `metrics, traces`), and tenant count.
- **app/endpoints**: thin route wrapper (FSD — routing only).
- **Nav**: "Endpoints" sidebar entry, gated on `endpoint:LIST` RBAC.
- **public/samples/endpoints.yaml**: single OTLP backend, multi-tenant Mimir (`X-Scope-OrgID` per tenant), and traces-only Tempo examples for the create dialog.

## Testing

Per `web/` checks — all pass:
- `npx tsc --noEmit`
- `npm run lint`
- `npm test` (56 tests)
- `npm run build` (`/endpoints` route prerendered)

🤖 Generated with [Claude Code](https://claude.com/claude-code)