### PR TITLE
fix(web): make app shell usable on mobile viewports

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,3 +120,23 @@ wrappers re-exporting a view). Path aliases: `@shared/* @entities/* @features/*
 internal files. See `web/ARCHITECTURE.md` for layer rules, where types/contexts
 live, and how to add an entity/feature/route. Checks: `cd web && npx tsc
 --noEmit && npm run lint && npm test && npm run build`.
+
+### Mobile / Responsive
+The UI must stay usable on phone-width viewports (≈375px). When building or
+changing any web feature, verify it at a narrow width — don't assume desktop.
+Conventions to follow:
+- **Breakpoint:** treat `< md` (`theme.breakpoints.down('md')`) as mobile. The
+  app shell (`widgets/app-layout`) already switches the sidebar to a `temporary`
+  overlay drawer below `md` and a `persistent` drawer above it; don't reintroduce
+  a fixed-width sidebar that pushes content.
+- **No fixed widths that overflow:** prefer responsive `sx` objects
+  (`minWidth: { xs: 120, sm: 200 }`, `flexDirection: { xs: 'column', sm: 'row' }`,
+  `display: { xs: 'none', sm: 'block' }`) over hardcoded `px` widths. Hide or
+  shrink secondary chrome (titles, dividers, labels) on `xs`.
+- **Wide content scrolls, not overflows:** wrap tables in MUI `TableContainer`
+  (as `widgets/resource-list-page` does) so they scroll horizontally instead of
+  breaking the layout.
+- **Dialogs:** use `fullWidth` with a `maxWidth`; consider `fullScreen` on `xs`
+  for large forms.
+- Reuse `shared/ui` and the `widgets/*` shells rather than hand-rolling layout —
+  they already carry the responsive behavior.

--- a/web/src/features/namespace-select/ui/NamespaceSelector.tsx
+++ b/web/src/features/namespace-select/ui/NamespaceSelector.tsx
@@ -60,7 +60,7 @@ export default function NamespaceSelector() {
 
   return (
     <>
-      <FormControl size="small" sx={{ minWidth: 200 }}>
+      <FormControl size="small" sx={{ minWidth: { xs: 120, sm: 200 } }}>
         <InputLabel
           id="namespace-label"
           sx={{ color: 'inherit', '&.Mui-focused': { color: 'inherit' } }}

--- a/web/src/widgets/app-layout/ui/AppLayout.tsx
+++ b/web/src/widgets/app-layout/ui/AppLayout.tsx
@@ -20,6 +20,8 @@ import {
   MenuItem,
   Divider,
   Tooltip,
+  useMediaQuery,
+  useTheme,
 } from '@mui/material';
 import {
   Dashboard as DashboardIcon,
@@ -165,7 +167,16 @@ export default function AppLayout({ children }: { children: ReactNode }) {
   const { email, logout } = useAuth();
   const { hasPermission, showAll, setShowAll } = usePermissions();
   const [menuAnchor, setMenuAnchor] = useState<HTMLElement | null>(null);
-  const [drawerOpen, setDrawerOpen] = useState(true);
+  const theme = useTheme();
+  // Below `md` we treat the viewport as a phone/tablet. Which drawer renders is
+  // decided purely by CSS (`display` breakpoints on the two Drawers below), so
+  // it's SSR-safe — there's no flash of the desktop sidebar before hydration.
+  // `isMobile` is only read inside event handlers (post-mount), where the JS
+  // match is reliable; the two modes track open state separately so switching
+  // orientation/breakpoint doesn't leak one into the other.
+  const isMobile = useMediaQuery(theme.breakpoints.down('md'));
+  const [desktopOpen, setDesktopOpen] = useState(true);
+  const [mobileOpen, setMobileOpen] = useState(false);
 
   // Filter nav items by RBAC. Items without `requires` (Dashboard) always show;
   // others need the resource:LIST permission unless the user has toggled
@@ -198,14 +209,19 @@ export default function AppLayout({ children }: { children: ReactNode }) {
       const stored = window.localStorage.getItem(SIDEBAR_OPEN_KEY);
       if (stored === null) return;
       // eslint-disable-next-line react-hooks/set-state-in-effect
-      setDrawerOpen(stored === '1');
+      setDesktopOpen(stored === '1');
     } catch {
       // Keep the default open state.
     }
   }, []);
 
   const toggleDrawer = () => {
-    setDrawerOpen((prev) => {
+    if (isMobile) {
+      // The overlay drawer is transient — no need to persist its state.
+      setMobileOpen((prev) => !prev);
+      return;
+    }
+    setDesktopOpen((prev) => {
       const next = !prev;
       if (typeof window !== 'undefined') {
         try {
@@ -217,6 +233,102 @@ export default function AppLayout({ children }: { children: ReactNode }) {
       return next;
     });
   };
+
+  // On mobile the drawer overlays content, so selecting a destination should
+  // dismiss it; on desktop the persistent drawer stays put.
+  const closeMobileDrawer = () => {
+    if (isMobile) setMobileOpen(false);
+  };
+
+  // Shared sidebar body, rendered into both the mobile (temporary) and desktop
+  // (persistent) drawers below. Leading <Toolbar /> spacer clears the AppBar.
+  const drawerContent = (
+    <>
+      <Toolbar />
+      <Box sx={{ overflow: 'auto', flexGrow: 1 }}>
+        {visibleSections.map((section) => (
+          <List
+            key={section.heading}
+            dense
+            subheader={
+              <ListSubheader component="div" sx={{ bgcolor: 'transparent' }}>
+                {section.heading}
+              </ListSubheader>
+            }
+          >
+            {section.items.map((item) => {
+              // Boundary-aware match: a subroute like /agents/123 still
+              // highlights /agents, but /agentgroups never highlights
+              // /agents even though they share a prefix.
+              const isActive =
+                item.href === '/'
+                  ? pathname === '/'
+                  : pathname === item.href || pathname.startsWith(`${item.href}/`);
+              return (
+                <ListItem key={item.text} disablePadding>
+                  <ListItemButton
+                    component={Link}
+                    href={item.href}
+                    selected={isActive}
+                    onClick={closeMobileDrawer}
+                  >
+                    <ListItemIcon>{item.icon}</ListItemIcon>
+                    <ListItemText primary={item.text} />
+                  </ListItemButton>
+                </ListItem>
+              );
+            })}
+          </List>
+        ))}
+      </Box>
+      <Box
+        sx={{
+          px: 2,
+          py: 1,
+          borderTop: '1px solid',
+          borderColor: 'divider',
+        }}
+      >
+        <Tooltip
+          title={
+            hiddenCount > 0
+              ? `Reveal ${hiddenCount} menu item${hiddenCount === 1 ? '' : 's'} hidden because you lack LIST permission. Pages may still return 403 when opened.`
+              : 'Reveal menu items hidden by RBAC. You currently have access to all items.'
+          }
+          placement="right"
+        >
+          <FormControlLabel
+            control={
+              <Switch
+                size="small"
+                checked={showAll}
+                onChange={(e) => setShowAll(e.target.checked)}
+              />
+            }
+            label={
+              <Stack direction="row" spacing={0.5} alignItems="baseline">
+                <Typography variant="caption">Show restricted menus</Typography>
+                {hiddenCount > 0 && !showAll && (
+                  <Typography variant="caption" color="text.disabled">
+                    ({hiddenCount})
+                  </Typography>
+                )}
+              </Stack>
+            }
+            sx={{ m: 0, '& .MuiFormControlLabel-label': { ml: 1 } }}
+          />
+        </Tooltip>
+      </Box>
+      <VersionFooter />
+    </>
+  );
+
+  const drawerPaperSx = {
+    width: drawerWidth,
+    boxSizing: 'border-box',
+    display: 'flex',
+    flexDirection: 'column',
+  } as const;
 
   return (
     <Box sx={{ display: 'flex' }}>
@@ -244,7 +356,12 @@ export default function AppLayout({ children }: { children: ReactNode }) {
             }}
           >
             <Image src="/logo.png" alt="OpAMP Commander" width={32} height={32} priority />
-            <Typography variant="h6" noWrap component="div">
+            <Typography
+              variant="h6"
+              noWrap
+              component="div"
+              sx={{ display: { xs: 'none', sm: 'block' } }}
+            >
               OpAMP Commander
             </Typography>
           </Box>
@@ -253,6 +370,7 @@ export default function AppLayout({ children }: { children: ReactNode }) {
               borderLeft: '1px solid rgba(255,255,255,0.3)',
               height: 32,
               alignSelf: 'center',
+              display: { xs: 'none', sm: 'block' },
             }}
           />
           <NamespaceSelector />
@@ -302,91 +420,33 @@ export default function AppLayout({ children }: { children: ReactNode }) {
           </Menu>
         </Toolbar>
       </AppBar>
+      {/* Mobile: temporary overlay drawer. Hidden above `md` via CSS so it
+          never reserves layout width. keepMounted preserves the nav list. */}
       <Drawer
