### PR TITLE
feat(apiserver): match/create endpoints from remote config (no auto-delete)

### DIFF
--- a/pkg/apiserver/application/service/agentremoteconfig/agentremoteconfig.go
+++ b/pkg/apiserver/application/service/agentremoteconfig/agentremoteconfig.go
@@ -25,6 +25,7 @@ var _ port.AgentRemoteConfigManageUsecase = (*Service)(nil)
 type Service struct {
 	agentRemoteConfigUsecase agentport.AgentRemoteConfigUsecase
 	agentGroupUsecase        agentport.AgentGroupUsecase
+	endpointDetectionUsecase agentport.EndpointDetectionUsecase
 	mapper                   *helper.Mapper
 	sanityFilter             *filter.Sanity
 	clock                    clock.Clock
@@ -35,6 +36,7 @@ type Service struct {
 func NewAgentRemoteConfigService(
 	agentRemoteConfigUsecase agentport.AgentRemoteConfigUsecase,
 	agentGroupUsecase agentport.AgentGroupUsecase,
+	endpointDetectionUsecase agentport.EndpointDetectionUsecase,
 	logger *slog.Logger,
 ) *Service {
 	realClock := clock.NewRealClock()
@@ -42,6 +44,7 @@ func NewAgentRemoteConfigService(
 	return &Service{
 		agentRemoteConfigUsecase: agentRemoteConfigUsecase,
 		agentGroupUsecase:        agentGroupUsecase,
+		endpointDetectionUsecase: endpointDetectionUsecase,
 		mapper:                   helper.NewMapper(realClock, 0),
 		sanityFilter:             filter.NewSanity(),
 		clock:                    realClock,
@@ -135,6 +138,7 @@ func (s *Service) CreateAgentRemoteConfig(
 	}
 
 	s.triggerGroupPropagation(ctx, saved.Metadata.Namespace, saved.Metadata.Name)
+	s.triggerEndpointDetection(ctx, saved)
 
 	return s.mapper.MapAgentRemoteConfigToAPI(saved), nil
 }
@@ -164,6 +168,7 @@ func (s *Service) UpdateAgentRemoteConfig(
 	}
 
 	s.triggerGroupPropagation(ctx, updated.Metadata.Namespace, updated.Metadata.Name)
+	s.triggerEndpointDetection(ctx, updated)
 
 	return s.mapper.MapAgentRemoteConfigToAPI(updated), nil
 }
@@ -213,6 +218,25 @@ func (s *Service) triggerGroupPropagation(ctx context.Context, namespace, name s
 				"failed to propagate agent remote config change to groups",
 				slog.String("namespace", namespace),
 				slog.String("name", name),
+				slog.String("error", err.Error()),
+			)
+		}
+	}()
+}
+
+// triggerEndpointDetection reconciles the endpoints derived from this remote
+// config's collector configuration. Runs detached from the request ctx, in its own
+// goroutine, so it cannot block (or be cancelled with) the HTTP handler.
+func (s *Service) triggerEndpointDetection(ctx context.Context, remoteConfig *agentmodel.AgentRemoteConfig) {
+	bgCtx := context.WithoutCancel(ctx)
+
+	go func() {
+		err := s.endpointDetectionUsecase.ReconcileEndpointsFromRemoteConfig(bgCtx, remoteConfig)
+		if err != nil {
+			s.logger.Warn(
+				"failed to reconcile endpoints from remote config",
+				slog.String("namespace", remoteConfig.Metadata.Namespace),
+				slog.String("name", remoteConfig.Metadata.Name),
 				slog.String("error", err.Error()),
 			)
 		}

--- a/pkg/apiserver/domain/agent/port/in.go
+++ b/pkg/apiserver/domain/agent/port/in.go
@@ -124,6 +124,16 @@ type EndpointUsecase interface {
 		deletedAt time.Time, deletedBy string) error
 }
 
+// EndpointDetectionUsecase detects telemetry backends from an AgentRemoteConfig's
+// collector configuration and matches them to Endpoint resources.
+type EndpointDetectionUsecase interface {
+	// ReconcileEndpointsFromRemoteConfig matches every exporter destination in the
+	// remote config to an endpoint (linking an existing same-URL endpoint or
+	// auto-creating one). It never modifies a matched endpoint's spec and never
+	// deletes endpoints.
+	ReconcileEndpointsFromRemoteConfig(ctx context.Context, remoteConfig *agentmodel.AgentRemoteConfig) error
+}
+
 // AgentGroupUsecase is an interface that defines the methods for agent group use cases.
 type AgentGroupUsecase interface {
 	// GetAgentGroup retrieves an agent group by its namespace and name.

--- a/pkg/apiserver/domain/agent/service/endpointdetection.go
+++ b/pkg/apiserver/domain/agent/service/endpointdetection.go
@@ -2,6 +2,7 @@ package agentservice
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"slices"
@@ -13,6 +14,7 @@ import (
 	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
 	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/port"
 	"github.com/minuk-dev/opampcommander/pkg/utils/clock"
 )
 
@@ -103,20 +105,57 @@ func (s *EndpointDetectionService) ReconcileEndpointsFromRemoteConfig(
 
 	now := s.clock.Now()
 
-	for _, exporter := range exporters {
+	// Collapse exporters to one per destination URL (deterministic, signals merged)
+	// so a config with several exporters pointing at the same URL yields a single,
+	// stable endpoint rather than depending on map iteration order.
+	for _, exporter := range collapseByURL(exporters) {
 		if existing, ok := byURL[exporter.url]; ok {
 			s.linkExisting(ctx, existing, ref)
 
 			continue
 		}
 
-		created := s.createEndpoint(ctx, remoteConfig.Metadata.Name, namespace, ref, exporter, now)
-		if created != nil {
-			byURL[exporter.url] = created
-		}
+		s.createEndpoint(ctx, remoteConfig.Metadata.Name, namespace, ref, exporter, now)
 	}
 
 	return nil
+}
+
+// collapseByURL reduces the detected exporters to one entry per destination URL,
+// merging their supported signals. Exporters are processed in sorted key order so
+// the surviving protocol/headers/exporter-key for a shared URL is deterministic.
+func collapseByURL(exporters map[string]*detectedExporter) []*detectedExporter {
+	keys := make([]string, 0, len(exporters))
+	for key := range exporters {
+		keys = append(keys, key)
+	}
+
+	slices.Sort(keys)
+
+	byURL := make(map[string]*detectedExporter, len(exporters))
+	order := make([]string, 0, len(exporters))
+
+	for _, key := range keys {
+		exporter := exporters[key]
+		if existing, ok := byURL[exporter.url]; ok {
+			existing.signals.Metrics = existing.signals.Metrics || exporter.signals.Metrics
+			existing.signals.Logs = existing.signals.Logs || exporter.signals.Logs
+			existing.signals.Traces = existing.signals.Traces || exporter.signals.Traces
+
+			continue
+		}
+
+		clone := *exporter
+		byURL[exporter.url] = &clone
+		order = append(order, exporter.url)
+	}
+
+	out := make([]*detectedExporter, 0, len(order))
+	for _, url := range order {
+		out = append(out, byURL[url])
+	}
+
+	return out
 }
 
 // endpointsByURL indexes the namespace's live endpoints by their URL.
@@ -140,6 +179,11 @@ func (s *EndpointDetectionService) endpointsByURL(
 
 // linkExisting records that ref references the endpoint, preserving its spec. It is
 // a no-op (no write) when the link is already present.
+//
+// The matched-by set is best-effort metadata: it is a read-modify-write without
+// optimistic locking, so two reconciles linking the same endpoint concurrently can
+// drop one ref. It carries no behavioral weight (nothing keys off it), and the next
+// reconcile of the dropped remote config re-adds its ref.
 func (s *EndpointDetectionService) linkExisting(
 	ctx context.Context, endpoint *agentmodel.Endpoint, ref string,
 ) {
@@ -158,18 +202,36 @@ func (s *EndpointDetectionService) linkExisting(
 }
 
 // createEndpoint auto-creates an endpoint for an exporter destination that has no
-// matching URL. It will not overwrite or revive an endpoint that already exists by
-// name (manual or previously deleted), to avoid clobbering user-managed state.
+// matching URL. It never overwrites or revives an endpoint that already owns the
+// generated name: a soft-deleted one is left deleted (a user deleted it on purpose),
+// and a live one with a different URL is left untouched (name collision). Both cases
+// are logged rather than silently skipped.
 func (s *EndpointDetectionService) createEndpoint(
 	ctx context.Context, remoteConfigName, namespace, ref string,
 	exporter *detectedExporter, now time.Time,
-) *agentmodel.Endpoint {
+) {
 	name := endpointName(remoteConfigName, exporter.key)
 
-	_, err := s.endpointUsecase.GetEndpoint(ctx, namespace, name, &model.GetOptions{IncludeDeleted: true})
-	if err == nil {
-		// A different endpoint already owns this name; do not clobber it.
-		return nil
+	existing, err := s.endpointUsecase.GetEndpoint(ctx, namespace, name, &model.GetOptions{IncludeDeleted: true})
+
+	switch {
+	case err == nil && existing.IsDeleted():
+		// Respect a manual deletion: do not resurrect an endpoint the user removed.
+		s.logger.Debug("not recreating a user-deleted endpoint",
+			slog.String("namespace", namespace), slog.String("name", name))
+
+		return
+	case err == nil:
+		// A different live endpoint owns this name; do not clobber it.
+		s.logger.Warn("skipping detected endpoint: name already in use by another endpoint",
+			slog.String("namespace", namespace), slog.String("name", name), slog.String("url", exporter.url))
+
+		return
+	case !errors.Is(err, port.ErrResourceNotExist):
+		s.logger.Warn("failed to check endpoint name before create",
+			slog.String("namespace", namespace), slog.String("name", name), slog.String("error", err.Error()))
+
+		return
 	}
 
 	endpoint := buildEndpoint(namespace, name, ref, exporter, now)
@@ -181,11 +243,7 @@ func (s *EndpointDetectionService) createEndpoint(
 			slog.String("name", name),
 			slog.String("error", err.Error()),
 		)
-
-		return nil
 	}
-
-	return endpoint
 }
 
 // detectedExporter is a telemetry destination parsed from a collector config.
@@ -405,8 +463,15 @@ func stringMapField(cfg map[string]any, key string) map[string]string {
 	}
 
 	result := make(map[string]string, len(raw))
-	for k, v := range raw {
-		result[k] = fmt.Sprintf("%v", v)
+
+	for headerKey, headerValue := range raw {
+		switch headerValue.(type) {
+		case map[string]any, []any:
+			// Skip non-scalar header values; a header is always a scalar string.
+			continue
+		default:
+			result[headerKey] = fmt.Sprintf("%v", headerValue)
+		}
 	}
 
 	return result

--- a/pkg/apiserver/domain/agent/service/endpointdetection.go
+++ b/pkg/apiserver/domain/agent/service/endpointdetection.go
@@ -1,0 +1,424 @@
+package agentservice
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"slices"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
+	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	"github.com/minuk-dev/opampcommander/pkg/utils/clock"
+)
+
+const (
+	// EndpointGeneratedFromAttribute records the AgentRemoteConfig that auto-created
+	// an endpoint. Its value is "<namespace>/<remoteConfigName>". Manually created
+	// endpoints do not carry it.
+	EndpointGeneratedFromAttribute = "opampcommander.io/generated-from"
+	// EndpointMatchedByAttribute lists the AgentRemoteConfigs whose collector config
+	// references this endpoint's URL, as a comma-separated set of "<namespace>/<name>".
+	EndpointMatchedByAttribute = "opampcommander.io/matched-by"
+	// EndpointManagedByAttribute records the controller that auto-created the endpoint.
+	EndpointManagedByAttribute = "opampcommander.io/managed-by"
+	// EndpointExporterAttribute records the collector exporter key the endpoint was
+	// derived from (e.g. "otlp/mimir").
+	EndpointExporterAttribute = "opampcommander.io/exporter"
+
+	// endpointManagedByValue is the value stored in EndpointManagedByAttribute and
+	// used as the actor for the created condition on auto-generated endpoints.
+	endpointManagedByValue = "remoteconfig-endpoint-detector"
+
+	// scopeOrgIDHeader is the multi-tenancy header used by Mimir/Loki/Tempo. When an
+	// exporter sets it, the auto-created endpoint gets a tenant keyed by its value.
+	scopeOrgIDHeader = "X-Scope-OrgID"
+)
+
+var _ agentport.EndpointDetectionUsecase = (*EndpointDetectionService)(nil)
+
+// EndpointDetectionService detects telemetry backends from an AgentRemoteConfig's
+// OpenTelemetry Collector configuration and matches them to Endpoint resources.
+//
+// For each exporter destination it finds an existing endpoint with the same URL and
+// records the match (without changing that endpoint's spec); if none exists, it
+// auto-creates one. It never updates a matched endpoint's spec and never deletes
+// endpoints — removing an exporter or deleting the remote config leaves endpoints
+// in place. Users manage endpoint lifecycle (create/update/delete) themselves.
+type EndpointDetectionService struct {
+	endpointUsecase agentport.EndpointUsecase
+	clock           clock.Clock
+	logger          *slog.Logger
+}
+
+// NewEndpointDetectionService creates a new EndpointDetectionService.
+func NewEndpointDetectionService(
+	endpointUsecase agentport.EndpointUsecase,
+	logger *slog.Logger,
+) *EndpointDetectionService {
+	return &EndpointDetectionService{
+		endpointUsecase: endpointUsecase,
+		clock:           clock.NewRealClock(),
+		logger:          logger,
+	}
+}
+
+// SetClock overrides the clock used for condition timestamps. Intended for tests.
+func (s *EndpointDetectionService) SetClock(c clock.Clock) {
+	s.clock = c
+}
+
+// ReconcileEndpointsFromRemoteConfig matches every exporter destination in the
+// remote config's collector configuration to an endpoint: an existing endpoint with
+// the same URL is linked (its spec is preserved), otherwise a new endpoint is
+// created. It never modifies a matched endpoint's spec and never deletes endpoints.
+func (s *EndpointDetectionService) ReconcileEndpointsFromRemoteConfig(
+	ctx context.Context,
+	remoteConfig *agentmodel.AgentRemoteConfig,
+) error {
+	if remoteConfig == nil {
+		return nil
+	}
+
+	namespace := remoteConfig.Metadata.Namespace
+	ref := remoteConfigRef(namespace, remoteConfig.Metadata.Name)
+
+	exporters, err := parseCollectorExporters(remoteConfig.Spec.Value)
+	if err != nil {
+		return fmt.Errorf("detect endpoints from remote config %q: %w", ref, err)
+	}
+
+	if len(exporters) == 0 {
+		return nil
+	}
+
+	byURL, err := s.endpointsByURL(ctx, namespace)
+	if err != nil {
+		return err
+	}
+
+	now := s.clock.Now()
+
+	for _, exporter := range exporters {
+		if existing, ok := byURL[exporter.url]; ok {
+			s.linkExisting(ctx, existing, ref)
+
+			continue
+		}
+
+		created := s.createEndpoint(ctx, remoteConfig.Metadata.Name, namespace, ref, exporter, now)
+		if created != nil {
+			byURL[exporter.url] = created
+		}
+	}
+
+	return nil
+}
+
+// endpointsByURL indexes the namespace's live endpoints by their URL.
+func (s *EndpointDetectionService) endpointsByURL(
+	ctx context.Context, namespace string,
+) (map[string]*agentmodel.Endpoint, error) {
+	resp, err := s.endpointUsecase.ListEndpoints(ctx, namespace, nil)
+	if err != nil {
+		return nil, fmt.Errorf("list endpoints: %w", err)
+	}
+
+	byURL := make(map[string]*agentmodel.Endpoint, len(resp.Items))
+	for _, endpoint := range resp.Items {
+		if endpoint.Spec.URL != "" {
+			byURL[endpoint.Spec.URL] = endpoint
+		}
+	}
+
+	return byURL, nil
+}
+
+// linkExisting records that ref references the endpoint, preserving its spec. It is
+// a no-op (no write) when the link is already present.
+func (s *EndpointDetectionService) linkExisting(
+	ctx context.Context, endpoint *agentmodel.Endpoint, ref string,
+) {
+	if !addMatchedBy(endpoint, ref) {
+		return
+	}
+
+	_, err := s.endpointUsecase.SaveEndpoint(ctx, endpoint)
+	if err != nil {
+		s.logger.Warn("failed to link endpoint to remote config",
+			slog.String("namespace", endpoint.Metadata.Namespace),
+			slog.String("name", endpoint.Metadata.Name),
+			slog.String("error", err.Error()),
+		)
+	}
+}
+
+// createEndpoint auto-creates an endpoint for an exporter destination that has no
+// matching URL. It will not overwrite or revive an endpoint that already exists by
+// name (manual or previously deleted), to avoid clobbering user-managed state.
+func (s *EndpointDetectionService) createEndpoint(
+	ctx context.Context, remoteConfigName, namespace, ref string,
+	exporter *detectedExporter, now time.Time,
+) *agentmodel.Endpoint {
+	name := endpointName(remoteConfigName, exporter.key)
+
+	_, err := s.endpointUsecase.GetEndpoint(ctx, namespace, name, &model.GetOptions{IncludeDeleted: true})
+	if err == nil {
+		// A different endpoint already owns this name; do not clobber it.
+		return nil
+	}
+
+	endpoint := buildEndpoint(namespace, name, ref, exporter, now)
+
+	_, err = s.endpointUsecase.SaveEndpoint(ctx, endpoint)
+	if err != nil {
+		s.logger.Warn("failed to create detected endpoint",
+			slog.String("namespace", namespace),
+			slog.String("name", name),
+			slog.String("error", err.Error()),
+		)
+
+		return nil
+	}
+
+	return endpoint
+}
+
+// detectedExporter is a telemetry destination parsed from a collector config.
+type detectedExporter struct {
+	key      string
+	protocol string
+	url      string
+	headers  map[string]string
+	signals  agentmodel.EndpointSignals
+}
+
+// parseCollectorExporters extracts network exporters and their supported signals
+// from an OpenTelemetry Collector configuration (YAML or JSON — JSON is valid YAML).
+// Only exporters with an endpoint/url are returned; sinks like debug/nop are skipped.
+func parseCollectorExporters(value []byte) (map[string]*detectedExporter, error) {
+	if len(value) == 0 {
+		return map[string]*detectedExporter{}, nil
+	}
+
+	var root map[string]any
+
+	err := yaml.Unmarshal(value, &root)
+	if err != nil {
+		return nil, fmt.Errorf("parse collector config: %w", err)
+	}
+
+	detected := map[string]*detectedExporter{}
+
+	exporters, _ := root["exporters"].(map[string]any)
+	for key, raw := range exporters {
+		cfg, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		url := stringField(cfg, "endpoint")
+		if url == "" {
+			url = stringField(cfg, "url")
+		}
+
+		if url == "" {
+			continue // not a network destination
+		}
+
+		detected[key] = &detectedExporter{
+			key:      key,
+			protocol: typeFromKey(key),
+			url:      url,
+			headers:  stringMapField(cfg, "headers"),
+			signals:  agentmodel.EndpointSignals{Metrics: false, Logs: false, Traces: false},
+		}
+	}
+
+	applyPipelineSignals(root, detected)
+
+	return detected, nil
+}
+
+// applyPipelineSignals sets each detected exporter's signals from the
+// service.pipelines that reference it.
+func applyPipelineSignals(root map[string]any, detected map[string]*detectedExporter) {
+	service, _ := root["service"].(map[string]any)
+	pipelines, _ := service["pipelines"].(map[string]any)
+
+	for name, raw := range pipelines {
+		cfg, ok := raw.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		exporters, _ := cfg["exporters"].([]any)
+		for _, item := range exporters {
+			exporterName, ok := item.(string)
+			if !ok {
+				continue
+			}
+
+			exporter, ok := detected[exporterName]
+			if !ok {
+				continue
+			}
+
+			switch typeFromKey(name) {
+			case "metrics":
+				exporter.signals.Metrics = true
+			case "logs":
+				exporter.signals.Logs = true
+			case "traces":
+				exporter.signals.Traces = true
+			}
+		}
+	}
+}
+
+// buildEndpoint builds the endpoint to auto-create for a detected exporter.
+func buildEndpoint(
+	namespace, name, ref string,
+	exporter *detectedExporter,
+	now time.Time,
+) *agentmodel.Endpoint {
+	attributes := agentmodel.Attributes{
+		EndpointGeneratedFromAttribute: ref,
+		EndpointMatchedByAttribute:     ref,
+		EndpointManagedByAttribute:     endpointManagedByValue,
+		EndpointExporterAttribute:      exporter.key,
+	}
+
+	endpoint := agentmodel.NewEndpoint(namespace, name, attributes, now, endpointManagedByValue)
+	endpoint.Spec.URL = exporter.url
+	endpoint.Spec.Protocol = exporter.protocol
+	endpoint.Spec.Signals = exporter.signals
+
+	if orgID, ok := headerValue(exporter.headers, scopeOrgIDHeader); ok {
+		endpoint.Spec.Tenants = []agentmodel.EndpointTenant{
+			{
+				Name:    orgID,
+				Headers: exporter.headers,
+				Tags:    nil,
+				Signals: nil,
+			},
+		}
+	}
+
+	return endpoint
+}
+
+// addMatchedBy adds ref to the endpoint's matched-by attribute set, keeping it
+// sorted. It returns true if the endpoint was changed.
+func addMatchedBy(endpoint *agentmodel.Endpoint, ref string) bool {
+	current := splitSet(endpoint.Metadata.Attributes[EndpointMatchedByAttribute])
+	if slices.Contains(current, ref) {
+		return false
+	}
+
+	current = append(current, ref)
+	slices.Sort(current)
+
+	if endpoint.Metadata.Attributes == nil {
+		endpoint.Metadata.Attributes = agentmodel.Attributes{}
+	}
+
+	endpoint.Metadata.Attributes[EndpointMatchedByAttribute] = strings.Join(current, ",")
+
+	return true
+}
+
+// splitSet splits a comma-separated attribute value into its non-empty members.
+func splitSet(value string) []string {
+	if value == "" {
+		return nil
+	}
+
+	parts := strings.Split(value, ",")
+	out := make([]string, 0, len(parts))
+
+	for _, part := range parts {
+		trimmed := strings.TrimSpace(part)
+		if trimmed != "" {
+			out = append(out, trimmed)
+		}
+	}
+
+	return out
+}
+
+func remoteConfigRef(namespace, remoteConfigName string) string {
+	return namespace + "/" + remoteConfigName
+}
+
+// typeFromKey returns the part of a collector map key before "/", e.g. the exporter
+// type "otlp" from "otlp/mimir" or the signal "metrics" from "metrics/2".
+func typeFromKey(key string) string {
+	prefix, _, _ := strings.Cut(key, "/")
+
+	return prefix
+}
+
+// endpointName builds a deterministic, sanitized endpoint name from the remote
+// config name and the exporter key (e.g. "obs" + "otlp/mimir" -> "obs-otlp-mimir").
+func endpointName(remoteConfigName, exporterKey string) string {
+	return sanitizeName(remoteConfigName + "-" + exporterKey)
+}
+
+// sanitizeName lowercases the input and replaces any character outside
+// [a-z0-9._-] with "-" so the result is a valid resource name.
+func sanitizeName(s string) string {
+	var builder strings.Builder
+
+	for _, r := range strings.ToLower(s) {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '.', r == '-', r == '_':
+			builder.WriteRune(r)
+		default:
+			builder.WriteRune('-')
+		}
+	}
+
+	return builder.String()
+}
+
+// stringField returns cfg[key] as a string, or "" when absent or not a string.
+func stringField(cfg map[string]any, key string) string {
+	value, ok := cfg[key].(string)
+	if !ok {
+		return ""
+	}
+
+	return value
+}
+
+// stringMapField returns cfg[key] as a map[string]string, coercing scalar values
+// to strings. It returns nil when the field is absent or not a mapping.
+func stringMapField(cfg map[string]any, key string) map[string]string {
+	raw, ok := cfg[key].(map[string]any)
+	if !ok {
+		return nil
+	}
+
+	result := make(map[string]string, len(raw))
+	for k, v := range raw {
+		result[k] = fmt.Sprintf("%v", v)
+	}
+
+	return result
+}
+
+// headerValue does a case-insensitive lookup of name in headers.
+func headerValue(headers map[string]string, name string) (string, bool) {
+	for key, value := range headers {
+		if strings.EqualFold(key, name) {
+			return value, true
+		}
+	}
+
+	return "", false
+}

--- a/pkg/apiserver/domain/agent/service/endpointdetection_test.go
+++ b/pkg/apiserver/domain/agent/service/endpointdetection_test.go
@@ -1,0 +1,218 @@
+package agentservice_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
+	agentservice "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/service"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/port"
+)
+
+// fakeEndpointUsecase is an in-memory agentport.EndpointUsecase for tests, with
+// soft-delete semantics matching the real persistence.
+type fakeEndpointUsecase struct {
+	store map[string]*agentmodel.Endpoint // key: namespace/name
+}
+
+func newFakeEndpointUsecase() *fakeEndpointUsecase {
+	return &fakeEndpointUsecase{store: map[string]*agentmodel.Endpoint{}}
+}
+
+func key(namespace, name string) string { return namespace + "/" + name }
+
+func (f *fakeEndpointUsecase) GetEndpoint(
+	_ context.Context, namespace, name string, options *model.GetOptions,
+) (*agentmodel.Endpoint, error) {
+	endpoint, ok := f.store[key(namespace, name)]
+	if !ok {
+		return nil, port.ErrResourceNotExist
+	}
+
+	if endpoint.IsDeleted() && (options == nil || !options.IncludeDeleted) {
+		return nil, port.ErrResourceNotExist
+	}
+
+	return endpoint, nil
+}
+
+func (f *fakeEndpointUsecase) ListEndpoints(
+	_ context.Context, namespace string, _ *model.ListOptions,
+) (*model.ListResponse[*agentmodel.Endpoint], error) {
+	items := make([]*agentmodel.Endpoint, 0, len(f.store))
+
+	for _, endpoint := range f.store {
+		if endpoint.Metadata.Namespace == namespace && !endpoint.IsDeleted() {
+			items = append(items, endpoint)
+		}
+	}
+
+	return &model.ListResponse[*agentmodel.Endpoint]{Items: items, Continue: "", RemainingItemCount: 0}, nil
+}
+
+func (f *fakeEndpointUsecase) SaveEndpoint(
+	_ context.Context, endpoint *agentmodel.Endpoint,
+) (*agentmodel.Endpoint, error) {
+	f.store[key(endpoint.Metadata.Namespace, endpoint.Metadata.Name)] = endpoint
+
+	return endpoint, nil
+}
+
+func (f *fakeEndpointUsecase) DeleteEndpoint(
+	_ context.Context, namespace, name string, deletedAt time.Time, deletedBy string,
+) error {
+	endpoint, ok := f.store[key(namespace, name)]
+	if !ok {
+		return port.ErrResourceNotExist
+	}
+
+	endpoint.MarkDeleted(deletedAt, deletedBy)
+
+	return nil
+}
+
+const otlpAndMimirConfig = `
+exporters:
+  otlp:
+    endpoint: https://otlp.example.com:4317
+  prometheusremotewrite/mimir:
+    endpoint: https://mimir.example.com/api/v1/push
+    headers:
+      X-Scope-OrgID: team-a
+  debug:
+    verbosity: basic
+service:
+  pipelines:
+    traces:
+      exporters: [otlp]
+    metrics:
+      exporters: [otlp, prometheusremotewrite/mimir]
+`
+
+func newRemoteConfig(config string) *agentmodel.AgentRemoteConfig {
+	//exhaustruct:ignore
+	return &agentmodel.AgentRemoteConfig{
+		Metadata: agentmodel.AgentRemoteConfigMetadata{Namespace: "default", Name: "obs"},
+		Spec:     agentmodel.AgentRemoteConfigSpec{Value: []byte(config), ContentType: "text/yaml"},
+	}
+}
+
+func TestReconcileAutoCreatesEndpoints(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	fake := newFakeEndpointUsecase()
+	svc := agentservice.NewEndpointDetectionService(fake, slog.Default())
+
+	require.NoError(t, svc.ReconcileEndpointsFromRemoteConfig(ctx, newRemoteConfig(otlpAndMimirConfig)))
+
+	// debug has no endpoint/url, so only otlp + mimir become endpoints.
+	list, err := fake.ListEndpoints(ctx, "default", nil)
+	require.NoError(t, err)
+	assert.Len(t, list.Items, 2)
+
+	otlp, err := fake.GetEndpoint(ctx, "default", "obs-otlp", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "https://otlp.example.com:4317", otlp.Spec.URL)
+	assert.Equal(t, "otlp", otlp.Spec.Protocol)
+	assert.True(t, otlp.Spec.Signals.Traces)
+	assert.True(t, otlp.Spec.Signals.Metrics)
+	assert.False(t, otlp.Spec.Signals.Logs)
+	assert.Equal(t, "default/obs", otlp.Metadata.Attributes[agentservice.EndpointGeneratedFromAttribute])
+	assert.Equal(t, "default/obs", otlp.Metadata.Attributes[agentservice.EndpointMatchedByAttribute])
+
+	mimir, err := fake.GetEndpoint(ctx, "default", "obs-prometheusremotewrite-mimir", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "prometheusremotewrite", mimir.Spec.Protocol)
+	assert.True(t, mimir.Spec.Signals.Metrics)
+	require.Len(t, mimir.Spec.Tenants, 1)
+	assert.Equal(t, "team-a", mimir.Spec.Tenants[0].Name)
+	assert.Equal(t, "team-a", mimir.Spec.Tenants[0].Headers["X-Scope-OrgID"])
+}
+
+func TestReconcileMatchesExistingByURLPreservingSpec(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	fake := newFakeEndpointUsecase()
+	svc := agentservice.NewEndpointDetectionService(fake, slog.Default())
+
+	// A manually-created endpoint for the same URL the otlp exporter targets.
+	manual := agentmodel.NewEndpoint("default", "my-collector", agentmodel.Attributes{}, time.Now(), "alice")
+	manual.Spec.URL = "https://otlp.example.com:4317"
+	manual.Spec.Protocol = "otlp"
+	manual.Spec.Signals = agentmodel.EndpointSignals{Metrics: false, Logs: false, Traces: false}
+	_, err := fake.SaveEndpoint(ctx, manual)
+	require.NoError(t, err)
+
+	require.NoError(t, svc.ReconcileEndpointsFromRemoteConfig(ctx, newRemoteConfig(otlpAndMimirConfig)))
+
+	// The otlp exporter matches the manual endpoint by URL (no duplicate created);
+	// only the mimir exporter is auto-created.
+	_, err = fake.GetEndpoint(ctx, "default", "obs-otlp", &model.GetOptions{IncludeDeleted: true})
+	require.ErrorIs(t, err, port.ErrResourceNotExist)
+
+	matched, err := fake.GetEndpoint(ctx, "default", "my-collector", nil)
+	require.NoError(t, err)
+	// Linked to the remote config...
+	assert.Equal(t, "default/obs", matched.Metadata.Attributes[agentservice.EndpointMatchedByAttribute])
+	// ...but its spec is preserved (signals not overwritten by the config).
+	assert.False(t, matched.Spec.Signals.Traces)
+	assert.False(t, matched.Spec.Signals.Metrics)
+	// not auto-created, so no generated-from marker.
+	assert.Empty(t, matched.Metadata.Attributes[agentservice.EndpointGeneratedFromAttribute])
+
+	list, err := fake.ListEndpoints(ctx, "default", nil)
+	require.NoError(t, err)
+	assert.Len(t, list.Items, 2) // my-collector (matched) + obs-prometheusremotewrite-mimir (created)
+}
+
+func TestReconcileNeverDeletes(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	fake := newFakeEndpointUsecase()
+	svc := agentservice.NewEndpointDetectionService(fake, slog.Default())
+
+	require.NoError(t, svc.ReconcileEndpointsFromRemoteConfig(ctx, newRemoteConfig(otlpAndMimirConfig)))
+
+	// Re-reconcile with the mimir exporter removed: its endpoint must NOT be deleted.
+	const otlpOnly = `
+exporters:
+  otlp:
+    endpoint: https://otlp.example.com:4317
+service:
+  pipelines:
+    traces:
+      exporters: [otlp]
+`
+	require.NoError(t, svc.ReconcileEndpointsFromRemoteConfig(ctx, newRemoteConfig(otlpOnly)))
+
+	list, err := fake.ListEndpoints(ctx, "default", nil)
+	require.NoError(t, err)
+	assert.Len(t, list.Items, 2, "removing an exporter must not delete its endpoint")
+}
+
+func TestReconcileParseErrorKeepsExisting(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	fake := newFakeEndpointUsecase()
+	svc := agentservice.NewEndpointDetectionService(fake, slog.Default())
+
+	require.NoError(t, svc.ReconcileEndpointsFromRemoteConfig(ctx, newRemoteConfig(otlpAndMimirConfig)))
+
+	// A subsequent broken config must error without touching existing endpoints.
+	err := svc.ReconcileEndpointsFromRemoteConfig(ctx, newRemoteConfig("\tnot: [valid"))
+	require.Error(t, err)
+
+	list, listErr := fake.ListEndpoints(ctx, "default", nil)
+	require.NoError(t, listErr)
+	assert.Len(t, list.Items, 2)
+}

--- a/pkg/apiserver/domain/agent/service/endpointdetection_test.go
+++ b/pkg/apiserver/domain/agent/service/endpointdetection_test.go
@@ -199,6 +199,74 @@ service:
 	assert.Len(t, list.Items, 2, "removing an exporter must not delete its endpoint")
 }
 
+func TestReconcileCollapsesExportersSharingURL(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	fake := newFakeEndpointUsecase()
+	svc := agentservice.NewEndpointDetectionService(fake, slog.Default())
+
+	// Two exporters point at the same URL but carry different signals; they must
+	// collapse to a single endpoint whose signals are the union.
+	const sharedURL = `
+exporters:
+  otlp/traces:
+    endpoint: https://collector.example.com:4317
+  otlphttp/metrics:
+    endpoint: https://collector.example.com:4317
+service:
+  pipelines:
+    traces:
+      exporters: [otlp/traces]
+    metrics:
+      exporters: [otlphttp/metrics]
+`
+	require.NoError(t, svc.ReconcileEndpointsFromRemoteConfig(ctx, newRemoteConfig(sharedURL)))
+
+	list, err := fake.ListEndpoints(ctx, "default", nil)
+	require.NoError(t, err)
+	require.Len(t, list.Items, 1, "exporters sharing a URL collapse to one endpoint")
+
+	endpoint := list.Items[0]
+	assert.Equal(t, "https://collector.example.com:4317", endpoint.Spec.URL)
+	// Deterministic winner is the lowest sorted key ("otlp/traces"); signals merged.
+	assert.Equal(t, "obs-otlp-traces", endpoint.Metadata.Name)
+	assert.True(t, endpoint.Spec.Signals.Traces)
+	assert.True(t, endpoint.Spec.Signals.Metrics)
+}
+
+func TestReconcileSkipsNonScalarHeaderValues(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	fake := newFakeEndpointUsecase()
+	svc := agentservice.NewEndpointDetectionService(fake, slog.Default())
+
+	// A header whose value is a mapping must be skipped, not stringified to garbage.
+	const badHeader = `
+exporters:
+  otlp:
+    endpoint: https://otlp.example.com:4317
+    headers:
+      X-Scope-OrgID: team-a
+      bad:
+        nested: value
+service:
+  pipelines:
+    metrics:
+      exporters: [otlp]
+`
+	require.NoError(t, svc.ReconcileEndpointsFromRemoteConfig(ctx, newRemoteConfig(badHeader)))
+
+	endpoint, err := fake.GetEndpoint(ctx, "default", "obs-otlp", nil)
+	require.NoError(t, err)
+	require.Len(t, endpoint.Spec.Tenants, 1)
+	headers := endpoint.Spec.Tenants[0].Headers
+	assert.Equal(t, "team-a", headers["X-Scope-OrgID"])
+	_, hasBad := headers["bad"]
+	assert.False(t, hasBad, "non-scalar header value must be skipped")
+}
+
 func TestReconcileParseErrorKeepsExisting(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/apiserver/internal/module/domain/domain.go
+++ b/pkg/apiserver/internal/module/domain/domain.go
@@ -37,6 +37,7 @@ func New() fx.Option {
 		fx.Annotate(provideContainerService, fx.As(new(agentport.ContainerUsecase))),
 		fx.Annotate(agentservice.NewAgentRemoteConfigService, fx.As(new(agentport.AgentRemoteConfigUsecase))),
 		fx.Annotate(agentservice.NewEndpointService, fx.As(new(agentport.EndpointUsecase))),
+		fx.Annotate(agentservice.NewEndpointDetectionService, fx.As(new(agentport.EndpointDetectionUsecase))),
 		fx.Annotate(agentservice.NewCertificateService, fx.As(new(agentport.CertificateUsecase))),
 		agentservice.NewServerService,
 		fx.Annotate(


### PR DESCRIPTION
## What

When an `AgentRemoteConfig` is created/updated, its OpenTelemetry Collector config is parsed and each exporter destination is **linked to an Endpoint** — matching an existing one by URL, or auto-creating one if none exists. Endpoints remain fully user-managed.

## Behavior (per product decisions)
- **Auto-create**: an exporter destination with no matching endpoint → a new Endpoint is created (`generated-from` marker).
- **Match by URL, preserve spec**: if an endpoint with the same `spec.url` already exists (manually created or otherwise), it is **linked** via an `opampcommander.io/matched-by` attribute and its spec is **left untouched** (signals/tenants not overwritten).
- **No auto-delete**: removing an exporter, or deleting the remote config, does **not** delete endpoints. A parse failure is surfaced without touching anything.
- **Full user CRUD**: users can still create/update/delete endpoints directly (the earlier read-only restriction was reverted per the updated requirement). The detector never overwrites a matched endpoint's spec and never deletes.

## How
- `EndpointDetectionService` (domain): parses `exporters` + `service.pipelines` (YAML/JSON); protocol ← exporter type, signals ← referencing pipelines, `X-Scope-OrgID` header → tenant on auto-created endpoints.
- Hooked into the `AgentRemoteConfig` service create/update (async, mirroring group propagation). No hook on delete.

## Testing
- Unit tests: auto-create (signals/tenant), match-by-URL preserving spec (no duplicate), never-deletes on exporter removal, parse-error-keeps-existing.
- `make generate`, `go build`, `make lint` (0 issues), touched-package tests.
- Manual e2e on standalone: manual create 201; ARC create → auto-creates + matches manual endpoint by URL (spec preserved); ARC update dropping an exporter → endpoints remain; ARC delete → endpoints remain; manual delete 204.

> Supersedes the earlier read-only/auto-delete approach on this branch. #439 (opampctl) and #440 (web) endpoint create/delete remain valid since endpoints keep full user CRUD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)