-        variant="persistent"
-        open={drawerOpen}
+        variant="temporary"
+        open={mobileOpen}
+        onClose={() => setMobileOpen(false)}
+        ModalProps={{ keepMounted: true }}
         sx={{
-          width: drawerOpen ? drawerWidth : 0,
-          flexShrink: 0,
-          [`& .MuiDrawer-paper`]: {
-            width: drawerWidth,
-            boxSizing: 'border-box',
-            display: 'flex',
-            flexDirection: 'column',
-          },
+          display: { xs: 'block', md: 'none' },
+          [`& .MuiDrawer-paper`]: drawerPaperSx,
         }}
       >
-        <Toolbar />
-        <Box sx={{ overflow: 'auto', flexGrow: 1 }}>
-          {visibleSections.map((section) => (
-            <List
-              key={section.heading}
-              dense
-              subheader={
-                <ListSubheader component="div" sx={{ bgcolor: 'transparent' }}>
-                  {section.heading}
-                </ListSubheader>
-              }
-            >
-              {section.items.map((item) => {
-                // Boundary-aware match: a subroute like /agents/123 still
-                // highlights /agents, but /agentgroups never highlights
-                // /agents even though they share a prefix.
-                const isActive =
-                  item.href === '/'
-                    ? pathname === '/'
-                    : pathname === item.href || pathname.startsWith(`${item.href}/`);
-                return (
-                  <ListItem key={item.text} disablePadding>
-                    <ListItemButton component={Link} href={item.href} selected={isActive}>
-                      <ListItemIcon>{item.icon}</ListItemIcon>
-                      <ListItemText primary={item.text} />
-                    </ListItemButton>
-                  </ListItem>
-                );
-              })}
-            </List>
-          ))}
-        </Box>
-        <Box
-          sx={{
-            px: 2,
-            py: 1,
-            borderTop: '1px solid',
-            borderColor: 'divider',
-          }}
-        >
-          <Tooltip
-            title={
-              hiddenCount > 0
-                ? `Reveal ${hiddenCount} menu item${hiddenCount === 1 ? '' : 's'} hidden because you lack LIST permission. Pages may still return 403 when opened.`
-                : 'Reveal menu items hidden by RBAC. You currently have access to all items.'
-            }
-            placement="right"
-          >
-            <FormControlLabel
-              control={
-                <Switch
-                  size="small"
-                  checked={showAll}
-                  onChange={(e) => setShowAll(e.target.checked)}
-                />
-              }
-              label={
-                <Stack direction="row" spacing={0.5} alignItems="baseline">
-                  <Typography variant="caption">Show restricted menus</Typography>
-                  {hiddenCount > 0 && !showAll && (
-                    <Typography variant="caption" color="text.disabled">
-                      ({hiddenCount})
-                    </Typography>
-                  )}
-                </Stack>
-              }
-              sx={{ m: 0, '& .MuiFormControlLabel-label': { ml: 1 } }}
-            />
-          </Tooltip>
-        </Box>
-        <VersionFooter />
+        {drawerContent}
+      </Drawer>
+      {/* Desktop: persistent drawer that reserves width only when open. Hidden
+          below `md` via CSS. */}
+      <Drawer
+        variant="persistent"
+        open={desktopOpen}
+        sx={{
+          display: { xs: 'none', md: 'block' },
+          width: desktopOpen ? drawerWidth : 0,
+          flexShrink: 0,
+          [`& .MuiDrawer-paper`]: drawerPaperSx,
+        }}
+      >
+        {drawerContent}
       </Drawer>
       <Box
         component="main"


### PR DESCRIPTION
## What

The web app shell didn't render well on phone-width screens. The sidebar was a `persistent` 240px drawer that defaulted **open**, so on a ~375px viewport it pushed the main content nearly off-screen, and the top bar overflowed.

## Changes

- **Responsive sidebar** (`widgets/app-layout`): switch to MUI's CSS-driven two-drawer pattern.
  - **Mobile (`< md`):** a `temporary` overlay drawer that doesn't reserve layout width and dismisses on backdrop tap / nav selection.
  - **Desktop (`>= md`):** the existing `persistent` drawer, open state still persisted to `localStorage`.
  - Which drawer renders is decided purely by CSS `display` breakpoints → **SSR-safe, no flash** of the desktop sidebar before hydration. `useMediaQuery` is read only inside event handlers (post-mount).
- **Top bar:** hide the app title + divider on `xs`, and shrink the namespace selector (`minWidth: { xs: 120, sm: 200 }`) so it no longer overflows on phones.
- **CLAUDE.md:** add a "Mobile / Responsive" section documenting the breakpoint convention, responsive-`sx` guidance, table-scroll/dialog rules, and "reuse the shells" so future web features keep working at narrow widths.

## Notes

- The shared drawer body is rendered into both drawers; the duplicated `VersionFooter` is deduped by SWR (constant key), so there's no extra request.

## Verification

`cd web && npx tsc --noEmit && npm run lint && npm test && npm run build` — all green (60/60 tests, build OK).

🤖 Generated with [Claude Code](https://claude.com/claude-code)