### PR TITLE
feat(web): apply a remote config to an agent group from the group UI

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -37,6 +37,7 @@ linters:
         # Optional list/paging filters whose zero values are meaningful defaults;
         # call sites legitimately set only the fields they care about.
         - "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model.ListOptions"
+        - "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port.ListOptions"
     ireturn:
       allow:
         - generic
@@ -131,6 +132,18 @@ linters:
           deny:
             - pkg: go.uber.org/fx
               desc: Only pkg/apiserver/internal (the composition root) may import fx.
+        adapter-primary-no-domain:
+          # Primary (driving) adapters must reach the core only through the
+          # application layer (application/port + api/v1), never the domain
+          # directly. The messaging adapters are exempt: they implement domain
+          # driven (out) ports, so depending on the domain is expected there.
+          files:
+            - "**/pkg/apiserver/adapter/primary/**"
+            - "!**/pkg/apiserver/adapter/primary/messaging/**"
+            - "!**/*_test.go"
+          deny:
+            - pkg: github.com/minuk-dev/opampcommander/pkg/apiserver/domain
+              desc: Primary adapters must go through the application layer (application/port), not import the domain directly.
         test:
           files:
             - "**/*_test.go"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,19 @@ Derived from the OpAMP agent's `service.namespace` identifying attribute; defaul
 ### Controller Registration
 Every controller implements `RoutesInfo() gin.RoutesInfo` and is auto-registered into Gin by the FX infrastructure module — no manual route wiring needed.
 
+### Adapters Depend Only on the Application Layer
+Primary (driving) adapters — HTTP controllers, auth flows — must reach the core
+only through the application layer (`application/port` + `api/v1`), never by
+importing the domain directly. This is enforced by the `adapter-primary-no-domain`
+depguard rule (the `adapter/primary/messaging` adapters are exempt because they
+implement domain driven/out ports).
+
+Each HTTP controller depends on **at most one** application use case (a single
+`...Usecase` field; trivial controllers such as `ping`/`version` may need none).
+If a handler needs a different use case, it belongs in a different controller, or
+the use cases should be composed behind one application service — not injected
+side-by-side into the controller.
+
 ### Compile-Time Interface Checks
 All service implementations include:
 ```go

--- a/pkg/apiserver/adapter/primary/http/auth/basic/controller.go
+++ b/pkg/apiserver/adapter/primary/http/auth/basic/controller.go
@@ -2,43 +2,36 @@
 package basic
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
-	"time"
 
 	"github.com/gin-gonic/gin"
 
 	v1 "github.com/minuk-dev/opampcommander/api/v1"
 	v1auth "github.com/minuk-dev/opampcommander/api/v1/auth"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/port"
-	usermodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/model"
-	userport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/port"
+	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/security"
 )
 
 // Controller is a struct that implements the basic authentication controller for the opampcommander API client.
 type Controller struct {
-	logger      *slog.Logger
-	service     *security.Service
-	userUsecase userport.UserUsecase
-	rbacUsecase userport.RBACUsecase
+	logger              *slog.Logger
+	service             *security.Service
+	provisioningUsecase applicationport.AuthProvisioningUsecase
 }
 
 // NewController creates a new instance of the Controller struct with the provided settings.
 func NewController(
 	logger *slog.Logger,
 	service *security.Service,
-	userUsecase userport.UserUsecase,
-	rbacUsecase userport.RBACUsecase,
+	provisioningUsecase applicationport.AuthProvisioningUsecase,
 ) *Controller {
 	return &Controller{
-		logger:      logger,
-		service:     service,
-		userUsecase: userUsecase,
-		rbacUsecase: rbacUsecase,
+		logger:              logger,
+		service:             service,
+		provisioningUsecase: provisioningUsecase,
 	}
 }
 
@@ -105,7 +98,12 @@ func (c *Controller) BasicAuth(ctx *gin.Context) {
 		return
 	}
 
-	c.ensureUser(ctx.Request.Context(), username, result.Email, usermodel.IdentityProviderBasic)
+	c.provisioningUsecase.EnsureUserOnLogin(ctx.Request.Context(), applicationport.LoginProvisioning{
+		Provider: applicationport.IdentityProviderBasic,
+		Username: username,
+		Email:    result.Email,
+		Groups:   nil,
+	})
 
 	ctx.JSON(http.StatusOK, v1auth.AuthnTokenResponse{
 		Token:        result.Token,
@@ -183,99 +181,4 @@ func (c *Controller) Info(ctx *gin.Context) {
 		Authenticated: user.Authenticated,
 		Email:         user.Email,
 	})
-}
-
-// ensureUser creates or updates a user record on login.
-// Always syncs provider labels (login-type) and re-applies RBAC policies so the
-// freshly-saved user picks up the built-in default role (and any matching bindings).
-// Failures are logged but do not block the login flow.
-func (c *Controller) ensureUser(ctx context.Context, username, email, provider string) {
-	existing, err := c.userUsecase.GetUserByEmail(ctx, email)
-
-	switch {
-	case err == nil && existing != nil:
-		existing.SetLabel(usermodel.LabelLoginType, provider)
-		existing.Metadata.UpdatedAt = time.Now()
-
-		saveErr := c.userUsecase.SaveUser(ctx, existing)
-		if saveErr != nil {
-			c.logger.Warn("failed to update user on login",
-				slog.String("email", email),
-				slog.Any("error", saveErr),
-			)
-
-			return
-		}
-
-		c.syncRBACPolicies(ctx, email)
-
-		return
-	case err != nil && !errors.Is(err, port.ErrResourceNotExist):
-		c.logger.Warn("failed to check user existence on login",
-			slog.String("email", email),
-			slog.Any("error", err),
-		)
-
-		return
-	}
-
-	// No active user with this email. If a soft-deleted record exists, the user was
-	// deliberately deleted: do not resurrect or duplicate it. They can still authenticate
-	// but stay without a record (RBAC denies) until an admin restores them.
-	if c.isDeletedUser(ctx, email) {
-		return
-	}
-
-	newUser := usermodel.NewUserWithIdentity(provider, username, email, username)
-	newUser.SetLabel(usermodel.LabelLoginType, provider)
-
-	saveErr := c.userUsecase.SaveUser(ctx, newUser)
-	if saveErr != nil {
-		c.logger.Warn("failed to create user on login",
-			slog.String("email", email),
-			slog.Any("error", saveErr),
-		)
-
-		return
-	}
-
-	c.syncRBACPolicies(ctx, email)
-}
-
-// isDeletedUser reports whether a soft-deleted user record exists for the email.
-// On lookup failure it returns true (fail-closed): recreating on a transient error is the
-// behaviour that produced duplicate accounts, so we'd rather skip creation and let the user retry.
-func (c *Controller) isDeletedUser(ctx context.Context, email string) bool {
-	deleted, err := c.userUsecase.GetUserByEmailIncludingDeleted(ctx, email)
-	if err != nil {
-		if errors.Is(err, port.ErrResourceNotExist) {
-			return false
-		}
-
-		c.logger.Warn("failed to check for soft-deleted user on login; skipping user creation",
-			slog.String("email", email),
-			slog.Any("error", err),
-		)
-
-		return true
-	}
-
-	c.logger.Warn("not recreating soft-deleted user on login",
-		slog.String("email", email),
-		slog.String("uid", deleted.Metadata.UID.String()),
-	)
-
-	return true
-}
-
-// syncRBACPolicies re-runs the Casbin policy sync so newly persisted users/bindings take effect.
-// Best-effort: failures are logged but do not block the login flow.
-func (c *Controller) syncRBACPolicies(ctx context.Context, email string) {
-	err := c.rbacUsecase.SyncPolicies(ctx)
-	if err != nil {
-		c.logger.Warn("failed to sync RBAC policies after login",
-			slog.String("email", email),
-			slog.Any("error", err),
-		)
-	}
 }

--- a/pkg/apiserver/adapter/primary/http/auth/github/controller.go
+++ b/pkg/apiserver/adapter/primary/http/auth/github/controller.go
@@ -2,7 +2,6 @@
 package github
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -15,32 +14,27 @@ import (
 
 	v1 "github.com/minuk-dev/opampcommander/api/v1"
 	v1auth "github.com/minuk-dev/opampcommander/api/v1/auth"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/port"
-	usermodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/model"
-	userport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/port"
+	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/security"
 )
 
 // Controller is a struct that implements the GitHub OAuth2 authentication controller.
 type Controller struct {
-	logger      *slog.Logger
-	service     *security.Service
-	userUsecase userport.UserUsecase
-	rbacUsecase userport.RBACUsecase
+	logger              *slog.Logger
+	service             *security.Service
+	provisioningUsecase applicationport.AuthProvisioningUsecase
 }
 
 // NewController creates a new instance of the Controller struct with the provided settings.
 func NewController(
 	logger *slog.Logger,
 	service *security.Service,
-	userUsecase userport.UserUsecase,
-	rbacUsecase userport.RBACUsecase,
+	provisioningUsecase applicationport.AuthProvisioningUsecase,
 ) *Controller {
 	return &Controller{
-		logger:      logger,
-		service:     service,
-		userUsecase: userUsecase,
-		rbacUsecase: rbacUsecase,
+		logger:              logger,
+		service:             service,
+		provisioningUsecase: provisioningUsecase,
 	}
 }
 
@@ -275,7 +269,12 @@ func (c *Controller) Callback(ctx *gin.Context) {
 		return
 	}
 
-	c.ensureUser(ctx.Request.Context(), result.Email, usermodel.IdentityProviderGitHub, result.Groups)
+	c.provisioningUsecase.EnsureUserOnLogin(ctx.Request.Context(), applicationport.LoginProvisioning{
+		Provider: applicationport.IdentityProviderGitHub,
+		Username: result.Email,
+		Email:    result.Email,
+		Groups:   result.Groups,
+	})
 
 	if cliRedirect != "" {
 		c.redirectToLoopback(ctx, cliRedirect, result)
@@ -368,7 +367,12 @@ func (c *Controller) ExchangeDeviceAuth(ctx *gin.Context) {
 		return
 	}
 
-	c.ensureUser(ctx.Request.Context(), result.Email, usermodel.IdentityProviderGitHub, result.Groups)
+	c.provisioningUsecase.EnsureUserOnLogin(ctx.Request.Context(), applicationport.LoginProvisioning{
+		Provider: applicationport.IdentityProviderGitHub,
+		Username: result.Email,
+		Email:    result.Email,
+		Groups:   result.Groups,
+	})
 
 	ctx.JSON(http.StatusOK, v1auth.AuthnTokenResponse{
 		Token:        result.Token,
@@ -434,121 +438,4 @@ func (c *Controller) handleCallbackError(ctx *gin.Context, cliRedirect, message 
 	target.RawQuery = params.Encode()
 
 	ctx.Redirect(http.StatusTemporaryRedirect, target.String())
-}
-
-// ensureUser creates or updates a user record on login.
-// Always syncs provider labels (login-type, github-org-*) and re-applies RBAC policies
-// so the freshly-saved user picks up the built-in default role (and any matching bindings).
-// Failures are logged but do not block the login flow.
-func (c *Controller) ensureUser(ctx context.Context, email, provider string, groups []string) {
-	existing, err := c.userUsecase.GetUserByEmail(ctx, email)
-
-	switch {
-	case err == nil && existing != nil:
-		c.syncLabels(ctx, existing, provider, groups)
-
-		existing.Metadata.UpdatedAt = time.Now()
-
-		saveErr := c.userUsecase.SaveUser(ctx, existing)
-		if saveErr != nil {
-			c.logger.Warn("failed to update user on login",
-				slog.String("email", email),
-				slog.Any("error", saveErr),
-			)
-
-			return
-		}
-
-		c.syncRBACPolicies(ctx, email)
-
-		return
-	case err != nil && !errors.Is(err, port.ErrResourceNotExist):
-		c.logger.Warn("failed to check user existence on login",
-			slog.String("email", email),
-			slog.Any("error", err),
-		)
-
-		return
-	}
-
-	// No active user with this email. If a soft-deleted record exists, the user was
-	// deliberately deleted: do not resurrect or duplicate it. They can still authenticate
-	// but stay without a record (RBAC denies) until an admin restores them.
-	if c.isDeletedUser(ctx, email) {
-		return
-	}
-
-	newUser := usermodel.NewUserWithIdentity(provider, email, email, email)
-	c.syncLabels(ctx, newUser, provider, groups)
-
-	saveErr := c.userUsecase.SaveUser(ctx, newUser)
-	if saveErr != nil {
-		c.logger.Warn("failed to create user on login",
-			slog.String("email", email),
-			slog.Any("error", saveErr),
-		)
-
-		return
-	}
-
-	c.syncRBACPolicies(ctx, email)
-}
-
-// isDeletedUser reports whether a soft-deleted user record exists for the email.
-// On lookup failure it returns true (fail-closed): recreating on a transient error is the
-// behaviour that produced duplicate accounts, so we'd rather skip creation and let the user retry.
-func (c *Controller) isDeletedUser(ctx context.Context, email string) bool {
-	deleted, err := c.userUsecase.GetUserByEmailIncludingDeleted(ctx, email)
-	if err != nil {
-		if errors.Is(err, port.ErrResourceNotExist) {
-			return false
-		}
-
-		c.logger.Warn("failed to check for soft-deleted user on login; skipping user creation",
-			slog.String("email", email),
-			slog.Any("error", err),
-		)
-
-		return true
-	}
-
-	c.logger.Warn("not recreating soft-deleted user on login",
-		slog.String("email", email),
-		slog.String("uid", deleted.Metadata.UID.String()),
-	)
-
-	return true
-}
-
-// syncRBACPolicies re-runs the Casbin policy sync so newly persisted users/bindings take effect.
-// Best-effort: failures are logged but do not block the login flow.
-func (c *Controller) syncRBACPolicies(ctx context.Context, email string) {
-	err := c.rbacUsecase.SyncPolicies(ctx)
-	if err != nil {
-		c.logger.Warn("failed to sync RBAC policies after login",
-			slog.String("email", email),
-			slog.Any("error", err),
-		)
-	}
-}
-
-// syncLabels updates the user's metadata labels to reflect the current login session.
-// Existing non-provider labels are preserved.
-func (c *Controller) syncLabels(ctx context.Context, user *usermodel.User, provider string, groups []string) {
-	_ = ctx // reserved for future use
-
-	// Remove stale provider-specific labels before re-setting
-	for key := range user.Metadata.Labels {
-		if len(key) > len(usermodel.LabelGitHubOrg) && key[:len(usermodel.LabelGitHubOrg)] == usermodel.LabelGitHubOrg {
-			delete(user.Metadata.Labels, key)
-		}
-	}
-
-	user.SetLabel(usermodel.LabelLoginType, provider)
-
-	if provider == usermodel.IdentityProviderGitHub {
-		for _, org := range groups {
-			user.SetLabel(usermodel.LabelGitHubOrg+org, "true")
-		}
-	}
 }

--- a/pkg/apiserver/adapter/primary/http/v1/agent/controller.go
+++ b/pkg/apiserver/adapter/primary/http/v1/agent/controller.go
@@ -13,7 +13,6 @@ import (
 
 	v1 "github.com/minuk-dev/opampcommander/api/v1"
 	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/ginutil"
 )
 
@@ -142,7 +141,7 @@ func (c *Controller) List(ctx *gin.Context) {
 
 	continueToken := ctx.Query("continue")
 
-	response, err := c.agentUsecase.ListAgents(ctx.Request.Context(), namespace, &model.ListOptions{
+	response, err := c.agentUsecase.ListAgents(ctx.Request.Context(), namespace, &applicationport.ListOptions{
 		Limit:                    limit,
 		Continue:                 continueToken,
 		ConnectedOnly:            connectedOnly,
@@ -220,7 +219,7 @@ func (c *Controller) Search(ctx *gin.Context) {
 
 	continueToken := ctx.Query("continue")
 
-	response, err := c.agentUsecase.SearchAgents(ctx.Request.Context(), namespace, query, &model.ListOptions{
+	response, err := c.agentUsecase.SearchAgents(ctx.Request.Context(), namespace, query, &applicationport.ListOptions{
 		Limit:         limit,
 		Continue:      continueToken,
 		ConnectedOnly: connectedOnly,

--- a/pkg/apiserver/adapter/primary/http/v1/agent/controller_test.go
+++ b/pkg/apiserver/adapter/primary/http/v1/agent/controller_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/primary/http/v1/agent"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/primary/http/v1/agent/usecasemock"
 	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/port"
 	"github.com/minuk-dev/opampcommander/pkg/testutil"
 )
@@ -96,7 +95,7 @@ func TestAgentControllerListAgent(t *testing.T) {
 		// given: repeated selector params are threaded into
 		// ListOptions.IdentifyingAttributes as exact key=value pairs.
 		agentUsecase.EXPECT().
-			ListAgents(mock.Anything, "default", mock.MatchedBy(func(opts *model.ListOptions) bool {
+			ListAgents(mock.Anything, "default", mock.MatchedBy(func(opts *applicationport.ListOptions) bool {
 				return opts != nil &&
 					opts.IdentifyingAttributes["service.name"] == "otel-collector" &&
 					opts.IdentifyingAttributes["service.namespace"] == "prod"
@@ -136,7 +135,7 @@ func TestAgentControllerListAgent(t *testing.T) {
 		// given: a single selector entry is one key=value pair, split on the first
 		// "=" only and never on commas, so the value is preserved verbatim.
 		agentUsecase.EXPECT().
-			ListAgents(mock.Anything, "default", mock.MatchedBy(func(opts *model.ListOptions) bool {
+			ListAgents(mock.Anything, "default", mock.MatchedBy(func(opts *applicationport.ListOptions) bool {
 				return opts != nil &&
 					opts.IdentifyingAttributes["service.instance.id"] == "a,b=c"
 			})).
@@ -290,7 +289,7 @@ func TestAgentControllerListAgentSelectorThreading(t *testing.T) {
 
 	// given: selector and nonIdentifyingSelector map to their own attribute sets.
 	agentUsecase.EXPECT().
-		ListAgents(mock.Anything, "default", mock.MatchedBy(func(opts *model.ListOptions) bool {
+		ListAgents(mock.Anything, "default", mock.MatchedBy(func(opts *applicationport.ListOptions) bool {
 			return opts != nil &&
 				opts.IdentifyingAttributes["service.name"] == "otel-collector" &&
 				opts.NonIdentifyingAttributes["os.type"] == "linux"

--- a/pkg/apiserver/adapter/primary/http/v1/agent/usecasemock/mocks.go
+++ b/pkg/apiserver/adapter/primary/http/v1/agent/usecasemock/mocks.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/minuk-dev/opampcommander/api/v1"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -252,7 +252,7 @@ func (_c *MockManageUsecase_ListAgentEndpoints_Call) RunAndReturn(run func(ctx c
 }
 
 // ListAgents provides a mock function for the type MockManageUsecase
-func (_mock *MockManageUsecase) ListAgents(ctx context.Context, namespace string, options *model.ListOptions) (*v1.ListResponse[v1.Agent], error) {
+func (_mock *MockManageUsecase) ListAgents(ctx context.Context, namespace string, options *port.ListOptions) (*v1.ListResponse[v1.Agent], error) {
 	ret := _mock.Called(ctx, namespace, options)
 
 	if len(ret) == 0 {
@@ -261,17 +261,17 @@ func (_mock *MockManageUsecase) ListAgents(ctx context.Context, namespace string
 
 	var r0 *v1.ListResponse[v1.Agent]
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *model.ListOptions) (*v1.ListResponse[v1.Agent], error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *port.ListOptions) (*v1.ListResponse[v1.Agent], error)); ok {
 		return returnFunc(ctx, namespace, options)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *model.ListOptions) *v1.ListResponse[v1.Agent]); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *port.ListOptions) *v1.ListResponse[v1.Agent]); ok {
 		r0 = returnFunc(ctx, namespace, options)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*v1.ListResponse[v1.Agent])
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *model.ListOptions) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *port.ListOptions) error); ok {
 		r1 = returnFunc(ctx, namespace, options)
 	} else {
 		r1 = ret.Error(1)
@@ -287,12 +287,12 @@ type MockManageUsecase_ListAgents_Call struct {
 // ListAgents is a helper method to define mock.On call
 //   - ctx context.Context
 //   - namespace string
-//   - options *model.ListOptions
+//   - options *port.ListOptions
 func (_e *MockManageUsecase_Expecter) ListAgents(ctx interface{}, namespace interface{}, options interface{}) *MockManageUsecase_ListAgents_Call {
 	return &MockManageUsecase_ListAgents_Call{Call: _e.mock.On("ListAgents", ctx, namespace, options)}
 }
 
-func (_c *MockManageUsecase_ListAgents_Call) Run(run func(ctx context.Context, namespace string, options *model.ListOptions)) *MockManageUsecase_ListAgents_Call {
+func (_c *MockManageUsecase_ListAgents_Call) Run(run func(ctx context.Context, namespace string, options *port.ListOptions)) *MockManageUsecase_ListAgents_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -302,9 +302,9 @@ func (_c *MockManageUsecase_ListAgents_Call) Run(run func(ctx context.Context, n
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 *model.ListOptions
+		var arg2 *port.ListOptions
 		if args[2] != nil {
-			arg2 = args[2].(*model.ListOptions)
+			arg2 = args[2].(*port.ListOptions)
 		}
 		run(
 			arg0,
@@ -320,13 +320,13 @@ func (_c *MockManageUsecase_ListAgents_Call) Return(listResponse *v1.ListRespons
 	return _c
 }
 
-func (_c *MockManageUsecase_ListAgents_Call) RunAndReturn(run func(ctx context.Context, namespace string, options *model.ListOptions) (*v1.ListResponse[v1.Agent], error)) *MockManageUsecase_ListAgents_Call {
+func (_c *MockManageUsecase_ListAgents_Call) RunAndReturn(run func(ctx context.Context, namespace string, options *port.ListOptions) (*v1.ListResponse[v1.Agent], error)) *MockManageUsecase_ListAgents_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // SearchAgents provides a mock function for the type MockManageUsecase
-func (_mock *MockManageUsecase) SearchAgents(ctx context.Context, namespace string, query string, options *model.ListOptions) (*v1.ListResponse[v1.Agent], error) {
+func (_mock *MockManageUsecase) SearchAgents(ctx context.Context, namespace string, query string, options *port.ListOptions) (*v1.ListResponse[v1.Agent], error) {
 	ret := _mock.Called(ctx, namespace, query, options)
 
 	if len(ret) == 0 {
@@ -335,17 +335,17 @@ func (_mock *MockManageUsecase) SearchAgents(ctx context.Context, namespace stri
 
 	var r0 *v1.ListResponse[v1.Agent]
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *model.ListOptions) (*v1.ListResponse[v1.Agent], error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *port.ListOptions) (*v1.ListResponse[v1.Agent], error)); ok {
 		return returnFunc(ctx, namespace, query, options)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *model.ListOptions) *v1.ListResponse[v1.Agent]); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *port.ListOptions) *v1.ListResponse[v1.Agent]); ok {
 		r0 = returnFunc(ctx, namespace, query, options)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*v1.ListResponse[v1.Agent])
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, *model.ListOptions) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, *port.ListOptions) error); ok {
 		r1 = returnFunc(ctx, namespace, query, options)
 	} else {
 		r1 = ret.Error(1)
@@ -362,12 +362,12 @@ type MockManageUsecase_SearchAgents_Call struct {
 //   - ctx context.Context
 //   - namespace string
 //   - query string
-//   - options *model.ListOptions
+//   - options *port.ListOptions
 func (_e *MockManageUsecase_Expecter) SearchAgents(ctx interface{}, namespace interface{}, query interface{}, options interface{}) *MockManageUsecase_SearchAgents_Call {
 	return &MockManageUsecase_SearchAgents_Call{Call: _e.mock.On("SearchAgents", ctx, namespace, query, options)}
 }
 
-func (_c *MockManageUsecase_SearchAgents_Call) Run(run func(ctx context.Context, namespace string, query string, options *model.ListOptions)) *MockManageUsecase_SearchAgents_Call {
+func (_c *MockManageUsecase_SearchAgents_Call) Run(run func(ctx context.Context, namespace string, query string, options *port.ListOptions)) *MockManageUsecase_SearchAgents_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -381,9 +381,9 @@ func (_c *MockManageUsecase_SearchAgents_Call) Run(run func(ctx context.Context,
 		if args[2] != nil {
 			arg2 = args[2].(string)
 		}
-		var arg3 *model.ListOptions
+		var arg3 *port.ListOptions
 		if args[3] != nil {
-			arg3 = args[3].(*model.ListOptions)
+			arg3 = args[3].(*port.ListOptions)
 		}
 		run(
 			arg0,
@@ -400,7 +400,7 @@ func (_c *MockManageUsecase_SearchAgents_Call) Return(listResponse *v1.ListRespo
 	return _c
 }
 
-func (_c *MockManageUsecase_SearchAgents_Call) RunAndReturn(run func(ctx context.Context, namespace string, query string, options *model.ListOptions) (*v1.ListResponse[v1.Agent], error)) *MockManageUsecase_SearchAgents_Call {
+func (_c *MockManageUsecase_SearchAgents_Call) RunAndReturn(run func(ctx context.Context, namespace string, query string, options *port.ListOptions) (*v1.ListResponse[v1.Agent], error)) *MockManageUsecase_SearchAgents_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/apiserver/adapter/primary/http/v1/agentgroup/controller.go
+++ b/pkg/apiserver/adapter/primary/http/v1/agentgroup/controller.go
@@ -10,7 +10,6 @@ import (
 
 	v1 "github.com/minuk-dev/opampcommander/api/v1"
 	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/ginutil"
 )
 
@@ -110,7 +109,7 @@ func (c *Controller) List(ctx *gin.Context) {
 		return
 	}
 
-	response, err := c.agentGroupUsecase.ListAgentGroups(ctx.Request.Context(), &model.ListOptions{
+	response, err := c.agentGroupUsecase.ListAgentGroups(ctx.Request.Context(), &applicationport.ListOptions{
 		Limit:          limit,
 		Continue:       continueToken,
 		IncludeDeleted: includeDeleted,
@@ -162,9 +161,10 @@ func (c *Controller) Get(ctx *gin.Context) {
 		return
 	}
 
-	agentGroup, err := c.agentGroupUsecase.GetAgentGroup(ctx.Request.Context(), namespace, name, &model.GetOptions{
-		IncludeDeleted: includeDeleted,
-	})
+	agentGroup, err := c.agentGroupUsecase.GetAgentGroup(
+		ctx.Request.Context(), namespace, name, &applicationport.GetOptions{
+			IncludeDeleted: includeDeleted,
+		})
 	if err != nil {
 		c.logger.Error("failed to get agent group", "error", err.Error())
 		ginutil.HandleDomainError(ctx, err, "An error occurred while retrieving the agent group.")
@@ -217,11 +217,12 @@ func (c *Controller) ListAgentsByAgentGroup(ctx *gin.Context) {
 		return
 	}
 
-	agents, err := c.agentGroupUsecase.ListAgentsByAgentGroup(ctx.Request.Context(), namespace, name, &model.ListOptions{
-		Limit:         limit,
-		Continue:      continueToken,
-		ConnectedOnly: connectedOnly,
-	})
+	agents, err := c.agentGroupUsecase.ListAgentsByAgentGroup(
+		ctx.Request.Context(), namespace, name, &applicationport.ListOptions{
+			Limit:         limit,
+			Continue:      continueToken,
+			ConnectedOnly: connectedOnly,
+		})
 	if err != nil {
 		c.logger.Error("failed to get agents by agent group", "error", err.Error())
 		ginutil.HandleDomainError(ctx, err, "An error occurred while retrieving the agents for the agent group.")

--- a/pkg/apiserver/adapter/primary/http/v1/agentgroup/usecasemock/mocks.go
+++ b/pkg/apiserver/adapter/primary/http/v1/agentgroup/usecasemock/mocks.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/minuk-dev/opampcommander/api/v1"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -172,7 +172,7 @@ func (_c *MockUsecase_DeleteAgentGroup_Call) RunAndReturn(run func(ctx context.C
 }
 
 // GetAgentGroup provides a mock function for the type MockUsecase
-func (_mock *MockUsecase) GetAgentGroup(ctx context.Context, namespace string, name string, options *model.GetOptions) (*v1.AgentGroup, error) {
+func (_mock *MockUsecase) GetAgentGroup(ctx context.Context, namespace string, name string, options *port.GetOptions) (*v1.AgentGroup, error) {
 	ret := _mock.Called(ctx, namespace, name, options)
 
 	if len(ret) == 0 {
@@ -181,17 +181,17 @@ func (_mock *MockUsecase) GetAgentGroup(ctx context.Context, namespace string, n
 
 	var r0 *v1.AgentGroup
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *model.GetOptions) (*v1.AgentGroup, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *port.GetOptions) (*v1.AgentGroup, error)); ok {
 		return returnFunc(ctx, namespace, name, options)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *model.GetOptions) *v1.AgentGroup); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *port.GetOptions) *v1.AgentGroup); ok {
 		r0 = returnFunc(ctx, namespace, name, options)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*v1.AgentGroup)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, *model.GetOptions) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, *port.GetOptions) error); ok {
 		r1 = returnFunc(ctx, namespace, name, options)
 	} else {
 		r1 = ret.Error(1)
@@ -208,12 +208,12 @@ type MockUsecase_GetAgentGroup_Call struct {
 //   - ctx context.Context
 //   - namespace string
 //   - name string
-//   - options *model.GetOptions
+//   - options *port.GetOptions
 func (_e *MockUsecase_Expecter) GetAgentGroup(ctx interface{}, namespace interface{}, name interface{}, options interface{}) *MockUsecase_GetAgentGroup_Call {
 	return &MockUsecase_GetAgentGroup_Call{Call: _e.mock.On("GetAgentGroup", ctx, namespace, name, options)}
 }
 
-func (_c *MockUsecase_GetAgentGroup_Call) Run(run func(ctx context.Context, namespace string, name string, options *model.GetOptions)) *MockUsecase_GetAgentGroup_Call {
+func (_c *MockUsecase_GetAgentGroup_Call) Run(run func(ctx context.Context, namespace string, name string, options *port.GetOptions)) *MockUsecase_GetAgentGroup_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -227,9 +227,9 @@ func (_c *MockUsecase_GetAgentGroup_Call) Run(run func(ctx context.Context, name
 		if args[2] != nil {
 			arg2 = args[2].(string)
 		}
-		var arg3 *model.GetOptions
+		var arg3 *port.GetOptions
 		if args[3] != nil {
-			arg3 = args[3].(*model.GetOptions)
+			arg3 = args[3].(*port.GetOptions)
 		}
 		run(
 			arg0,
@@ -246,13 +246,13 @@ func (_c *MockUsecase_GetAgentGroup_Call) Return(agentGroup *v1.AgentGroup, err 
 	return _c
 }
 
-func (_c *MockUsecase_GetAgentGroup_Call) RunAndReturn(run func(ctx context.Context, namespace string, name string, options *model.GetOptions) (*v1.AgentGroup, error)) *MockUsecase_GetAgentGroup_Call {
+func (_c *MockUsecase_GetAgentGroup_Call) RunAndReturn(run func(ctx context.Context, namespace string, name string, options *port.GetOptions) (*v1.AgentGroup, error)) *MockUsecase_GetAgentGroup_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ListAgentGroups provides a mock function for the type MockUsecase
-func (_mock *MockUsecase) ListAgentGroups(ctx context.Context, options *model.ListOptions) (*v1.ListResponse[v1.AgentGroup], error) {
+func (_mock *MockUsecase) ListAgentGroups(ctx context.Context, options *port.ListOptions) (*v1.ListResponse[v1.AgentGroup], error) {
 	ret := _mock.Called(ctx, options)
 
 	if len(ret) == 0 {
@@ -261,17 +261,17 @@ func (_mock *MockUsecase) ListAgentGroups(ctx context.Context, options *model.Li
 
 	var r0 *v1.ListResponse[v1.AgentGroup]
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *model.ListOptions) (*v1.ListResponse[v1.AgentGroup], error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *port.ListOptions) (*v1.ListResponse[v1.AgentGroup], error)); ok {
 		return returnFunc(ctx, options)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *model.ListOptions) *v1.ListResponse[v1.AgentGroup]); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *port.ListOptions) *v1.ListResponse[v1.AgentGroup]); ok {
 		r0 = returnFunc(ctx, options)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*v1.ListResponse[v1.AgentGroup])
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, *model.ListOptions) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *port.ListOptions) error); ok {
 		r1 = returnFunc(ctx, options)
 	} else {
 		r1 = ret.Error(1)
@@ -286,20 +286,20 @@ type MockUsecase_ListAgentGroups_Call struct {
 
 // ListAgentGroups is a helper method to define mock.On call
 //   - ctx context.Context
-//   - options *model.ListOptions
+//   - options *port.ListOptions
 func (_e *MockUsecase_Expecter) ListAgentGroups(ctx interface{}, options interface{}) *MockUsecase_ListAgentGroups_Call {
 	return &MockUsecase_ListAgentGroups_Call{Call: _e.mock.On("ListAgentGroups", ctx, options)}
 }
 
-func (_c *MockUsecase_ListAgentGroups_Call) Run(run func(ctx context.Context, options *model.ListOptions)) *MockUsecase_ListAgentGroups_Call {
+func (_c *MockUsecase_ListAgentGroups_Call) Run(run func(ctx context.Context, options *port.ListOptions)) *MockUsecase_ListAgentGroups_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 *model.ListOptions
+		var arg1 *port.ListOptions
 		if args[1] != nil {
-			arg1 = args[1].(*model.ListOptions)
+			arg1 = args[1].(*port.ListOptions)
 		}
 		run(
 			arg0,
@@ -314,7 +314,7 @@ func (_c *MockUsecase_ListAgentGroups_Call) Return(listResponse *v1.ListResponse
 	return _c
 }
 
-func (_c *MockUsecase_ListAgentGroups_Call) RunAndReturn(run func(ctx context.Context, options *model.ListOptions) (*v1.ListResponse[v1.AgentGroup], error)) *MockUsecase_ListAgentGroups_Call {
+func (_c *MockUsecase_ListAgentGroups_Call) RunAndReturn(run func(ctx context.Context, options *port.ListOptions) (*v1.ListResponse[v1.AgentGroup], error)) *MockUsecase_ListAgentGroups_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -394,7 +394,7 @@ func (_c *MockUsecase_ListAgentGroupsByAgent_Call) RunAndReturn(run func(ctx con
 }
 
 // ListAgentsByAgentGroup provides a mock function for the type MockUsecase
-func (_mock *MockUsecase) ListAgentsByAgentGroup(ctx context.Context, namespace string, agentGroupName string, options *model.ListOptions) (*v1.ListResponse[v1.Agent], error) {
+func (_mock *MockUsecase) ListAgentsByAgentGroup(ctx context.Context, namespace string, agentGroupName string, options *port.ListOptions) (*v1.ListResponse[v1.Agent], error) {
 	ret := _mock.Called(ctx, namespace, agentGroupName, options)
 
 	if len(ret) == 0 {
@@ -403,17 +403,17 @@ func (_mock *MockUsecase) ListAgentsByAgentGroup(ctx context.Context, namespace 
 
 	var r0 *v1.ListResponse[v1.Agent]
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *model.ListOptions) (*v1.ListResponse[v1.Agent], error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *port.ListOptions) (*v1.ListResponse[v1.Agent], error)); ok {
 		return returnFunc(ctx, namespace, agentGroupName, options)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *model.ListOptions) *v1.ListResponse[v1.Agent]); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *port.ListOptions) *v1.ListResponse[v1.Agent]); ok {
 		r0 = returnFunc(ctx, namespace, agentGroupName, options)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*v1.ListResponse[v1.Agent])
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, *model.ListOptions) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, *port.ListOptions) error); ok {
 		r1 = returnFunc(ctx, namespace, agentGroupName, options)
 	} else {
 		r1 = ret.Error(1)
@@ -430,12 +430,12 @@ type MockUsecase_ListAgentsByAgentGroup_Call struct {
 //   - ctx context.Context
 //   - namespace string
 //   - agentGroupName string
-//   - options *model.ListOptions
+//   - options *port.ListOptions
 func (_e *MockUsecase_Expecter) ListAgentsByAgentGroup(ctx interface{}, namespace interface{}, agentGroupName interface{}, options interface{}) *MockUsecase_ListAgentsByAgentGroup_Call {
 	return &MockUsecase_ListAgentsByAgentGroup_Call{Call: _e.mock.On("ListAgentsByAgentGroup", ctx, namespace, agentGroupName, options)}
 }
 
-func (_c *MockUsecase_ListAgentsByAgentGroup_Call) Run(run func(ctx context.Context, namespace string, agentGroupName string, options *model.ListOptions)) *MockUsecase_ListAgentsByAgentGroup_Call {
+func (_c *MockUsecase_ListAgentsByAgentGroup_Call) Run(run func(ctx context.Context, namespace string, agentGroupName string, options *port.ListOptions)) *MockUsecase_ListAgentsByAgentGroup_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -449,9 +449,9 @@ func (_c *MockUsecase_ListAgentsByAgentGroup_Call) Run(run func(ctx context.Cont
 		if args[2] != nil {
 			arg2 = args[2].(string)
 		}
-		var arg3 *model.ListOptions
+		var arg3 *port.ListOptions
 		if args[3] != nil {
-			arg3 = args[3].(*model.ListOptions)
+			arg3 = args[3].(*port.ListOptions)
 		}
 		run(
 			arg0,
@@ -468,7 +468,7 @@ func (_c *MockUsecase_ListAgentsByAgentGroup_Call) Return(listResponse *v1.ListR
 	return _c
 }
 
-func (_c *MockUsecase_ListAgentsByAgentGroup_Call) RunAndReturn(run func(ctx context.Context, namespace string, agentGroupName string, options *model.ListOptions) (*v1.ListResponse[v1.Agent], error)) *MockUsecase_ListAgentsByAgentGroup_Call {
+func (_c *MockUsecase_ListAgentsByAgentGroup_Call) RunAndReturn(run func(ctx context.Context, namespace string, agentGroupName string, options *port.ListOptions) (*v1.ListResponse[v1.Agent], error)) *MockUsecase_ListAgentsByAgentGroup_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/apiserver/adapter/primary/http/v1/agentpackage/controller.go
+++ b/pkg/apiserver/adapter/primary/http/v1/agentpackage/controller.go
@@ -9,7 +9,6 @@ import (
 
 	v1 "github.com/minuk-dev/opampcommander/api/v1"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/ginutil"
 )
 
@@ -99,7 +98,7 @@ func (c *Controller) List(ctx *gin.Context) {
 		return
 	}
 
-	response, err := c.agentpackageUsecase.ListAgentPackages(ctx.Request.Context(), &model.ListOptions{
+	response, err := c.agentpackageUsecase.ListAgentPackages(ctx.Request.Context(), &port.ListOptions{
 		Limit:          limit,
 		Continue:       continueToken,
 		IncludeDeleted: includeDeleted,
@@ -149,7 +148,7 @@ func (c *Controller) Get(ctx *gin.Context) {
 		return
 	}
 
-	agentPackage, err := c.agentpackageUsecase.GetAgentPackage(ctx.Request.Context(), namespace, name, &model.GetOptions{
+	agentPackage, err := c.agentpackageUsecase.GetAgentPackage(ctx.Request.Context(), namespace, name, &port.GetOptions{
 		IncludeDeleted: includeDeleted,
 	})
 	if err != nil {

--- a/pkg/apiserver/adapter/primary/http/v1/agentpackage/usecasemock/mocks.go
+++ b/pkg/apiserver/adapter/primary/http/v1/agentpackage/usecasemock/mocks.go
@@ -8,7 +8,7 @@ import (
 	"context"
 
 	"github.com/minuk-dev/opampcommander/api/v1"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -171,7 +171,7 @@ func (_c *MockUsecase_DeleteAgentPackage_Call) RunAndReturn(run func(ctx context
 }
 
 // GetAgentPackage provides a mock function for the type MockUsecase
-func (_mock *MockUsecase) GetAgentPackage(ctx context.Context, namespace string, name string, options *model.GetOptions) (*v1.AgentPackage, error) {
+func (_mock *MockUsecase) GetAgentPackage(ctx context.Context, namespace string, name string, options *port.GetOptions) (*v1.AgentPackage, error) {
 	ret := _mock.Called(ctx, namespace, name, options)
 
 	if len(ret) == 0 {
@@ -180,17 +180,17 @@ func (_mock *MockUsecase) GetAgentPackage(ctx context.Context, namespace string,
 
 	var r0 *v1.AgentPackage
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *model.GetOptions) (*v1.AgentPackage, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *port.GetOptions) (*v1.AgentPackage, error)); ok {
 		return returnFunc(ctx, namespace, name, options)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *model.GetOptions) *v1.AgentPackage); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *port.GetOptions) *v1.AgentPackage); ok {
 		r0 = returnFunc(ctx, namespace, name, options)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*v1.AgentPackage)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, *model.GetOptions) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, *port.GetOptions) error); ok {
 		r1 = returnFunc(ctx, namespace, name, options)
 	} else {
 		r1 = ret.Error(1)
@@ -207,12 +207,12 @@ type MockUsecase_GetAgentPackage_Call struct {
 //   - ctx context.Context
 //   - namespace string
 //   - name string
-//   - options *model.GetOptions
+//   - options *port.GetOptions
 func (_e *MockUsecase_Expecter) GetAgentPackage(ctx interface{}, namespace interface{}, name interface{}, options interface{}) *MockUsecase_GetAgentPackage_Call {
 	return &MockUsecase_GetAgentPackage_Call{Call: _e.mock.On("GetAgentPackage", ctx, namespace, name, options)}
 }
 
-func (_c *MockUsecase_GetAgentPackage_Call) Run(run func(ctx context.Context, namespace string, name string, options *model.GetOptions)) *MockUsecase_GetAgentPackage_Call {
+func (_c *MockUsecase_GetAgentPackage_Call) Run(run func(ctx context.Context, namespace string, name string, options *port.GetOptions)) *MockUsecase_GetAgentPackage_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -226,9 +226,9 @@ func (_c *MockUsecase_GetAgentPackage_Call) Run(run func(ctx context.Context, na
 		if args[2] != nil {
 			arg2 = args[2].(string)
 		}
-		var arg3 *model.GetOptions
+		var arg3 *port.GetOptions
 		if args[3] != nil {
-			arg3 = args[3].(*model.GetOptions)
+			arg3 = args[3].(*port.GetOptions)
 		}
 		run(
 			arg0,
@@ -245,13 +245,13 @@ func (_c *MockUsecase_GetAgentPackage_Call) Return(agentPackage *v1.AgentPackage
 	return _c
 }
 
-func (_c *MockUsecase_GetAgentPackage_Call) RunAndReturn(run func(ctx context.Context, namespace string, name string, options *model.GetOptions) (*v1.AgentPackage, error)) *MockUsecase_GetAgentPackage_Call {
+func (_c *MockUsecase_GetAgentPackage_Call) RunAndReturn(run func(ctx context.Context, namespace string, name string, options *port.GetOptions) (*v1.AgentPackage, error)) *MockUsecase_GetAgentPackage_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ListAgentPackages provides a mock function for the type MockUsecase
-func (_mock *MockUsecase) ListAgentPackages(ctx context.Context, options *model.ListOptions) (*v1.ListResponse[v1.AgentPackage], error) {
+func (_mock *MockUsecase) ListAgentPackages(ctx context.Context, options *port.ListOptions) (*v1.ListResponse[v1.AgentPackage], error) {
 	ret := _mock.Called(ctx, options)
 
 	if len(ret) == 0 {
@@ -260,17 +260,17 @@ func (_mock *MockUsecase) ListAgentPackages(ctx context.Context, options *model.
 
 	var r0 *v1.ListResponse[v1.AgentPackage]
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *model.ListOptions) (*v1.ListResponse[v1.AgentPackage], error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *port.ListOptions) (*v1.ListResponse[v1.AgentPackage], error)); ok {
 		return returnFunc(ctx, options)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *model.ListOptions) *v1.ListResponse[v1.AgentPackage]); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *port.ListOptions) *v1.ListResponse[v1.AgentPackage]); ok {
 		r0 = returnFunc(ctx, options)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*v1.ListResponse[v1.AgentPackage])
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, *model.ListOptions) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *port.ListOptions) error); ok {
 		r1 = returnFunc(ctx, options)
 	} else {
 		r1 = ret.Error(1)
@@ -285,20 +285,20 @@ type MockUsecase_ListAgentPackages_Call struct {
 
 // ListAgentPackages is a helper method to define mock.On call
 //   - ctx context.Context
-//   - options *model.ListOptions
+//   - options *port.ListOptions
 func (_e *MockUsecase_Expecter) ListAgentPackages(ctx interface{}, options interface{}) *MockUsecase_ListAgentPackages_Call {
 	return &MockUsecase_ListAgentPackages_Call{Call: _e.mock.On("ListAgentPackages", ctx, options)}
 }
 
-func (_c *MockUsecase_ListAgentPackages_Call) Run(run func(ctx context.Context, options *model.ListOptions)) *MockUsecase_ListAgentPackages_Call {
+func (_c *MockUsecase_ListAgentPackages_Call) Run(run func(ctx context.Context, options *port.ListOptions)) *MockUsecase_ListAgentPackages_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 *model.ListOptions
+		var arg1 *port.ListOptions
 		if args[1] != nil {
-			arg1 = args[1].(*model.ListOptions)
+			arg1 = args[1].(*port.ListOptions)
 		}
 		run(
 			arg0,
@@ -313,7 +313,7 @@ func (_c *MockUsecase_ListAgentPackages_Call) Return(listResponse *v1.ListRespon
 	return _c
 }
 
-func (_c *MockUsecase_ListAgentPackages_Call) RunAndReturn(run func(ctx context.Context, options *model.ListOptions) (*v1.ListResponse[v1.AgentPackage], error)) *MockUsecase_ListAgentPackages_Call {
+func (_c *MockUsecase_ListAgentPackages_Call) RunAndReturn(run func(ctx context.Context, options *port.ListOptions) (*v1.ListResponse[v1.AgentPackage], error)) *MockUsecase_ListAgentPackages_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/apiserver/adapter/primary/http/v1/agentremoteconfig/controller.go
+++ b/pkg/apiserver/adapter/primary/http/v1/agentremoteconfig/controller.go
@@ -9,7 +9,6 @@ import (
 
 	v1 "github.com/minuk-dev/opampcommander/api/v1"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/ginutil"
 )
 
@@ -92,7 +91,7 @@ func (c *Controller) List(ctx *gin.Context) {
 	}
 
 	response, err := c.agentRemoteConfigUsecase.ListAgentRemoteConfigs(
-		ctx.Request.Context(), &model.ListOptions{
+		ctx.Request.Context(), &port.ListOptions{
 			Limit:          limit,
 			Continue:       continueToken,
 			IncludeDeleted: includeDeleted,
@@ -143,7 +142,7 @@ func (c *Controller) Get(ctx *gin.Context) {
 	}
 
 	config, err := c.agentRemoteConfigUsecase.GetAgentRemoteConfig(
-		ctx.Request.Context(), namespace, name, &model.GetOptions{
+		ctx.Request.Context(), namespace, name, &port.GetOptions{
 			IncludeDeleted: includeDeleted,
 		},
 	)

--- a/pkg/apiserver/adapter/primary/http/v1/certificate/controller.go
+++ b/pkg/apiserver/adapter/primary/http/v1/certificate/controller.go
@@ -9,7 +9,6 @@ import (
 
 	v1 "github.com/minuk-dev/opampcommander/api/v1"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/ginutil"
 )
 
@@ -99,7 +98,7 @@ func (c *Controller) List(ctx *gin.Context) {
 		return
 	}
 
-	response, err := c.certificateUsecase.ListCertificates(ctx.Request.Context(), &model.ListOptions{
+	response, err := c.certificateUsecase.ListCertificates(ctx.Request.Context(), &port.ListOptions{
 		Limit:          limit,
 		Continue:       continueToken,
 		IncludeDeleted: includeDeleted,
@@ -149,7 +148,7 @@ func (c *Controller) Get(ctx *gin.Context) {
 		return
 	}
 
-	certificate, err := c.certificateUsecase.GetCertificate(ctx.Request.Context(), namespace, name, &model.GetOptions{
+	certificate, err := c.certificateUsecase.GetCertificate(ctx.Request.Context(), namespace, name, &port.GetOptions{
 		IncludeDeleted: includeDeleted,
 	})
 	if err != nil {

--- a/pkg/apiserver/adapter/primary/http/v1/certificate/usecasemock/mocks.go
+++ b/pkg/apiserver/adapter/primary/http/v1/certificate/usecasemock/mocks.go
@@ -8,7 +8,7 @@ import (
 	"context"
 
 	"github.com/minuk-dev/opampcommander/api/v1"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -171,7 +171,7 @@ func (_c *MockUsecase_DeleteCertificate_Call) RunAndReturn(run func(ctx context.
 }
 
 // GetCertificate provides a mock function for the type MockUsecase
-func (_mock *MockUsecase) GetCertificate(ctx context.Context, namespace string, name string, options *model.GetOptions) (*v1.Certificate, error) {
+func (_mock *MockUsecase) GetCertificate(ctx context.Context, namespace string, name string, options *port.GetOptions) (*v1.Certificate, error) {
 	ret := _mock.Called(ctx, namespace, name, options)
 
 	if len(ret) == 0 {
@@ -180,17 +180,17 @@ func (_mock *MockUsecase) GetCertificate(ctx context.Context, namespace string, 
 
 	var r0 *v1.Certificate
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *model.GetOptions) (*v1.Certificate, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *port.GetOptions) (*v1.Certificate, error)); ok {
 		return returnFunc(ctx, namespace, name, options)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *model.GetOptions) *v1.Certificate); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *port.GetOptions) *v1.Certificate); ok {
 		r0 = returnFunc(ctx, namespace, name, options)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*v1.Certificate)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, *model.GetOptions) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, *port.GetOptions) error); ok {
 		r1 = returnFunc(ctx, namespace, name, options)
 	} else {
 		r1 = ret.Error(1)
@@ -207,12 +207,12 @@ type MockUsecase_GetCertificate_Call struct {
 //   - ctx context.Context
 //   - namespace string
 //   - name string
-//   - options *model.GetOptions
+//   - options *port.GetOptions
 func (_e *MockUsecase_Expecter) GetCertificate(ctx interface{}, namespace interface{}, name interface{}, options interface{}) *MockUsecase_GetCertificate_Call {
 	return &MockUsecase_GetCertificate_Call{Call: _e.mock.On("GetCertificate", ctx, namespace, name, options)}
 }
 
-func (_c *MockUsecase_GetCertificate_Call) Run(run func(ctx context.Context, namespace string, name string, options *model.GetOptions)) *MockUsecase_GetCertificate_Call {
+func (_c *MockUsecase_GetCertificate_Call) Run(run func(ctx context.Context, namespace string, name string, options *port.GetOptions)) *MockUsecase_GetCertificate_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -226,9 +226,9 @@ func (_c *MockUsecase_GetCertificate_Call) Run(run func(ctx context.Context, nam
 		if args[2] != nil {
 			arg2 = args[2].(string)
 		}
-		var arg3 *model.GetOptions
+		var arg3 *port.GetOptions
 		if args[3] != nil {
-			arg3 = args[3].(*model.GetOptions)
+			arg3 = args[3].(*port.GetOptions)
 		}
 		run(
 			arg0,
@@ -245,13 +245,13 @@ func (_c *MockUsecase_GetCertificate_Call) Return(certificate *v1.Certificate, e
 	return _c
 }
 
-func (_c *MockUsecase_GetCertificate_Call) RunAndReturn(run func(ctx context.Context, namespace string, name string, options *model.GetOptions) (*v1.Certificate, error)) *MockUsecase_GetCertificate_Call {
+func (_c *MockUsecase_GetCertificate_Call) RunAndReturn(run func(ctx context.Context, namespace string, name string, options *port.GetOptions) (*v1.Certificate, error)) *MockUsecase_GetCertificate_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ListCertificates provides a mock function for the type MockUsecase
-func (_mock *MockUsecase) ListCertificates(ctx context.Context, options *model.ListOptions) (*v1.ListResponse[v1.Certificate], error) {
+func (_mock *MockUsecase) ListCertificates(ctx context.Context, options *port.ListOptions) (*v1.ListResponse[v1.Certificate], error) {
 	ret := _mock.Called(ctx, options)
 
 	if len(ret) == 0 {
@@ -260,17 +260,17 @@ func (_mock *MockUsecase) ListCertificates(ctx context.Context, options *model.L
 
 	var r0 *v1.ListResponse[v1.Certificate]
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *model.ListOptions) (*v1.ListResponse[v1.Certificate], error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *port.ListOptions) (*v1.ListResponse[v1.Certificate], error)); ok {
 		return returnFunc(ctx, options)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *model.ListOptions) *v1.ListResponse[v1.Certificate]); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *port.ListOptions) *v1.ListResponse[v1.Certificate]); ok {
 		r0 = returnFunc(ctx, options)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*v1.ListResponse[v1.Certificate])
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, *model.ListOptions) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *port.ListOptions) error); ok {
 		r1 = returnFunc(ctx, options)
 	} else {
 		r1 = ret.Error(1)
@@ -285,20 +285,20 @@ type MockUsecase_ListCertificates_Call struct {
 
 // ListCertificates is a helper method to define mock.On call
 //   - ctx context.Context
-//   - options *model.ListOptions
+//   - options *port.ListOptions
 func (_e *MockUsecase_Expecter) ListCertificates(ctx interface{}, options interface{}) *MockUsecase_ListCertificates_Call {
 	return &MockUsecase_ListCertificates_Call{Call: _e.mock.On("ListCertificates", ctx, options)}
 }
 
-func (_c *MockUsecase_ListCertificates_Call) Run(run func(ctx context.Context, options *model.ListOptions)) *MockUsecase_ListCertificates_Call {
+func (_c *MockUsecase_ListCertificates_Call) Run(run func(ctx context.Context, options *port.ListOptions)) *MockUsecase_ListCertificates_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 *model.ListOptions
+		var arg1 *port.ListOptions
 		if args[1] != nil {
-			arg1 = args[1].(*model.ListOptions)
+			arg1 = args[1].(*port.ListOptions)
 		}
 		run(
 			arg0,
@@ -313,7 +313,7 @@ func (_c *MockUsecase_ListCertificates_Call) Return(listResponse *v1.ListRespons
 	return _c
 }
 
-func (_c *MockUsecase_ListCertificates_Call) RunAndReturn(run func(ctx context.Context, options *model.ListOptions) (*v1.ListResponse[v1.Certificate], error)) *MockUsecase_ListCertificates_Call {
+func (_c *MockUsecase_ListCertificates_Call) RunAndReturn(run func(ctx context.Context, options *port.ListOptions) (*v1.ListResponse[v1.Certificate], error)) *MockUsecase_ListCertificates_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/apiserver/adapter/primary/http/v1/connection/controller.go
+++ b/pkg/apiserver/adapter/primary/http/v1/connection/controller.go
@@ -6,12 +6,9 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/samber/lo"
 
 	v1 "github.com/minuk-dev/opampcommander/api/v1"
 	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
-	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/ginutil"
 	"github.com/minuk-dev/opampcommander/pkg/utils/clock"
 )
@@ -65,7 +62,6 @@ func (c *Controller) RoutesInfo() gin.RoutesInfo {
 // @Failure 500 {object} map[string]any
 // @Router /api/v1/namespaces/{namespace}/connections [get].
 func (c *Controller) List(ctx *gin.Context) {
-	now := c.clock.Now()
 	namespace := ctx.Param("namespace")
 
 	limit, err := ginutil.ParseInt64(ctx, "limit", 0)
@@ -77,34 +73,20 @@ func (c *Controller) List(ctx *gin.Context) {
 
 	continueToken := ctx.Query("continue")
 
-	response, err := c.adminUsecase.ListConnections(ctx.Request.Context(), namespace, &model.ListOptions{
-		Limit:          limit,
-		Continue:       continueToken,
-		IncludeDeleted: false,
-	})
+	var connectionResponse *v1.ListResponse[v1.Connection]
+
+	connectionResponse, err = c.adminUsecase.ListConnections(
+		ctx.Request.Context(), namespace, &applicationport.ListOptions{
+			Limit:          limit,
+			Continue:       continueToken,
+			IncludeDeleted: false,
+		})
 	if err != nil {
 		c.logger.Error("failed to list connections", "error", err.Error())
 		ginutil.InternalServerError(ctx, err, "An error occurred while listing connections.")
 
 		return
 	}
-
-	connectionResponse := v1.NewConnectionListResponse(
-		lo.Map(response.Items, func(connection *agentmodel.Connection, _ int) v1.Connection {
-			return v1.Connection{
-				ID:                 connection.UID,
-				InstanceUID:        connection.InstanceUID,
-				Namespace:          connection.Namespace,
-				Type:               connection.Type.String(),
-				Alive:              connection.IsAlive(now),
-				LastCommunicatedAt: v1.NewTime(connection.LastCommunicatedAt),
-			}
-		}),
-		v1.ListMeta{
-			RemainingItemCount: response.RemainingItemCount,
-			Continue:           response.Continue,
-		},
-	)
 
 	ctx.JSON(http.StatusOK, connectionResponse)
 }

--- a/pkg/apiserver/adapter/primary/http/v1/connection/controller_test.go
+++ b/pkg/apiserver/adapter/primary/http/v1/connection/controller_test.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
@@ -15,10 +14,9 @@ import (
 	"github.com/tidwall/gjson"
 	"go.uber.org/goleak"
 
+	v1 "github.com/minuk-dev/opampcommander/api/v1"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/primary/http/v1/connection"
 	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
-	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
 	"github.com/minuk-dev/opampcommander/pkg/testutil"
 )
 
@@ -43,30 +41,28 @@ func TestConnectionController_List(t *testing.T) {
 		conn2UID := uuid.New()
 		agent1UID := uuid.New()
 		agent2UID := uuid.New()
-		now := time.Now()
 
-		connections := []*agentmodel.Connection{
+		connections := []v1.Connection{
 			{
-				UID:                conn1UID,
-				InstanceUID:        agent1UID,
-				Namespace:          "default",
-				Type:               agentmodel.ConnectionTypeWebSocket,
-				LastCommunicatedAt: now,
+				ID:          conn1UID,
+				InstanceUID: agent1UID,
+				Namespace:   "default",
+				Type:        "WebSocket",
+				Alive:       true,
 			},
 			{
-				UID:                conn2UID,
-				InstanceUID:        agent2UID,
-				Namespace:          "default",
-				Type:               agentmodel.ConnectionTypeHTTP,
-				LastCommunicatedAt: now,
+				ID:          conn2UID,
+				InstanceUID: agent2UID,
+				Namespace:   "default",
+				Type:        "HTTP",
+				Alive:       true,
 			},
 		}
 		adminUsecase.On("ListConnections", mock.Anything, "default", mock.Anything).
-			Return(&model.ListResponse[*agentmodel.Connection]{
+			Return(v1.NewConnectionListResponse(connections, v1.ListMeta{
 				RemainingItemCount: 0,
 				Continue:           "",
-				Items:              connections,
-			}, nil)
+			}), nil)
 
 		// when
 		recorder := httptest.NewRecorder()
@@ -102,7 +98,7 @@ func TestConnectionController_List(t *testing.T) {
 
 		// given
 		adminUsecase.On("ListConnections", mock.Anything, "default", mock.Anything).
-			Return((*model.ListResponse[*agentmodel.Connection])(nil), assert.AnError)
+			Return((*v1.ListResponse[v1.Connection])(nil), assert.AnError)
 
 		// when
 		recorder := httptest.NewRecorder()
@@ -158,16 +154,9 @@ func newMockAdminUsecase(t *testing.T) *mockAdminUsecase {
 func (m *mockAdminUsecase) ListConnections(
 	ctx context.Context,
 	namespace string,
-	options *model.ListOptions,
-) (*model.ListResponse[*agentmodel.Connection], error) {
+	options *applicationport.ListOptions,
+) (*v1.ListResponse[v1.Connection], error) {
 	args := m.Called(ctx, namespace, options)
 
-	return args.Get(0).(*model.ListResponse[*agentmodel.Connection]), args.Error(1)
-}
-
-//nolint:wrapcheck
-func (m *mockAdminUsecase) ApplyRawConfig(ctx context.Context, targetInstanceUID uuid.UUID, config any) error {
-	args := m.Called(ctx, targetInstanceUID, config)
-
-	return args.Error(0)
+	return args.Get(0).(*v1.ListResponse[v1.Connection]), args.Error(1)
 }

--- a/pkg/apiserver/adapter/primary/http/v1/container/controller.go
+++ b/pkg/apiserver/adapter/primary/http/v1/container/controller.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	v1 "github.com/minuk-dev/opampcommander/api/v1"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/ginutil"
 )
 
@@ -78,7 +78,7 @@ func (c *Controller) List(ctx *gin.Context) {
 
 	response, err = c.containerUsecase.ListContainers(
 		ctx.Request.Context(),
-		&model.ListOptions{
+		&applicationport.ListOptions{
 			Limit:                    limit,
 			Continue:                 ctx.Query("continue"),
 			IncludeDeleted:           false,
@@ -166,7 +166,7 @@ func (c *Controller) ListAgents(ctx *gin.Context) {
 	response, err = c.containerUsecase.ListAgentsByContainer(
 		ctx.Request.Context(),
 		id,
-		&model.ListOptions{
+		&applicationport.ListOptions{
 			Limit:                    limit,
 			Continue:                 ctx.Query("continue"),
 			IncludeDeleted:           false,

--- a/pkg/apiserver/adapter/primary/http/v1/container/usecasemock/mocks.go
+++ b/pkg/apiserver/adapter/primary/http/v1/container/usecasemock/mocks.go
@@ -8,7 +8,7 @@ import (
 	"context"
 
 	"github.com/minuk-dev/opampcommander/api/v1"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -108,7 +108,7 @@ func (_c *MockManageUsecase_GetContainer_Call) RunAndReturn(run func(ctx context
 }
 
 // ListAgentsByContainer provides a mock function for the type MockManageUsecase
-func (_mock *MockManageUsecase) ListAgentsByContainer(ctx context.Context, id string, options *model.ListOptions) (*v1.ListResponse[v1.Agent], error) {
+func (_mock *MockManageUsecase) ListAgentsByContainer(ctx context.Context, id string, options *port.ListOptions) (*v1.ListResponse[v1.Agent], error) {
 	ret := _mock.Called(ctx, id, options)
 
 	if len(ret) == 0 {
@@ -117,17 +117,17 @@ func (_mock *MockManageUsecase) ListAgentsByContainer(ctx context.Context, id st
 
 	var r0 *v1.ListResponse[v1.Agent]
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *model.ListOptions) (*v1.ListResponse[v1.Agent], error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *port.ListOptions) (*v1.ListResponse[v1.Agent], error)); ok {
 		return returnFunc(ctx, id, options)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *model.ListOptions) *v1.ListResponse[v1.Agent]); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *port.ListOptions) *v1.ListResponse[v1.Agent]); ok {
 		r0 = returnFunc(ctx, id, options)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*v1.ListResponse[v1.Agent])
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *model.ListOptions) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *port.ListOptions) error); ok {
 		r1 = returnFunc(ctx, id, options)
 	} else {
 		r1 = ret.Error(1)
@@ -143,12 +143,12 @@ type MockManageUsecase_ListAgentsByContainer_Call struct {
 // ListAgentsByContainer is a helper method to define mock.On call
 //   - ctx context.Context
 //   - id string
-//   - options *model.ListOptions
+//   - options *port.ListOptions
 func (_e *MockManageUsecase_Expecter) ListAgentsByContainer(ctx interface{}, id interface{}, options interface{}) *MockManageUsecase_ListAgentsByContainer_Call {
 	return &MockManageUsecase_ListAgentsByContainer_Call{Call: _e.mock.On("ListAgentsByContainer", ctx, id, options)}
 }
 
-func (_c *MockManageUsecase_ListAgentsByContainer_Call) Run(run func(ctx context.Context, id string, options *model.ListOptions)) *MockManageUsecase_ListAgentsByContainer_Call {
+func (_c *MockManageUsecase_ListAgentsByContainer_Call) Run(run func(ctx context.Context, id string, options *port.ListOptions)) *MockManageUsecase_ListAgentsByContainer_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -158,9 +158,9 @@ func (_c *MockManageUsecase_ListAgentsByContainer_Call) Run(run func(ctx context
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 *model.ListOptions
+		var arg2 *port.ListOptions
 		if args[2] != nil {
-			arg2 = args[2].(*model.ListOptions)
+			arg2 = args[2].(*port.ListOptions)
 		}
 		run(
 			arg0,
@@ -176,13 +176,13 @@ func (_c *MockManageUsecase_ListAgentsByContainer_Call) Return(listResponse *v1.
 	return _c
 }
 
-func (_c *MockManageUsecase_ListAgentsByContainer_Call) RunAndReturn(run func(ctx context.Context, id string, options *model.ListOptions) (*v1.ListResponse[v1.Agent], error)) *MockManageUsecase_ListAgentsByContainer_Call {
+func (_c *MockManageUsecase_ListAgentsByContainer_Call) RunAndReturn(run func(ctx context.Context, id string, options *port.ListOptions) (*v1.ListResponse[v1.Agent], error)) *MockManageUsecase_ListAgentsByContainer_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ListContainers provides a mock function for the type MockManageUsecase
-func (_mock *MockManageUsecase) ListContainers(ctx context.Context, options *model.ListOptions) (*v1.ListResponse[v1.Container], error) {
+func (_mock *MockManageUsecase) ListContainers(ctx context.Context, options *port.ListOptions) (*v1.ListResponse[v1.Container], error) {
 	ret := _mock.Called(ctx, options)
 
 	if len(ret) == 0 {
@@ -191,17 +191,17 @@ func (_mock *MockManageUsecase) ListContainers(ctx context.Context, options *mod
 
 	var r0 *v1.ListResponse[v1.Container]
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *model.ListOptions) (*v1.ListResponse[v1.Container], error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *port.ListOptions) (*v1.ListResponse[v1.Container], error)); ok {
 		return returnFunc(ctx, options)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *model.ListOptions) *v1.ListResponse[v1.Container]); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *port.ListOptions) *v1.ListResponse[v1.Container]); ok {
 		r0 = returnFunc(ctx, options)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*v1.ListResponse[v1.Container])
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, *model.ListOptions) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *port.ListOptions) error); ok {
 		r1 = returnFunc(ctx, options)
 	} else {
 		r1 = ret.Error(1)
@@ -216,20 +216,20 @@ type MockManageUsecase_ListContainers_Call struct {
 
 // ListContainers is a helper method to define mock.On call
 //   - ctx context.Context
-//   - options *model.ListOptions
+//   - options *port.ListOptions
 func (_e *MockManageUsecase_Expecter) ListContainers(ctx interface{}, options interface{}) *MockManageUsecase_ListContainers_Call {
 	return &MockManageUsecase_ListContainers_Call{Call: _e.mock.On("ListContainers", ctx, options)}
 }
 
-func (_c *MockManageUsecase_ListContainers_Call) Run(run func(ctx context.Context, options *model.ListOptions)) *MockManageUsecase_ListContainers_Call {
+func (_c *MockManageUsecase_ListContainers_Call) Run(run func(ctx context.Context, options *port.ListOptions)) *MockManageUsecase_ListContainers_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 *model.ListOptions
+		var arg1 *port.ListOptions
 		if args[1] != nil {
-			arg1 = args[1].(*model.ListOptions)
+			arg1 = args[1].(*port.ListOptions)
 		}
 		run(
 			arg0,
@@ -244,7 +244,7 @@ func (_c *MockManageUsecase_ListContainers_Call) Return(listResponse *v1.ListRes
 	return _c
 }
 
-func (_c *MockManageUsecase_ListContainers_Call) RunAndReturn(run func(ctx context.Context, options *model.ListOptions) (*v1.ListResponse[v1.Container], error)) *MockManageUsecase_ListContainers_Call {
+func (_c *MockManageUsecase_ListContainers_Call) RunAndReturn(run func(ctx context.Context, options *port.ListOptions) (*v1.ListResponse[v1.Container], error)) *MockManageUsecase_ListContainers_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/apiserver/adapter/primary/http/v1/endpoint/controller.go
+++ b/pkg/apiserver/adapter/primary/http/v1/endpoint/controller.go
@@ -9,7 +9,6 @@ import (
 
 	v1 "github.com/minuk-dev/opampcommander/api/v1"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/ginutil"
 )
 
@@ -113,7 +112,7 @@ func (c *Controller) List(ctx *gin.Context) {
 	}
 
 	response, err := c.endpointUsecase.ListEndpoints(
-		ctx.Request.Context(), namespace, &model.ListOptions{
+		ctx.Request.Context(), namespace, &port.ListOptions{
 			Limit:          limit,
 			Continue:       continueToken,
 			IncludeDeleted: includeDeleted,
@@ -176,7 +175,7 @@ func (c *Controller) Get(ctx *gin.Context) {
 	}
 
 	endpoint, err := c.endpointUsecase.GetEndpoint(
-		ctx.Request.Context(), namespace, name, &model.GetOptions{
+		ctx.Request.Context(), namespace, name, &port.GetOptions{
 			IncludeDeleted: includeDeleted,
 		},
 	)

--- a/pkg/apiserver/adapter/primary/http/v1/host/controller.go
+++ b/pkg/apiserver/adapter/primary/http/v1/host/controller.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	v1 "github.com/minuk-dev/opampcommander/api/v1"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/ginutil"
 )
 
@@ -78,7 +78,7 @@ func (c *Controller) List(ctx *gin.Context) {
 
 	response, err = c.hostUsecase.ListHosts(
 		ctx.Request.Context(),
-		&model.ListOptions{
+		&applicationport.ListOptions{
 			Limit:                    limit,
 			Continue:                 ctx.Query("continue"),
 			IncludeDeleted:           false,
@@ -166,7 +166,7 @@ func (c *Controller) ListAgents(ctx *gin.Context) {
 	response, err = c.hostUsecase.ListAgentsByHost(
 		ctx.Request.Context(),
 		id,
-		&model.ListOptions{
+		&applicationport.ListOptions{
 			Limit:                    limit,
 			Continue:                 ctx.Query("continue"),
 			IncludeDeleted:           false,

--- a/pkg/apiserver/adapter/primary/http/v1/host/usecasemock/mocks.go
+++ b/pkg/apiserver/adapter/primary/http/v1/host/usecasemock/mocks.go
@@ -8,7 +8,7 @@ import (
 	"context"
 
 	"github.com/minuk-dev/opampcommander/api/v1"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -108,7 +108,7 @@ func (_c *MockManageUsecase_GetHost_Call) RunAndReturn(run func(ctx context.Cont
 }
 
 // ListAgentsByHost provides a mock function for the type MockManageUsecase
-func (_mock *MockManageUsecase) ListAgentsByHost(ctx context.Context, id string, options *model.ListOptions) (*v1.ListResponse[v1.Agent], error) {
+func (_mock *MockManageUsecase) ListAgentsByHost(ctx context.Context, id string, options *port.ListOptions) (*v1.ListResponse[v1.Agent], error) {
 	ret := _mock.Called(ctx, id, options)
 
 	if len(ret) == 0 {
@@ -117,17 +117,17 @@ func (_mock *MockManageUsecase) ListAgentsByHost(ctx context.Context, id string,
 
 	var r0 *v1.ListResponse[v1.Agent]
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *model.ListOptions) (*v1.ListResponse[v1.Agent], error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *port.ListOptions) (*v1.ListResponse[v1.Agent], error)); ok {
 		return returnFunc(ctx, id, options)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *model.ListOptions) *v1.ListResponse[v1.Agent]); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, *port.ListOptions) *v1.ListResponse[v1.Agent]); ok {
 		r0 = returnFunc(ctx, id, options)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*v1.ListResponse[v1.Agent])
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *model.ListOptions) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, *port.ListOptions) error); ok {
 		r1 = returnFunc(ctx, id, options)
 	} else {
 		r1 = ret.Error(1)
@@ -143,12 +143,12 @@ type MockManageUsecase_ListAgentsByHost_Call struct {
 // ListAgentsByHost is a helper method to define mock.On call
 //   - ctx context.Context
 //   - id string
-//   - options *model.ListOptions
+//   - options *port.ListOptions
 func (_e *MockManageUsecase_Expecter) ListAgentsByHost(ctx interface{}, id interface{}, options interface{}) *MockManageUsecase_ListAgentsByHost_Call {
 	return &MockManageUsecase_ListAgentsByHost_Call{Call: _e.mock.On("ListAgentsByHost", ctx, id, options)}
 }
 
-func (_c *MockManageUsecase_ListAgentsByHost_Call) Run(run func(ctx context.Context, id string, options *model.ListOptions)) *MockManageUsecase_ListAgentsByHost_Call {
+func (_c *MockManageUsecase_ListAgentsByHost_Call) Run(run func(ctx context.Context, id string, options *port.ListOptions)) *MockManageUsecase_ListAgentsByHost_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -158,9 +158,9 @@ func (_c *MockManageUsecase_ListAgentsByHost_Call) Run(run func(ctx context.Cont
 		if args[1] != nil {
 			arg1 = args[1].(string)
 		}
-		var arg2 *model.ListOptions
+		var arg2 *port.ListOptions
 		if args[2] != nil {
-			arg2 = args[2].(*model.ListOptions)
+			arg2 = args[2].(*port.ListOptions)
 		}
 		run(
 			arg0,
@@ -176,13 +176,13 @@ func (_c *MockManageUsecase_ListAgentsByHost_Call) Return(listResponse *v1.ListR
 	return _c
 }
 
-func (_c *MockManageUsecase_ListAgentsByHost_Call) RunAndReturn(run func(ctx context.Context, id string, options *model.ListOptions) (*v1.ListResponse[v1.Agent], error)) *MockManageUsecase_ListAgentsByHost_Call {
+func (_c *MockManageUsecase_ListAgentsByHost_Call) RunAndReturn(run func(ctx context.Context, id string, options *port.ListOptions) (*v1.ListResponse[v1.Agent], error)) *MockManageUsecase_ListAgentsByHost_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ListHosts provides a mock function for the type MockManageUsecase
-func (_mock *MockManageUsecase) ListHosts(ctx context.Context, options *model.ListOptions) (*v1.ListResponse[v1.Host], error) {
+func (_mock *MockManageUsecase) ListHosts(ctx context.Context, options *port.ListOptions) (*v1.ListResponse[v1.Host], error) {
 	ret := _mock.Called(ctx, options)
 
 	if len(ret) == 0 {
@@ -191,17 +191,17 @@ func (_mock *MockManageUsecase) ListHosts(ctx context.Context, options *model.Li
 
 	var r0 *v1.ListResponse[v1.Host]
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *model.ListOptions) (*v1.ListResponse[v1.Host], error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *port.ListOptions) (*v1.ListResponse[v1.Host], error)); ok {
 		return returnFunc(ctx, options)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *model.ListOptions) *v1.ListResponse[v1.Host]); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *port.ListOptions) *v1.ListResponse[v1.Host]); ok {
 		r0 = returnFunc(ctx, options)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*v1.ListResponse[v1.Host])
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, *model.ListOptions) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *port.ListOptions) error); ok {
 		r1 = returnFunc(ctx, options)
 	} else {
 		r1 = ret.Error(1)
@@ -216,20 +216,20 @@ type MockManageUsecase_ListHosts_Call struct {
 
 // ListHosts is a helper method to define mock.On call
 //   - ctx context.Context
-//   - options *model.ListOptions
+//   - options *port.ListOptions
 func (_e *MockManageUsecase_Expecter) ListHosts(ctx interface{}, options interface{}) *MockManageUsecase_ListHosts_Call {
 	return &MockManageUsecase_ListHosts_Call{Call: _e.mock.On("ListHosts", ctx, options)}
 }
 
-func (_c *MockManageUsecase_ListHosts_Call) Run(run func(ctx context.Context, options *model.ListOptions)) *MockManageUsecase_ListHosts_Call {
+func (_c *MockManageUsecase_ListHosts_Call) Run(run func(ctx context.Context, options *port.ListOptions)) *MockManageUsecase_ListHosts_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 *model.ListOptions
+		var arg1 *port.ListOptions
 		if args[1] != nil {
-			arg1 = args[1].(*model.ListOptions)
+			arg1 = args[1].(*port.ListOptions)
 		}
 		run(
 			arg0,
@@ -244,7 +244,7 @@ func (_c *MockManageUsecase_ListHosts_Call) Return(listResponse *v1.ListResponse
 	return _c
 }
 
-func (_c *MockManageUsecase_ListHosts_Call) RunAndReturn(run func(ctx context.Context, options *model.ListOptions) (*v1.ListResponse[v1.Host], error)) *MockManageUsecase_ListHosts_Call {
+func (_c *MockManageUsecase_ListHosts_Call) RunAndReturn(run func(ctx context.Context, options *port.ListOptions) (*v1.ListResponse[v1.Host], error)) *MockManageUsecase_ListHosts_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/apiserver/adapter/primary/http/v1/namespace/controller.go
+++ b/pkg/apiserver/adapter/primary/http/v1/namespace/controller.go
@@ -9,7 +9,6 @@ import (
 
 	v1 "github.com/minuk-dev/opampcommander/api/v1"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/ginutil"
 )
 
@@ -90,7 +89,7 @@ func (c *Controller) List(ctx *gin.Context) {
 
 	response, err := c.namespaceUsecase.ListNamespaces(
 		ctx.Request.Context(),
-		&model.ListOptions{
+		&port.ListOptions{
 			Limit:          limit,
 			Continue:       continueToken,
 			IncludeDeleted: includeDeleted,
@@ -133,7 +132,7 @@ func (c *Controller) Get(ctx *gin.Context) {
 	}
 
 	namespace, err := c.namespaceUsecase.GetNamespace(
-		ctx.Request.Context(), name, &model.GetOptions{
+		ctx.Request.Context(), name, &port.GetOptions{
 			IncludeDeleted: includeDeleted,
 		},
 	)

--- a/pkg/apiserver/adapter/primary/http/v1/role/controller.go
+++ b/pkg/apiserver/adapter/primary/http/v1/role/controller.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	v1 "github.com/minuk-dev/opampcommander/api/v1"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/ginutil"
 )
 
@@ -98,7 +98,7 @@ func (c *Controller) List(ctx *gin.Context) {
 		return
 	}
 
-	response, err := c.roleUsecase.ListRoles(ctx.Request.Context(), &model.ListOptions{
+	response, err := c.roleUsecase.ListRoles(ctx.Request.Context(), &applicationport.ListOptions{
 		Limit:          limit,
 		Continue:       continueToken,
 		IncludeDeleted: includeDeleted,
@@ -142,7 +142,7 @@ func (c *Controller) Get(ctx *gin.Context) {
 		return
 	}
 
-	role, err := c.roleUsecase.GetRole(ctx.Request.Context(), uid, &model.GetOptions{
+	role, err := c.roleUsecase.GetRole(ctx.Request.Context(), uid, &applicationport.GetOptions{
 		IncludeDeleted: includeDeleted,
 	})
 	if err != nil {

--- a/pkg/apiserver/adapter/primary/http/v1/rolebinding/controller.go
+++ b/pkg/apiserver/adapter/primary/http/v1/rolebinding/controller.go
@@ -8,7 +8,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	v1 "github.com/minuk-dev/opampcommander/api/v1"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/ginutil"
 )
 
@@ -94,7 +94,7 @@ func (c *Controller) List(ctx *gin.Context) {
 		return
 	}
 
-	response, err := c.usecase.ListRoleBindings(ctx.Request.Context(), &model.ListOptions{
+	response, err := c.usecase.ListRoleBindings(ctx.Request.Context(), &applicationport.ListOptions{
 		Limit:          limit,
 		Continue:       continueToken,
 		IncludeDeleted: includeDeleted,
@@ -146,7 +146,7 @@ func (c *Controller) Get(ctx *gin.Context) {
 		return
 	}
 
-	roleBinding, err := c.usecase.GetRoleBinding(ctx.Request.Context(), namespace, name, &model.GetOptions{
+	roleBinding, err := c.usecase.GetRoleBinding(ctx.Request.Context(), namespace, name, &applicationport.GetOptions{
 		IncludeDeleted: includeDeleted,
 	})
 	if err != nil {

--- a/pkg/apiserver/adapter/primary/http/v1/rolebinding/usecasemock/mocks.go
+++ b/pkg/apiserver/adapter/primary/http/v1/rolebinding/usecasemock/mocks.go
@@ -8,7 +8,7 @@ import (
 	"context"
 
 	"github.com/minuk-dev/opampcommander/api/v1"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -171,7 +171,7 @@ func (_c *MockUsecase_DeleteRoleBinding_Call) RunAndReturn(run func(ctx context.
 }
 
 // GetRoleBinding provides a mock function for the type MockUsecase
-func (_mock *MockUsecase) GetRoleBinding(ctx context.Context, namespace string, name string, options *model.GetOptions) (*v1.RoleBinding, error) {
+func (_mock *MockUsecase) GetRoleBinding(ctx context.Context, namespace string, name string, options *port.GetOptions) (*v1.RoleBinding, error) {
 	ret := _mock.Called(ctx, namespace, name, options)
 
 	if len(ret) == 0 {
@@ -180,17 +180,17 @@ func (_mock *MockUsecase) GetRoleBinding(ctx context.Context, namespace string, 
 
 	var r0 *v1.RoleBinding
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *model.GetOptions) (*v1.RoleBinding, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *port.GetOptions) (*v1.RoleBinding, error)); ok {
 		return returnFunc(ctx, namespace, name, options)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *model.GetOptions) *v1.RoleBinding); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string, *port.GetOptions) *v1.RoleBinding); ok {
 		r0 = returnFunc(ctx, namespace, name, options)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*v1.RoleBinding)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, *model.GetOptions) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, string, string, *port.GetOptions) error); ok {
 		r1 = returnFunc(ctx, namespace, name, options)
 	} else {
 		r1 = ret.Error(1)
@@ -207,12 +207,12 @@ type MockUsecase_GetRoleBinding_Call struct {
 //   - ctx context.Context
 //   - namespace string
 //   - name string
-//   - options *model.GetOptions
+//   - options *port.GetOptions
 func (_e *MockUsecase_Expecter) GetRoleBinding(ctx interface{}, namespace interface{}, name interface{}, options interface{}) *MockUsecase_GetRoleBinding_Call {
 	return &MockUsecase_GetRoleBinding_Call{Call: _e.mock.On("GetRoleBinding", ctx, namespace, name, options)}
 }
 
-func (_c *MockUsecase_GetRoleBinding_Call) Run(run func(ctx context.Context, namespace string, name string, options *model.GetOptions)) *MockUsecase_GetRoleBinding_Call {
+func (_c *MockUsecase_GetRoleBinding_Call) Run(run func(ctx context.Context, namespace string, name string, options *port.GetOptions)) *MockUsecase_GetRoleBinding_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -226,9 +226,9 @@ func (_c *MockUsecase_GetRoleBinding_Call) Run(run func(ctx context.Context, nam
 		if args[2] != nil {
 			arg2 = args[2].(string)
 		}
-		var arg3 *model.GetOptions
+		var arg3 *port.GetOptions
 		if args[3] != nil {
-			arg3 = args[3].(*model.GetOptions)
+			arg3 = args[3].(*port.GetOptions)
 		}
 		run(
 			arg0,
@@ -245,13 +245,13 @@ func (_c *MockUsecase_GetRoleBinding_Call) Return(roleBinding *v1.RoleBinding, e
 	return _c
 }
 
-func (_c *MockUsecase_GetRoleBinding_Call) RunAndReturn(run func(ctx context.Context, namespace string, name string, options *model.GetOptions) (*v1.RoleBinding, error)) *MockUsecase_GetRoleBinding_Call {
+func (_c *MockUsecase_GetRoleBinding_Call) RunAndReturn(run func(ctx context.Context, namespace string, name string, options *port.GetOptions) (*v1.RoleBinding, error)) *MockUsecase_GetRoleBinding_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
 // ListRoleBindings provides a mock function for the type MockUsecase
-func (_mock *MockUsecase) ListRoleBindings(ctx context.Context, options *model.ListOptions) (*v1.ListResponse[v1.RoleBinding], error) {
+func (_mock *MockUsecase) ListRoleBindings(ctx context.Context, options *port.ListOptions) (*v1.ListResponse[v1.RoleBinding], error) {
 	ret := _mock.Called(ctx, options)
 
 	if len(ret) == 0 {
@@ -260,17 +260,17 @@ func (_mock *MockUsecase) ListRoleBindings(ctx context.Context, options *model.L
 
 	var r0 *v1.ListResponse[v1.RoleBinding]
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *model.ListOptions) (*v1.ListResponse[v1.RoleBinding], error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *port.ListOptions) (*v1.ListResponse[v1.RoleBinding], error)); ok {
 		return returnFunc(ctx, options)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *model.ListOptions) *v1.ListResponse[v1.RoleBinding]); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *port.ListOptions) *v1.ListResponse[v1.RoleBinding]); ok {
 		r0 = returnFunc(ctx, options)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*v1.ListResponse[v1.RoleBinding])
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, *model.ListOptions) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *port.ListOptions) error); ok {
 		r1 = returnFunc(ctx, options)
 	} else {
 		r1 = ret.Error(1)
@@ -285,20 +285,20 @@ type MockUsecase_ListRoleBindings_Call struct {
 
 // ListRoleBindings is a helper method to define mock.On call
 //   - ctx context.Context
-//   - options *model.ListOptions
+//   - options *port.ListOptions
 func (_e *MockUsecase_Expecter) ListRoleBindings(ctx interface{}, options interface{}) *MockUsecase_ListRoleBindings_Call {
 	return &MockUsecase_ListRoleBindings_Call{Call: _e.mock.On("ListRoleBindings", ctx, options)}
 }
 
-func (_c *MockUsecase_ListRoleBindings_Call) Run(run func(ctx context.Context, options *model.ListOptions)) *MockUsecase_ListRoleBindings_Call {
+func (_c *MockUsecase_ListRoleBindings_Call) Run(run func(ctx context.Context, options *port.ListOptions)) *MockUsecase_ListRoleBindings_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 *model.ListOptions
+		var arg1 *port.ListOptions
 		if args[1] != nil {
-			arg1 = args[1].(*model.ListOptions)
+			arg1 = args[1].(*port.ListOptions)
 		}
 		run(
 			arg0,
@@ -313,7 +313,7 @@ func (_c *MockUsecase_ListRoleBindings_Call) Return(listResponse *v1.ListRespons
 	return _c
 }
 
-func (_c *MockUsecase_ListRoleBindings_Call) RunAndReturn(run func(ctx context.Context, options *model.ListOptions) (*v1.ListResponse[v1.RoleBinding], error)) *MockUsecase_ListRoleBindings_Call {
+func (_c *MockUsecase_ListRoleBindings_Call) RunAndReturn(run func(ctx context.Context, options *port.ListOptions) (*v1.ListResponse[v1.RoleBinding], error)) *MockUsecase_ListRoleBindings_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/apiserver/adapter/primary/http/v1/server/controller.go
+++ b/pkg/apiserver/adapter/primary/http/v1/server/controller.go
@@ -6,12 +6,9 @@ import (
 	"net/http"
 
 	"github.com/gin-gonic/gin"
-	"github.com/samber/lo"
 
 	v1 "github.com/minuk-dev/opampcommander/api/v1"
-	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
-	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/ginutil"
 )
 
@@ -20,13 +17,13 @@ type Controller struct {
 	logger *slog.Logger
 
 	// usecases
-	serverUsecase agentport.ServerUsecase
+	serverUsecase applicationport.ServerManageUsecase
 }
 
 // NewController creates a new instance of the Controller struct.
 func NewController(
 	logger *slog.Logger,
-	serverUsecase agentport.ServerUsecase,
+	serverUsecase applicationport.ServerManageUsecase,
 ) *Controller {
 	return &Controller{
 		logger:        logger,
@@ -57,7 +54,9 @@ func (c *Controller) RoutesInfo() gin.RoutesInfo {
 // @Failure 500 {object} map[string]any
 // @Router /api/v1/servers [get].
 func (c *Controller) List(ctx *gin.Context) {
-	servers, err := c.serverUsecase.ListServers(ctx.Request.Context())
+	var serverResponse *v1.ListResponse[v1.Server]
+
+	serverResponse, err := c.serverUsecase.ListServers(ctx.Request.Context())
 	if err != nil {
 		c.logger.Error("failed to list servers", "error", err.Error())
 		ginutil.InternalServerError(ctx, err, "An error occurred while listing servers.")
@@ -65,39 +64,5 @@ func (c *Controller) List(ctx *gin.Context) {
 		return
 	}
 
-	serverResponse := v1.NewServerListResponse(
-		lo.Map(servers, func(server *agentmodel.Server, _ int) v1.Server {
-			return v1.Server{
-				ID:              server.ID,
-				LastHeartbeatAt: v1.NewTime(server.LastHeartbeatAt),
-				Conditions:      mapConditionsToAPI(server.Conditions),
-			}
-		}),
-		v1.ListMeta{
-			RemainingItemCount: 0,
-			Continue:           "",
-		},
-	)
-
 	ctx.JSON(http.StatusOK, serverResponse)
-}
-
-// mapConditionsToAPI converts domain server conditions to API conditions.
-func mapConditionsToAPI(conditions []model.Condition) []v1.ServerCondition {
-	if len(conditions) == 0 {
-		return nil
-	}
-
-	apiConditions := make([]v1.ServerCondition, len(conditions))
-	for i, condition := range conditions {
-		apiConditions[i] = v1.ServerCondition{
-			Type:               v1.ServerConditionType(condition.Type),
-			LastTransitionTime: v1.NewTime(condition.LastTransitionTime),
-			Status:             v1.ServerConditionStatus(condition.Status),
-			Reason:             condition.Reason,
-			Message:            condition.Message,
-		}
-	}
-
-	return apiConditions
 }

--- a/pkg/apiserver/adapter/primary/http/v1/user/controller.go
+++ b/pkg/apiserver/adapter/primary/http/v1/user/controller.go
@@ -9,8 +9,7 @@ import (
 	"github.com/gin-gonic/gin"
 
 	v1 "github.com/minuk-dev/opampcommander/api/v1"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/port"
+	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/ginutil"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/security"
 )
@@ -101,7 +100,7 @@ func (c *Controller) List(ctx *gin.Context) {
 		return
 	}
 
-	response, err := c.userUsecase.ListUsers(ctx.Request.Context(), &model.ListOptions{
+	response, err := c.userUsecase.ListUsers(ctx.Request.Context(), &applicationport.ListOptions{
 		Limit:          limit,
 		Continue:       continueToken,
 		IncludeDeleted: includeDeleted,
@@ -145,7 +144,7 @@ func (c *Controller) Get(ctx *gin.Context) {
 		return
 	}
 
-	user, err := c.userUsecase.GetUser(ctx.Request.Context(), uid, &model.GetOptions{
+	user, err := c.userUsecase.GetUser(ctx.Request.Context(), uid, &applicationport.GetOptions{
 		IncludeDeleted: includeDeleted,
 	})
 	if err != nil {
@@ -244,7 +243,7 @@ func (c *Controller) Me(ctx *gin.Context) {
 
 	profile, err := c.userUsecase.GetMyProfile(ctx.Request.Context(), *secUser.Email)
 	if err != nil {
-		if errors.Is(err, port.ErrResourceNotExist) {
+		if errors.Is(err, applicationport.ErrResourceNotExist) {
 			// User is authenticated (JWT is valid) but has no DB record yet.
 			// This is expected for the admin account before its first login creates a record.
 			// Roles are omitted because label-based binding matching requires a DB record.

--- a/pkg/apiserver/adapter/primary/http/v1/user/usecasemock/mocks.go
+++ b/pkg/apiserver/adapter/primary/http/v1/user/usecasemock/mocks.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/minuk-dev/opampcommander/api/v1"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
 	mock "github.com/stretchr/testify/mock"
 )
 
@@ -234,7 +234,7 @@ func (_c *MockUsecase_GetMyProfile_Call) RunAndReturn(run func(ctx context.Conte
 }
 
 // GetUser provides a mock function for the type MockUsecase
-func (_mock *MockUsecase) GetUser(ctx context.Context, uid uuid.UUID, options *model.GetOptions) (*v1.User, error) {
+func (_mock *MockUsecase) GetUser(ctx context.Context, uid uuid.UUID, options *port.GetOptions) (*v1.User, error) {
 	ret := _mock.Called(ctx, uid, options)
 
 	if len(ret) == 0 {
@@ -243,17 +243,17 @@ func (_mock *MockUsecase) GetUser(ctx context.Context, uid uuid.UUID, options *m
 
 	var r0 *v1.User
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID, *model.GetOptions) (*v1.User, error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID, *port.GetOptions) (*v1.User, error)); ok {
 		return returnFunc(ctx, uid, options)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID, *model.GetOptions) *v1.User); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, uuid.UUID, *port.GetOptions) *v1.User); ok {
 		r0 = returnFunc(ctx, uid, options)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*v1.User)
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, uuid.UUID, *model.GetOptions) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, uuid.UUID, *port.GetOptions) error); ok {
 		r1 = returnFunc(ctx, uid, options)
 	} else {
 		r1 = ret.Error(1)
@@ -269,12 +269,12 @@ type MockUsecase_GetUser_Call struct {
 // GetUser is a helper method to define mock.On call
 //   - ctx context.Context
 //   - uid uuid.UUID
-//   - options *model.GetOptions
+//   - options *port.GetOptions
 func (_e *MockUsecase_Expecter) GetUser(ctx interface{}, uid interface{}, options interface{}) *MockUsecase_GetUser_Call {
 	return &MockUsecase_GetUser_Call{Call: _e.mock.On("GetUser", ctx, uid, options)}
 }
 
-func (_c *MockUsecase_GetUser_Call) Run(run func(ctx context.Context, uid uuid.UUID, options *model.GetOptions)) *MockUsecase_GetUser_Call {
+func (_c *MockUsecase_GetUser_Call) Run(run func(ctx context.Context, uid uuid.UUID, options *port.GetOptions)) *MockUsecase_GetUser_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
@@ -284,9 +284,9 @@ func (_c *MockUsecase_GetUser_Call) Run(run func(ctx context.Context, uid uuid.U
 		if args[1] != nil {
 			arg1 = args[1].(uuid.UUID)
 		}
-		var arg2 *model.GetOptions
+		var arg2 *port.GetOptions
 		if args[2] != nil {
-			arg2 = args[2].(*model.GetOptions)
+			arg2 = args[2].(*port.GetOptions)
 		}
 		run(
 			arg0,
@@ -302,7 +302,7 @@ func (_c *MockUsecase_GetUser_Call) Return(user *v1.User, err error) *MockUsecas
 	return _c
 }
 
-func (_c *MockUsecase_GetUser_Call) RunAndReturn(run func(ctx context.Context, uid uuid.UUID, options *model.GetOptions) (*v1.User, error)) *MockUsecase_GetUser_Call {
+func (_c *MockUsecase_GetUser_Call) RunAndReturn(run func(ctx context.Context, uid uuid.UUID, options *port.GetOptions) (*v1.User, error)) *MockUsecase_GetUser_Call {
 	_c.Call.Return(run)
 	return _c
 }
@@ -376,7 +376,7 @@ func (_c *MockUsecase_GetUserByEmail_Call) RunAndReturn(run func(ctx context.Con
 }
 
 // ListUsers provides a mock function for the type MockUsecase
-func (_mock *MockUsecase) ListUsers(ctx context.Context, options *model.ListOptions) (*v1.ListResponse[v1.User], error) {
+func (_mock *MockUsecase) ListUsers(ctx context.Context, options *port.ListOptions) (*v1.ListResponse[v1.User], error) {
 	ret := _mock.Called(ctx, options)
 
 	if len(ret) == 0 {
@@ -385,17 +385,17 @@ func (_mock *MockUsecase) ListUsers(ctx context.Context, options *model.ListOpti
 
 	var r0 *v1.ListResponse[v1.User]
 	var r1 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *model.ListOptions) (*v1.ListResponse[v1.User], error)); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *port.ListOptions) (*v1.ListResponse[v1.User], error)); ok {
 		return returnFunc(ctx, options)
 	}
-	if returnFunc, ok := ret.Get(0).(func(context.Context, *model.ListOptions) *v1.ListResponse[v1.User]); ok {
+	if returnFunc, ok := ret.Get(0).(func(context.Context, *port.ListOptions) *v1.ListResponse[v1.User]); ok {
 		r0 = returnFunc(ctx, options)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(*v1.ListResponse[v1.User])
 		}
 	}
-	if returnFunc, ok := ret.Get(1).(func(context.Context, *model.ListOptions) error); ok {
+	if returnFunc, ok := ret.Get(1).(func(context.Context, *port.ListOptions) error); ok {
 		r1 = returnFunc(ctx, options)
 	} else {
 		r1 = ret.Error(1)
@@ -410,20 +410,20 @@ type MockUsecase_ListUsers_Call struct {
 
 // ListUsers is a helper method to define mock.On call
 //   - ctx context.Context
-//   - options *model.ListOptions
+//   - options *port.ListOptions
 func (_e *MockUsecase_Expecter) ListUsers(ctx interface{}, options interface{}) *MockUsecase_ListUsers_Call {
 	return &MockUsecase_ListUsers_Call{Call: _e.mock.On("ListUsers", ctx, options)}
 }
 
-func (_c *MockUsecase_ListUsers_Call) Run(run func(ctx context.Context, options *model.ListOptions)) *MockUsecase_ListUsers_Call {
+func (_c *MockUsecase_ListUsers_Call) Run(run func(ctx context.Context, options *port.ListOptions)) *MockUsecase_ListUsers_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		var arg0 context.Context
 		if args[0] != nil {
 			arg0 = args[0].(context.Context)
 		}
-		var arg1 *model.ListOptions
+		var arg1 *port.ListOptions
 		if args[1] != nil {
-			arg1 = args[1].(*model.ListOptions)
+			arg1 = args[1].(*port.ListOptions)
 		}
 		run(
 			arg0,
@@ -438,7 +438,7 @@ func (_c *MockUsecase_ListUsers_Call) Return(listResponse *v1.ListResponse[v1.Us
 	return _c
 }
 
-func (_c *MockUsecase_ListUsers_Call) RunAndReturn(run func(ctx context.Context, options *model.ListOptions) (*v1.ListResponse[v1.User], error)) *MockUsecase_ListUsers_Call {
+func (_c *MockUsecase_ListUsers_Call) RunAndReturn(run func(ctx context.Context, options *port.ListOptions) (*v1.ListResponse[v1.User], error)) *MockUsecase_ListUsers_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/pkg/apiserver/application/port/auth.go
+++ b/pkg/apiserver/application/port/auth.go
@@ -1,0 +1,35 @@
+package port
+
+import (
+	"context"
+
+	usermodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/model"
+)
+
+// Identity provider names used when provisioning a user on login. They alias the
+// domain values so primary adapters can specify the provider without importing the domain.
+const (
+	IdentityProviderGitHub = usermodel.IdentityProviderGitHub
+	IdentityProviderBasic  = usermodel.IdentityProviderBasic
+)
+
+// LoginProvisioning carries the identity attributes resolved during a successful
+// login that the application layer uses to create or update the user's record.
+type LoginProvisioning struct {
+	// Provider is the identity provider that authenticated the user (e.g. "github", "basic").
+	Provider string
+	// Username is the provider-side username; for providers that have no separate
+	// username it is the email.
+	Username string
+	// Email is the user's email, used as the stable identity key.
+	Email string
+	// Groups are provider groups (e.g. GitHub orgs) synced to the user's labels.
+	Groups []string
+}
+
+// AuthProvisioningUsecase creates or updates the user record on login and re-applies
+// RBAC policies so the user picks up default roles and matching bindings. It is
+// best-effort: failures are logged internally and never block authentication.
+type AuthProvisioningUsecase interface {
+	EnsureUserOnLogin(ctx context.Context, provisioning LoginProvisioning)
+}

--- a/pkg/apiserver/application/port/in.go
+++ b/pkg/apiserver/application/port/in.go
@@ -10,10 +10,13 @@ import (
 	opamptypes "github.com/open-telemetry/opamp-go/server/types"
 
 	v1 "github.com/minuk-dev/opampcommander/api/v1"
-	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
 	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	domainport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/port"
 )
+
+// ErrResourceNotExist is returned when a requested resource does not exist. It aliases the
+// domain sentinel so primary adapters can map it (e.g. to a 404) without importing the domain.
+var ErrResourceNotExist = domainport.ErrResourceNotExist
 
 // ErrAgentConnected is returned when attempting to delete an agent that is still connected.
 // Only disconnected agents can be deleted. It aliases the domain sentinel (the guard is
@@ -39,15 +42,20 @@ type OpAMPUsecase interface {
 // AdminUsecase is a use case that handles admin operations.
 type AdminUsecase interface {
 	ListConnections(ctx context.Context, namespace string,
-		options *model.ListOptions) (*model.ListResponse[*agentmodel.Connection], error)
+		options *ListOptions) (*v1.ListResponse[v1.Connection], error)
+}
+
+// ServerManageUsecase is a use case that handles server management operations.
+type ServerManageUsecase interface {
+	ListServers(ctx context.Context) (*v1.ListResponse[v1.Server], error)
 }
 
 // NamespaceManageUsecase is a use case that handles namespace management operations.
 type NamespaceManageUsecase interface {
 	GetNamespace(ctx context.Context, name string,
-		options *model.GetOptions) (*v1.Namespace, error)
+		options *GetOptions) (*v1.Namespace, error)
 	ListNamespaces(ctx context.Context,
-		options *model.ListOptions) (*v1.ListResponse[v1.Namespace], error)
+		options *ListOptions) (*v1.ListResponse[v1.Namespace], error)
 	CreateNamespace(ctx context.Context,
 		namespace *v1.Namespace) (*v1.Namespace, error)
 	UpdateNamespace(ctx context.Context, name string,
@@ -58,8 +66,8 @@ type NamespaceManageUsecase interface {
 // AgentPackageManageUsecase is a use case that handles agent package operations.
 type AgentPackageManageUsecase interface {
 	GetAgentPackage(ctx context.Context, namespace string, name string,
-		options *model.GetOptions) (*v1.AgentPackage, error)
-	ListAgentPackages(ctx context.Context, options *model.ListOptions) (*v1.ListResponse[v1.AgentPackage], error)
+		options *GetOptions) (*v1.AgentPackage, error)
+	ListAgentPackages(ctx context.Context, options *ListOptions) (*v1.ListResponse[v1.AgentPackage], error)
 	CreateAgentPackage(ctx context.Context, agentPackage *v1.AgentPackage) (*v1.AgentPackage, error)
 	UpdateAgentPackage(ctx context.Context, namespace string, name string,
 		agentPackage *v1.AgentPackage) (*v1.AgentPackage, error)
@@ -70,9 +78,9 @@ type AgentPackageManageUsecase interface {
 type AgentManageUsecase interface {
 	GetAgent(ctx context.Context, namespace string, instanceUID uuid.UUID) (*v1.Agent, error)
 	ListAgents(ctx context.Context, namespace string,
-		options *model.ListOptions) (*v1.ListResponse[v1.Agent], error)
+		options *ListOptions) (*v1.ListResponse[v1.Agent], error)
 	SearchAgents(ctx context.Context, namespace string, query string,
-		options *model.ListOptions) (*v1.ListResponse[v1.Agent], error)
+		options *ListOptions) (*v1.ListResponse[v1.Agent], error)
 	UpdateAgent(ctx context.Context, namespace string, instanceUID uuid.UUID,
 		agent *v1.Agent) (*v1.Agent, error)
 	DeleteAgent(ctx context.Context, namespace string, instanceUID uuid.UUID) error
@@ -85,13 +93,13 @@ type AgentManageUsecase interface {
 // AgentGroupManageUsecase is a use case that handles agent group management operations.
 type AgentGroupManageUsecase interface {
 	GetAgentGroup(ctx context.Context, namespace string, name string,
-		options *model.GetOptions) (*v1.AgentGroup, error)
-	ListAgentGroups(ctx context.Context, options *model.ListOptions) (*v1.ListResponse[v1.AgentGroup], error)
+		options *GetOptions) (*v1.AgentGroup, error)
+	ListAgentGroups(ctx context.Context, options *ListOptions) (*v1.ListResponse[v1.AgentGroup], error)
 	ListAgentsByAgentGroup(
 		ctx context.Context,
 		namespace string,
 		agentGroupName string,
-		options *model.ListOptions,
+		options *ListOptions,
 	) (*v1.ListResponse[v1.Agent], error)
 	// ListAgentGroupsByAgent lists the agent groups in the given namespace whose selector
 	// matches the agent identified by instanceUID.
@@ -109,24 +117,24 @@ type AgentGroupManageUsecase interface {
 // HostManageUsecase is a use case that handles host management operations.
 type HostManageUsecase interface {
 	GetHost(ctx context.Context, id string) (*v1.Host, error)
-	ListHosts(ctx context.Context, options *model.ListOptions) (*v1.ListResponse[v1.Host], error)
+	ListHosts(ctx context.Context, options *ListOptions) (*v1.ListResponse[v1.Host], error)
 	ListAgentsByHost(ctx context.Context, id string,
-		options *model.ListOptions) (*v1.ListResponse[v1.Agent], error)
+		options *ListOptions) (*v1.ListResponse[v1.Agent], error)
 }
 
 // ContainerManageUsecase is a use case that handles container management operations.
 type ContainerManageUsecase interface {
 	GetContainer(ctx context.Context, id string) (*v1.Container, error)
-	ListContainers(ctx context.Context, options *model.ListOptions) (*v1.ListResponse[v1.Container], error)
+	ListContainers(ctx context.Context, options *ListOptions) (*v1.ListResponse[v1.Container], error)
 	ListAgentsByContainer(ctx context.Context, id string,
-		options *model.ListOptions) (*v1.ListResponse[v1.Agent], error)
+		options *ListOptions) (*v1.ListResponse[v1.Agent], error)
 }
 
 // CertificateManageUsecase is a use case that handles certificate management operations.
 type CertificateManageUsecase interface {
 	GetCertificate(ctx context.Context, namespace string, name string,
-		options *model.GetOptions) (*v1.Certificate, error)
-	ListCertificates(ctx context.Context, options *model.ListOptions) (*v1.ListResponse[v1.Certificate], error)
+		options *GetOptions) (*v1.Certificate, error)
+	ListCertificates(ctx context.Context, options *ListOptions) (*v1.ListResponse[v1.Certificate], error)
 	CreateCertificate(ctx context.Context, certificate *v1.Certificate) (*v1.Certificate, error)
 	UpdateCertificate(ctx context.Context, namespace string, name string,
 		certificate *v1.Certificate) (*v1.Certificate, error)
@@ -136,9 +144,9 @@ type CertificateManageUsecase interface {
 // AgentRemoteConfigManageUsecase is a use case that handles agent remote config management operations.
 type AgentRemoteConfigManageUsecase interface {
 	GetAgentRemoteConfig(ctx context.Context, namespace string,
-		name string, options *model.GetOptions) (*v1.AgentRemoteConfig, error)
+		name string, options *GetOptions) (*v1.AgentRemoteConfig, error)
 	ListAgentRemoteConfigs(ctx context.Context,
-		options *model.ListOptions) (*v1.ListResponse[v1.AgentRemoteConfig], error)
+		options *ListOptions) (*v1.ListResponse[v1.AgentRemoteConfig], error)
 	CreateAgentRemoteConfig(ctx context.Context,
 		agentRemoteConfig *v1.AgentRemoteConfig) (*v1.AgentRemoteConfig, error)
 	UpdateAgentRemoteConfig(ctx context.Context, namespace string, name string,
@@ -149,9 +157,9 @@ type AgentRemoteConfigManageUsecase interface {
 // EndpointManageUsecase is a use case that handles endpoint management operations.
 type EndpointManageUsecase interface {
 	GetEndpoint(ctx context.Context, namespace string,
-		name string, options *model.GetOptions) (*v1.Endpoint, error)
+		name string, options *GetOptions) (*v1.Endpoint, error)
 	ListEndpoints(ctx context.Context, namespace string,
-		options *model.ListOptions) (*v1.ListResponse[v1.Endpoint], error)
+		options *ListOptions) (*v1.ListResponse[v1.Endpoint], error)
 	CreateEndpoint(ctx context.Context,
 		endpoint *v1.Endpoint) (*v1.Endpoint, error)
 	UpdateEndpoint(ctx context.Context, namespace string, name string,
@@ -161,9 +169,9 @@ type EndpointManageUsecase interface {
 
 // UserManageUsecase is a use case that handles user management operations.
 type UserManageUsecase interface {
-	GetUser(ctx context.Context, uid uuid.UUID, options *model.GetOptions) (*v1.User, error)
+	GetUser(ctx context.Context, uid uuid.UUID, options *GetOptions) (*v1.User, error)
 	GetUserByEmail(ctx context.Context, email string) (*v1.User, error)
-	ListUsers(ctx context.Context, options *model.ListOptions) (*v1.ListResponse[v1.User], error)
+	ListUsers(ctx context.Context, options *ListOptions) (*v1.ListResponse[v1.User], error)
 	CreateUser(ctx context.Context, user *v1.User) (*v1.User, error)
 	DeleteUser(ctx context.Context, uid uuid.UUID) error
 	GetMyProfile(ctx context.Context, email string) (*v1.UserProfileResponse, error)
@@ -171,8 +179,8 @@ type UserManageUsecase interface {
 
 // RoleManageUsecase is a use case that handles role management operations.
 type RoleManageUsecase interface {
-	GetRole(ctx context.Context, uid uuid.UUID, options *model.GetOptions) (*v1.Role, error)
-	ListRoles(ctx context.Context, options *model.ListOptions) (*v1.ListResponse[v1.Role], error)
+	GetRole(ctx context.Context, uid uuid.UUID, options *GetOptions) (*v1.Role, error)
+	ListRoles(ctx context.Context, options *ListOptions) (*v1.ListResponse[v1.Role], error)
 	CreateRole(ctx context.Context, role *v1.Role) (*v1.Role, error)
 	UpdateRole(ctx context.Context, uid uuid.UUID, role *v1.Role) (*v1.Role, error)
 	DeleteRole(ctx context.Context, uid uuid.UUID) error
@@ -181,8 +189,8 @@ type RoleManageUsecase interface {
 // RoleBindingManageUsecase is a use case that handles RoleBinding management operations.
 type RoleBindingManageUsecase interface {
 	GetRoleBinding(ctx context.Context, namespace, name string,
-		options *model.GetOptions) (*v1.RoleBinding, error)
-	ListRoleBindings(ctx context.Context, options *model.ListOptions) (*v1.ListResponse[v1.RoleBinding], error)
+		options *GetOptions) (*v1.RoleBinding, error)
+	ListRoleBindings(ctx context.Context, options *ListOptions) (*v1.ListResponse[v1.RoleBinding], error)
 	CreateRoleBinding(ctx context.Context, rb *v1.RoleBinding) (*v1.RoleBinding, error)
 	UpdateRoleBinding(ctx context.Context, namespace, name string, rb *v1.RoleBinding) (*v1.RoleBinding, error)
 	DeleteRoleBinding(ctx context.Context, namespace, name string) error

--- a/pkg/apiserver/application/port/options.go
+++ b/pkg/apiserver/application/port/options.go
@@ -1,0 +1,68 @@
+package port
+
+import (
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+)
+
+// ListOptions holds options for listing resources at the application boundary.
+//
+// It mirrors the domain-level list options but is owned by the application
+// layer so that primary adapters (HTTP controllers, messaging consumers) can
+// express paging/filtering without importing the domain package. The
+// application layer converts it to the domain representation via ToDomain.
+type ListOptions struct {
+	Limit          int64
+	Continue       string
+	IncludeDeleted bool
+
+	// ConnectedOnly, when true, restricts an agent listing to agents that are
+	// currently considered connected. It is a no-op for resources that have no
+	// connection state.
+	ConnectedOnly bool
+
+	// IdentifyingAttributes, when non-empty, restricts an agent listing to agents
+	// whose identifying attributes match every key=value pair exactly (an AND of
+	// equality conditions). It is a no-op for resources that have no identifying
+	// attributes.
+	IdentifyingAttributes map[string]string
+
+	// NonIdentifyingAttributes, when non-empty, restricts an agent listing to
+	// agents whose non-identifying attributes match every key=value pair exactly.
+	// It is combined with IdentifyingAttributes via AND, and is a no-op for
+	// resources that have no non-identifying attributes.
+	NonIdentifyingAttributes map[string]string
+}
+
+// ToDomain converts the application-level list options to the domain model.
+// A nil receiver yields nil so callers can pass options through transparently.
+func (o *ListOptions) ToDomain() *model.ListOptions {
+	if o == nil {
+		return nil
+	}
+
+	return &model.ListOptions{
+		Limit:                    o.Limit,
+		Continue:                 o.Continue,
+		IncludeDeleted:           o.IncludeDeleted,
+		ConnectedOnly:            o.ConnectedOnly,
+		IdentifyingAttributes:    o.IdentifyingAttributes,
+		NonIdentifyingAttributes: o.NonIdentifyingAttributes,
+	}
+}
+
+// GetOptions holds options for getting a single resource at the application boundary.
+type GetOptions struct {
+	IncludeDeleted bool
+}
+
+// ToDomain converts the application-level get options to the domain model.
+// A nil receiver yields nil so callers can pass options through transparently.
+func (o *GetOptions) ToDomain() *model.GetOptions {
+	if o == nil {
+		return nil
+	}
+
+	return &model.GetOptions{
+		IncludeDeleted: o.IncludeDeleted,
+	}
+}

--- a/pkg/apiserver/application/service/admin/admin.go
+++ b/pkg/apiserver/application/service/admin/admin.go
@@ -6,10 +6,13 @@ import (
 	"fmt"
 	"log/slog"
 
+	"github.com/samber/lo"
+	"k8s.io/utils/clock"
+
+	v1 "github.com/minuk-dev/opampcommander/api/v1"
 	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
 	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
 	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
 )
 
 var _ applicationport.AdminUsecase = (*Service)(nil)
@@ -17,6 +20,7 @@ var _ applicationport.AdminUsecase = (*Service)(nil)
 // Service is a struct that implements the AdminUsecase interface.
 type Service struct {
 	logger                   *slog.Logger
+	clock                    clock.Clock
 	agentUsecase             agentport.AgentUsecase
 	connectionUsecase        agentport.ConnectionUsecase
 	agentNotificationUsecase agentport.AgentNotificationUsecase
@@ -31,6 +35,7 @@ func New(
 ) *Service {
 	return &Service{
 		logger:                   logger,
+		clock:                    clock.RealClock{},
 		agentUsecase:             agentUsecase,
 		connectionUsecase:        connectionUsecase,
 		agentNotificationUsecase: agentNotificationUsecase,
@@ -41,12 +46,29 @@ func New(
 func (s *Service) ListConnections(
 	ctx context.Context,
 	namespace string,
-	options *model.ListOptions,
-) (*model.ListResponse[*agentmodel.Connection], error) {
-	response, err := s.connectionUsecase.ListConnections(ctx, namespace, options)
+	options *applicationport.ListOptions,
+) (*v1.ListResponse[v1.Connection], error) {
+	response, err := s.connectionUsecase.ListConnections(ctx, namespace, options.ToDomain())
 	if err != nil {
 		return nil, fmt.Errorf("failed to list connections: %w", err)
 	}
 
-	return response, nil
+	now := s.clock.Now()
+
+	return v1.NewConnectionListResponse(
+		lo.Map(response.Items, func(connection *agentmodel.Connection, _ int) v1.Connection {
+			return v1.Connection{
+				ID:                 connection.UID,
+				InstanceUID:        connection.InstanceUID,
+				Namespace:          connection.Namespace,
+				Type:               connection.Type.String(),
+				Alive:              connection.IsAlive(now),
+				LastCommunicatedAt: v1.NewTime(connection.LastCommunicatedAt),
+			}
+		}),
+		v1.ListMeta{
+			RemainingItemCount: response.RemainingItemCount,
+			Continue:           response.Continue,
+		},
+	), nil
 }

--- a/pkg/apiserver/application/service/agent/agent.go
+++ b/pkg/apiserver/application/service/agent/agent.go
@@ -16,7 +16,6 @@ import (
 	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
 	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
 	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
 )
 
 var (
@@ -107,9 +106,9 @@ func (s *Service) GetAgent(
 func (s *Service) ListAgents(
 	ctx context.Context,
 	namespace string,
-	options *model.ListOptions,
+	options *applicationport.ListOptions,
 ) (*v1.ListResponse[v1.Agent], error) {
-	response, err := s.agentUsecase.ListAgents(ctx, namespace, options)
+	response, err := s.agentUsecase.ListAgents(ctx, namespace, options.ToDomain())
 	if err != nil {
 		return nil, fmt.Errorf("failed to list agents: %w", err)
 	}
@@ -132,9 +131,9 @@ func (s *Service) SearchAgents(
 	ctx context.Context,
 	namespace string,
 	query string,
-	options *model.ListOptions,
+	options *applicationport.ListOptions,
 ) (*v1.ListResponse[v1.Agent], error) {
-	response, err := s.agentUsecase.SearchAgents(ctx, namespace, query, options)
+	response, err := s.agentUsecase.SearchAgents(ctx, namespace, query, options.ToDomain())
 	if err != nil {
 		return nil, fmt.Errorf("failed to search agents: %w", err)
 	}

--- a/pkg/apiserver/application/service/agent/agent_test.go
+++ b/pkg/apiserver/application/service/agent/agent_test.go
@@ -161,7 +161,7 @@ func TestService_SearchAgents(t *testing.T) {
 		mockAgentUsecase.On("SearchAgents", ctx, "default", "1234", mock.Anything).Return(domainResponse, nil)
 
 		// when
-		response, err := service.SearchAgents(ctx, "default", "1234", &model.ListOptions{})
+		response, err := service.SearchAgents(ctx, "default", "1234", &applicationport.ListOptions{})
 
 		// then
 		require.NoError(t, err)
@@ -183,7 +183,7 @@ func TestService_SearchAgents(t *testing.T) {
 		mockAgentUsecase.On("SearchAgents", ctx, "default", "test", mock.Anything).Return(nil, errMockError)
 
 		// when
-		response, err := service.SearchAgents(ctx, "default", "test", &model.ListOptions{})
+		response, err := service.SearchAgents(ctx, "default", "test", &applicationport.ListOptions{})
 
 		// then
 		require.Error(t, err)
@@ -211,12 +211,12 @@ func TestService_SearchAgents(t *testing.T) {
 			RemainingItemCount: 10,
 		}
 
-		options := &model.ListOptions{
+		options := &applicationport.ListOptions{
 			Limit:    2,
 			Continue: "",
 		}
 
-		mockAgentUsecase.On("SearchAgents", ctx, "default", "abcd", options).Return(domainResponse, nil)
+		mockAgentUsecase.On("SearchAgents", ctx, "default", "abcd", options.ToDomain()).Return(domainResponse, nil)
 
 		// when
 		response, err := service.SearchAgents(ctx, "default", "abcd", options)

--- a/pkg/apiserver/application/service/agentgroup/agentgroup_manage_service.go
+++ b/pkg/apiserver/application/service/agentgroup/agentgroup_manage_service.go
@@ -59,9 +59,9 @@ func (s *ManageService) GetAgentGroup(
 	ctx context.Context,
 	namespace string,
 	name string,
-	options *model.GetOptions,
+	options *port.GetOptions,
 ) (*v1.AgentGroup, error) {
-	agentGroup, err := s.agentgroupUsecase.GetAgentGroup(ctx, namespace, name, options)
+	agentGroup, err := s.agentgroupUsecase.GetAgentGroup(ctx, namespace, name, options.ToDomain())
 	if err != nil {
 		return nil, fmt.Errorf("get agent group: %w", err)
 	}
@@ -72,9 +72,9 @@ func (s *ManageService) GetAgentGroup(
 // ListAgentGroups returns a paginated list of agent groups.
 func (s *ManageService) ListAgentGroups(
 	ctx context.Context,
-	options *model.ListOptions,
+	options *port.ListOptions,
 ) (*v1.ListResponse[v1.AgentGroup], error) {
-	domainResp, err := s.agentgroupUsecase.ListAgentGroups(ctx, options)
+	domainResp, err := s.agentgroupUsecase.ListAgentGroups(ctx, options.ToDomain())
 	if err != nil {
 		return nil, fmt.Errorf("list agent groups: %w", err)
 	}
@@ -97,14 +97,14 @@ func (s *ManageService) ListAgentsByAgentGroup(
 	ctx context.Context,
 	namespace string,
 	agentGroupName string,
-	options *model.ListOptions,
+	options *port.ListOptions,
 ) (*v1.ListResponse[v1.Agent], error) {
 	agentGroup, err := s.agentgroupUsecase.GetAgentGroup(ctx, namespace, agentGroupName, nil)
 	if err != nil {
 		return nil, fmt.Errorf("get agent group: %w", err)
 	}
 
-	domainResp, err := s.agentUsecase.ListAgentsBySelector(ctx, agentGroup.Spec.Selector, options)
+	domainResp, err := s.agentUsecase.ListAgentsBySelector(ctx, agentGroup.Spec.Selector, options.ToDomain())
 	if err != nil {
 		return nil, fmt.Errorf("list agents by agent group: %w", err)
 	}

--- a/pkg/apiserver/application/service/agentpackage/agentpackage.go
+++ b/pkg/apiserver/application/service/agentpackage/agentpackage.go
@@ -14,7 +14,6 @@ import (
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/agentpackage/filter"
 	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
 	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/security"
 	"github.com/minuk-dev/opampcommander/pkg/utils/clock"
 )
@@ -51,9 +50,9 @@ func (a *Service) GetAgentPackage(
 	ctx context.Context,
 	namespace string,
 	name string,
-	options *model.GetOptions,
+	options *port.GetOptions,
 ) (*v1.AgentPackage, error) {
-	agentPackage, err := a.agentpackageUsecase.GetAgentPackage(ctx, namespace, name, options)
+	agentPackage, err := a.agentpackageUsecase.GetAgentPackage(ctx, namespace, name, options.ToDomain())
 	if err != nil {
 		return nil, fmt.Errorf("get agent package: %w", err)
 	}
@@ -64,9 +63,9 @@ func (a *Service) GetAgentPackage(
 // ListAgentPackages implements [port.AgentPackageManageUsecase].
 func (a *Service) ListAgentPackages(
 	ctx context.Context,
-	options *model.ListOptions,
+	options *port.ListOptions,
 ) (*v1.ListResponse[v1.AgentPackage], error) {
-	agentPackages, err := a.agentpackageUsecase.ListAgentPackages(ctx, options)
+	agentPackages, err := a.agentpackageUsecase.ListAgentPackages(ctx, options.ToDomain())
 	if err != nil {
 		return nil, fmt.Errorf("list agent packages: %w", err)
 	}

--- a/pkg/apiserver/application/service/agentremoteconfig/agentremoteconfig.go
+++ b/pkg/apiserver/application/service/agentremoteconfig/agentremoteconfig.go
@@ -57,10 +57,10 @@ func (s *Service) GetAgentRemoteConfig(
 	ctx context.Context,
 	namespace string,
 	name string,
-	options *model.GetOptions,
+	options *port.GetOptions,
 ) (*v1.AgentRemoteConfig, error) {
 	config, err := s.agentRemoteConfigUsecase.GetAgentRemoteConfig(
-		ctx, namespace, name, options,
+		ctx, namespace, name, options.ToDomain(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("get agent remote config: %w", err)
@@ -72,10 +72,10 @@ func (s *Service) GetAgentRemoteConfig(
 // ListAgentRemoteConfigs implements [port.AgentRemoteConfigManageUsecase].
 func (s *Service) ListAgentRemoteConfigs(
 	ctx context.Context,
-	options *model.ListOptions,
+	options *port.ListOptions,
 ) (*v1.ListResponse[v1.AgentRemoteConfig], error) {
 	configs, err := s.agentRemoteConfigUsecase.ListAgentRemoteConfigs(
-		ctx, options,
+		ctx, options.ToDomain(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("list agent remote configs: %w", err)

--- a/pkg/apiserver/application/service/auth/auth.go
+++ b/pkg/apiserver/application/service/auth/auth.go
@@ -1,0 +1,158 @@
+// Package auth provides the implementation of the AuthProvisioningUsecase interface.
+//
+// It owns the user-provisioning logic that runs on every successful login (creating
+// or updating the user record and re-syncing RBAC policies). This logic used to live
+// in the HTTP auth controllers; it is kept here so those primary adapters depend only
+// on the application layer, not on the domain.
+package auth
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"time"
+
+	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
+	domainport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/port"
+	usermodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/model"
+	userport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/port"
+)
+
+var _ applicationport.AuthProvisioningUsecase = (*Service)(nil)
+
+// Service implements AuthProvisioningUsecase.
+type Service struct {
+	logger      *slog.Logger
+	userUsecase userport.UserUsecase
+	rbacUsecase userport.RBACUsecase
+}
+
+// New creates a new instance of the Service struct.
+func New(
+	userUsecase userport.UserUsecase,
+	rbacUsecase userport.RBACUsecase,
+	logger *slog.Logger,
+) *Service {
+	return &Service{
+		logger:      logger,
+		userUsecase: userUsecase,
+		rbacUsecase: rbacUsecase,
+	}
+}
+
+// EnsureUserOnLogin creates or updates a user record on login.
+// Always syncs provider labels and re-applies RBAC policies so the freshly-saved user
+// picks up the built-in default role (and any matching bindings).
+// Failures are logged but do not block the login flow.
+func (s *Service) EnsureUserOnLogin(ctx context.Context, provisioning applicationport.LoginProvisioning) {
+	existing, err := s.userUsecase.GetUserByEmail(ctx, provisioning.Email)
+
+	switch {
+	case err == nil && existing != nil:
+		s.syncLabels(existing, provisioning.Provider, provisioning.Groups)
+
+		existing.Metadata.UpdatedAt = time.Now()
+
+		saveErr := s.userUsecase.SaveUser(ctx, existing)
+		if saveErr != nil {
+			s.logger.Warn("failed to update user on login",
+				slog.String("email", provisioning.Email),
+				slog.Any("error", saveErr),
+			)
+
+			return
+		}
+
+		s.syncRBACPolicies(ctx, provisioning.Email)
+
+		return
+	case err != nil && !errors.Is(err, domainport.ErrResourceNotExist):
+		s.logger.Warn("failed to check user existence on login",
+			slog.String("email", provisioning.Email),
+			slog.Any("error", err),
+		)
+
+		return
+	}
+
+	// No active user with this email. If a soft-deleted record exists, the user was
+	// deliberately deleted: do not resurrect or duplicate it. They can still authenticate
+	// but stay without a record (RBAC denies) until an admin restores them.
+	if s.isDeletedUser(ctx, provisioning.Email) {
+		return
+	}
+
+	newUser := usermodel.NewUserWithIdentity(
+		provisioning.Provider, provisioning.Username, provisioning.Email, provisioning.Username,
+	)
+	s.syncLabels(newUser, provisioning.Provider, provisioning.Groups)
+
+	saveErr := s.userUsecase.SaveUser(ctx, newUser)
+	if saveErr != nil {
+		s.logger.Warn("failed to create user on login",
+			slog.String("email", provisioning.Email),
+			slog.Any("error", saveErr),
+		)
+
+		return
+	}
+
+	s.syncRBACPolicies(ctx, provisioning.Email)
+}
+
+// isDeletedUser reports whether a soft-deleted user record exists for the email.
+// On lookup failure it returns true (fail-closed): recreating on a transient error is the
+// behaviour that produced duplicate accounts, so we'd rather skip creation and let the user retry.
+func (s *Service) isDeletedUser(ctx context.Context, email string) bool {
+	deleted, err := s.userUsecase.GetUserByEmailIncludingDeleted(ctx, email)
+	if err != nil {
+		if errors.Is(err, domainport.ErrResourceNotExist) {
+			return false
+		}
+
+		s.logger.Warn("failed to check for soft-deleted user on login; skipping user creation",
+			slog.String("email", email),
+			slog.Any("error", err),
+		)
+
+		return true
+	}
+
+	s.logger.Warn("not recreating soft-deleted user on login",
+		slog.String("email", email),
+		slog.String("uid", deleted.Metadata.UID.String()),
+	)
+
+	return true
+}
+
+// syncRBACPolicies re-runs the Casbin policy sync so newly persisted users/bindings take effect.
+// Best-effort: failures are logged but do not block the login flow.
+func (s *Service) syncRBACPolicies(ctx context.Context, email string) {
+	err := s.rbacUsecase.SyncPolicies(ctx)
+	if err != nil {
+		s.logger.Warn("failed to sync RBAC policies after login",
+			slog.String("email", email),
+			slog.Any("error", err),
+		)
+	}
+}
+
+// syncLabels updates the user's metadata labels to reflect the current login session.
+// Existing non-provider labels are preserved.
+func (s *Service) syncLabels(user *usermodel.User, provider string, groups []string) {
+	// Remove stale provider-specific labels before re-setting.
+	for key := range user.Metadata.Labels {
+		if len(key) > len(usermodel.LabelGitHubOrg) && key[:len(usermodel.LabelGitHubOrg)] == usermodel.LabelGitHubOrg {
+			delete(user.Metadata.Labels, key)
+		}
+	}
+
+	user.SetLabel(usermodel.LabelLoginType, provider)
+
+	if provider == usermodel.IdentityProviderGitHub {
+		for _, org := range groups {
+			user.SetLabel(usermodel.LabelGitHubOrg+org, "true")
+		}
+	}
+}

--- a/pkg/apiserver/application/service/certificate/certificate.go
+++ b/pkg/apiserver/application/service/certificate/certificate.go
@@ -51,9 +51,9 @@ func (s *Service) GetCertificate(
 	ctx context.Context,
 	namespace string,
 	name string,
-	options *model.GetOptions,
+	options *port.GetOptions,
 ) (*v1.Certificate, error) {
-	certificate, err := s.certificateUsecase.GetCertificate(ctx, namespace, name, options)
+	certificate, err := s.certificateUsecase.GetCertificate(ctx, namespace, name, options.ToDomain())
 	if err != nil {
 		return nil, fmt.Errorf("get certificate: %w", err)
 	}
@@ -64,9 +64,9 @@ func (s *Service) GetCertificate(
 // ListCertificates implements [port.CertificateManageUsecase].
 func (s *Service) ListCertificates(
 	ctx context.Context,
-	options *model.ListOptions,
+	options *port.ListOptions,
 ) (*v1.ListResponse[v1.Certificate], error) {
-	certificates, err := s.certificateUsecase.ListCertificate(ctx, options)
+	certificates, err := s.certificateUsecase.ListCertificate(ctx, options.ToDomain())
 	if err != nil {
 		return nil, fmt.Errorf("list certificates: %w", err)
 	}

--- a/pkg/apiserver/application/service/container/container.go
+++ b/pkg/apiserver/application/service/container/container.go
@@ -16,7 +16,6 @@ import (
 	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
 	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
 	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/port"
 )
 
@@ -57,9 +56,9 @@ func (s *Service) GetContainer(ctx context.Context, id string) (*v1.Container, e
 // ListContainers implements applicationport.ContainerManageUsecase.
 func (s *Service) ListContainers(
 	ctx context.Context,
-	options *model.ListOptions,
+	options *applicationport.ListOptions,
 ) (*v1.ListResponse[v1.Container], error) {
-	response, err := s.containerUsecase.ListContainers(ctx, options)
+	response, err := s.containerUsecase.ListContainers(ctx, options.ToDomain())
 	if err != nil {
 		return nil, fmt.Errorf("failed to list containers: %w", err)
 	}
@@ -81,14 +80,14 @@ func (s *Service) ListContainers(
 func (s *Service) ListAgentsByContainer(
 	ctx context.Context,
 	id string,
-	options *model.ListOptions,
+	options *applicationport.ListOptions,
 ) (*v1.ListResponse[v1.Agent], error) {
 	container, err := s.containerUsecase.GetContainer(ctx, id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get container: %w", err)
 	}
 
-	page, err := helper.PaginateUUIDs(container.Status.AgentInstanceUIDs, options)
+	page, err := helper.PaginateUUIDs(container.Status.AgentInstanceUIDs, options.ToDomain())
 	if err != nil {
 		return nil, fmt.Errorf("failed to paginate container agents: %w", err)
 	}

--- a/pkg/apiserver/application/service/endpoint/endpoint.go
+++ b/pkg/apiserver/application/service/endpoint/endpoint.go
@@ -53,9 +53,9 @@ func (s *Service) GetEndpoint(
 	ctx context.Context,
 	namespace string,
 	name string,
-	options *model.GetOptions,
+	options *port.GetOptions,
 ) (*v1.Endpoint, error) {
-	endpoint, err := s.endpointUsecase.GetEndpoint(ctx, namespace, name, options)
+	endpoint, err := s.endpointUsecase.GetEndpoint(ctx, namespace, name, options.ToDomain())
 	if err != nil {
 		return nil, fmt.Errorf("get endpoint: %w", err)
 	}
@@ -67,9 +67,9 @@ func (s *Service) GetEndpoint(
 func (s *Service) ListEndpoints(
 	ctx context.Context,
 	namespace string,
-	options *model.ListOptions,
+	options *port.ListOptions,
 ) (*v1.ListResponse[v1.Endpoint], error) {
-	endpoints, err := s.endpointUsecase.ListEndpoints(ctx, namespace, options)
+	endpoints, err := s.endpointUsecase.ListEndpoints(ctx, namespace, options.ToDomain())
 	if err != nil {
 		return nil, fmt.Errorf("list endpoints: %w", err)
 	}

--- a/pkg/apiserver/application/service/host/host.go
+++ b/pkg/apiserver/application/service/host/host.go
@@ -16,7 +16,6 @@ import (
 	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
 	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
 	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/port"
 )
 
@@ -57,9 +56,9 @@ func (s *Service) GetHost(ctx context.Context, id string) (*v1.Host, error) {
 // ListHosts implements applicationport.HostManageUsecase.
 func (s *Service) ListHosts(
 	ctx context.Context,
-	options *model.ListOptions,
+	options *applicationport.ListOptions,
 ) (*v1.ListResponse[v1.Host], error) {
-	response, err := s.hostUsecase.ListHosts(ctx, options)
+	response, err := s.hostUsecase.ListHosts(ctx, options.ToDomain())
 	if err != nil {
 		return nil, fmt.Errorf("failed to list hosts: %w", err)
 	}
@@ -81,14 +80,14 @@ func (s *Service) ListHosts(
 func (s *Service) ListAgentsByHost(
 	ctx context.Context,
 	id string,
-	options *model.ListOptions,
+	options *applicationport.ListOptions,
 ) (*v1.ListResponse[v1.Agent], error) {
 	host, err := s.hostUsecase.GetHost(ctx, id)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get host: %w", err)
 	}
 
-	page, err := helper.PaginateUUIDs(host.Status.AgentInstanceUIDs, options)
+	page, err := helper.PaginateUUIDs(host.Status.AgentInstanceUIDs, options.ToDomain())
 	if err != nil {
 		return nil, fmt.Errorf("failed to paginate host agents: %w", err)
 	}

--- a/pkg/apiserver/application/service/namespace/namespace_manage_service.go
+++ b/pkg/apiserver/application/service/namespace/namespace_manage_service.go
@@ -84,9 +84,9 @@ func NewNamespaceService(
 func (s *Service) GetNamespace(
 	ctx context.Context,
 	name string,
-	options *model.GetOptions,
+	options *port.GetOptions,
 ) (*v1.Namespace, error) {
-	ns, err := s.namespaceUsecase.GetNamespace(ctx, name, options)
+	ns, err := s.namespaceUsecase.GetNamespace(ctx, name, options.ToDomain())
 	if err != nil {
 		return nil, fmt.Errorf("get namespace: %w", err)
 	}
@@ -97,9 +97,9 @@ func (s *Service) GetNamespace(
 // ListNamespaces implements [port.NamespaceManageUsecase].
 func (s *Service) ListNamespaces(
 	ctx context.Context,
-	options *model.ListOptions,
+	options *port.ListOptions,
 ) (*v1.ListResponse[v1.Namespace], error) {
-	namespaces, err := s.namespaceUsecase.ListNamespaces(ctx, options)
+	namespaces, err := s.namespaceUsecase.ListNamespaces(ctx, options.ToDomain())
 	if err != nil {
 		return nil, fmt.Errorf("list namespaces: %w", err)
 	}

--- a/pkg/apiserver/application/service/role/service.go
+++ b/pkg/apiserver/application/service/role/service.go
@@ -14,7 +14,6 @@ import (
 	v1 "github.com/minuk-dev/opampcommander/api/v1"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/application/helper"
 	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
 	usermodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/model"
 	userport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/port"
 )
@@ -38,8 +37,8 @@ func New(roleUsecase userport.RoleUsecase, logger *slog.Logger) *Service {
 }
 
 // GetRole implements [applicationport.RoleManageUsecase].
-func (s *Service) GetRole(ctx context.Context, uid uuid.UUID, options *model.GetOptions) (*v1.Role, error) {
-	role, err := s.roleUsecase.GetRole(ctx, uid, options)
+func (s *Service) GetRole(ctx context.Context, uid uuid.UUID, options *applicationport.GetOptions) (*v1.Role, error) {
+	role, err := s.roleUsecase.GetRole(ctx, uid, options.ToDomain())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get role: %w", err)
 	}
@@ -50,9 +49,9 @@ func (s *Service) GetRole(ctx context.Context, uid uuid.UUID, options *model.Get
 // ListRoles implements [applicationport.RoleManageUsecase].
 func (s *Service) ListRoles(
 	ctx context.Context,
-	options *model.ListOptions,
+	options *applicationport.ListOptions,
 ) (*v1.ListResponse[v1.Role], error) {
-	response, err := s.roleUsecase.ListRoles(ctx, options)
+	response, err := s.roleUsecase.ListRoles(ctx, options.ToDomain())
 	if err != nil {
 		return nil, fmt.Errorf("failed to list roles: %w", err)
 	}

--- a/pkg/apiserver/application/service/rolebinding/service.go
+++ b/pkg/apiserver/application/service/rolebinding/service.go
@@ -12,7 +12,6 @@ import (
 	v1 "github.com/minuk-dev/opampcommander/api/v1"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/application/helper"
 	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
 	usermodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/model"
 	userport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/port"
 )
@@ -48,9 +47,9 @@ func New(
 func (s *Service) GetRoleBinding(
 	ctx context.Context,
 	namespace, name string,
-	options *model.GetOptions,
+	options *applicationport.GetOptions,
 ) (*v1.RoleBinding, error) {
-	rb, err := s.roleBindingUsecase.GetRoleBinding(ctx, namespace, name, options)
+	rb, err := s.roleBindingUsecase.GetRoleBinding(ctx, namespace, name, options.ToDomain())
 	if err != nil {
 		return nil, fmt.Errorf("get role binding: %w", err)
 	}
@@ -61,9 +60,9 @@ func (s *Service) GetRoleBinding(
 // ListRoleBindings implements [applicationport.RoleBindingManageUsecase].
 func (s *Service) ListRoleBindings(
 	ctx context.Context,
-	options *model.ListOptions,
+	options *applicationport.ListOptions,
 ) (*v1.ListResponse[v1.RoleBinding], error) {
-	domainResp, err := s.roleBindingUsecase.ListRoleBindings(ctx, options)
+	domainResp, err := s.roleBindingUsecase.ListRoleBindings(ctx, options.ToDomain())
 	if err != nil {
 		return nil, fmt.Errorf("list role bindings: %w", err)
 	}

--- a/pkg/apiserver/application/service/rolebinding/service_test.go
+++ b/pkg/apiserver/application/service/rolebinding/service_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	v1 "github.com/minuk-dev/opampcommander/api/v1"
+	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
 	rolebindingsvc "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/rolebinding"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
 	usermodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/model"
@@ -271,8 +272,8 @@ func TestService_ListRoleBindings(t *testing.T) {
 		rb := newRB()
 		domainResp := &model.ListResponse[*usermodel.RoleBinding]{Items: []*usermodel.RoleBinding{rb}}
 
-		opts := &model.ListOptions{Limit: 10}
-		mockRBUsecase.On("ListRoleBindings", ctx, opts).Return(domainResp, nil)
+		opts := &applicationport.ListOptions{Limit: 10}
+		mockRBUsecase.On("ListRoleBindings", ctx, opts.ToDomain()).Return(domainResp, nil)
 
 		result, err := svc.ListRoleBindings(ctx, opts)
 
@@ -290,8 +291,8 @@ func TestService_ListRoleBindings(t *testing.T) {
 		mockRole := new(mockRoleUsecase)
 		svc := newSvc(t, mockRBUsecase, mockRole)
 
-		opts := &model.ListOptions{Limit: 10}
-		mockRBUsecase.On("ListRoleBindings", ctx, opts).Return(nil, errMock)
+		opts := &applicationport.ListOptions{Limit: 10}
+		mockRBUsecase.On("ListRoleBindings", ctx, opts.ToDomain()).Return(nil, errMock)
 
 		result, err := svc.ListRoleBindings(ctx, opts)
 

--- a/pkg/apiserver/application/service/server/server.go
+++ b/pkg/apiserver/application/service/server/server.go
@@ -1,0 +1,77 @@
+// Package server provides the implementation of the ServerManageUsecase interface.
+package server
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"github.com/samber/lo"
+
+	v1 "github.com/minuk-dev/opampcommander/api/v1"
+	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
+	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+)
+
+var _ applicationport.ServerManageUsecase = (*Service)(nil)
+
+// Service is a struct that implements the ServerManageUsecase interface.
+type Service struct {
+	logger        *slog.Logger
+	serverUsecase agentport.ServerUsecase
+}
+
+// New creates a new instance of the Service struct.
+func New(
+	serverUsecase agentport.ServerUsecase,
+	logger *slog.Logger,
+) *Service {
+	return &Service{
+		logger:        logger,
+		serverUsecase: serverUsecase,
+	}
+}
+
+// ListServers lists all alive servers.
+func (s *Service) ListServers(ctx context.Context) (*v1.ListResponse[v1.Server], error) {
+	servers, err := s.serverUsecase.ListServers(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list servers: %w", err)
+	}
+
+	return v1.NewServerListResponse(
+		lo.Map(servers, func(server *agentmodel.Server, _ int) v1.Server {
+			return v1.Server{
+				ID:              server.ID,
+				LastHeartbeatAt: v1.NewTime(server.LastHeartbeatAt),
+				Conditions:      mapConditionsToAPI(server.Conditions),
+			}
+		}),
+		v1.ListMeta{
+			RemainingItemCount: 0,
+			Continue:           "",
+		},
+	), nil
+}
+
+// mapConditionsToAPI converts domain server conditions to API conditions.
+func mapConditionsToAPI(conditions []model.Condition) []v1.ServerCondition {
+	if len(conditions) == 0 {
+		return nil
+	}
+
+	apiConditions := make([]v1.ServerCondition, len(conditions))
+	for i, condition := range conditions {
+		apiConditions[i] = v1.ServerCondition{
+			Type:               v1.ServerConditionType(condition.Type),
+			LastTransitionTime: v1.NewTime(condition.LastTransitionTime),
+			Status:             v1.ServerConditionStatus(condition.Status),
+			Reason:             condition.Reason,
+			Message:            condition.Message,
+		}
+	}
+
+	return apiConditions
+}

--- a/pkg/apiserver/application/service/user/service.go
+++ b/pkg/apiserver/application/service/user/service.go
@@ -16,7 +16,6 @@ import (
 	v1 "github.com/minuk-dev/opampcommander/api/v1"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/application/helper"
 	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
-	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/port"
 	usermodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/model"
 	userport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/port"
@@ -60,8 +59,8 @@ func New(
 }
 
 // GetUser implements [applicationport.UserManageUsecase].
-func (s *Service) GetUser(ctx context.Context, uid uuid.UUID, options *model.GetOptions) (*v1.User, error) {
-	user, err := s.userUsecase.GetUser(ctx, uid, options)
+func (s *Service) GetUser(ctx context.Context, uid uuid.UUID, options *applicationport.GetOptions) (*v1.User, error) {
+	user, err := s.userUsecase.GetUser(ctx, uid, options.ToDomain())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get user: %w", err)
 	}
@@ -82,9 +81,9 @@ func (s *Service) GetUserByEmail(ctx context.Context, email string) (*v1.User, e
 // ListUsers implements [applicationport.UserManageUsecase].
 func (s *Service) ListUsers(
 	ctx context.Context,
-	options *model.ListOptions,
+	options *applicationport.ListOptions,
 ) (*v1.ListResponse[v1.User], error) {
-	response, err := s.userUsecase.ListUsers(ctx, options)
+	response, err := s.userUsecase.ListUsers(ctx, options.ToDomain())
 	if err != nil {
 		return nil, fmt.Errorf("failed to list users: %w", err)
 	}

--- a/pkg/apiserver/internal/module/application/application.go
+++ b/pkg/apiserver/internal/module/application/application.go
@@ -12,6 +12,7 @@ import (
 	agentgroupApplicationService "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/agentgroup"
 	agentpackageApplicationService "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/agentpackage"
 	agentremoteconfigApplicationService "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/agentremoteconfig"
+	authApplicationService "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/auth"
 	certificateApplicationService "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/certificate"
 	containerApplicationService "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/container"
 	endpointApplicationService "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/endpoint"
@@ -20,6 +21,7 @@ import (
 	opampApplicationService "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/opamp"
 	roleApplicationService "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/role"
 	rolebindingApplicationService "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/rolebinding"
+	serverApplicationService "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/server"
 	userApplicationService "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/user"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/config"
 	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
@@ -38,6 +40,8 @@ func New() fx.Option {
 
 			adminApplicationService.New,
 			fx.Annotate(Identity[*adminApplicationService.Service], fx.As(new(port.AdminUsecase))),
+			serverApplicationService.New,
+			fx.Annotate(Identity[*serverApplicationService.Service], fx.As(new(port.ServerManageUsecase))),
 
 			agentApplicationService.New,
 			fx.Annotate(Identity[*agentApplicationService.Service], fx.As(new(port.AgentManageUsecase))),
@@ -73,6 +77,8 @@ func New() fx.Option {
 			),
 
 			// user & RBAC application services
+			authApplicationService.New,
+			fx.Annotate(Identity[*authApplicationService.Service], fx.As(new(port.AuthProvisioningUsecase))),
 			userApplicationService.New,
 			fx.Annotate(Identity[*userApplicationService.Service], fx.As(new(port.UserManageUsecase))),
 

--- a/web/src/entities/agent-group/index.ts
+++ b/web/src/entities/agent-group/index.ts
@@ -1,1 +1,2 @@
 export * from './model/types';
+export * from './lib/remote-config';

--- a/web/src/entities/agent-group/lib/remote-config.ts
+++ b/web/src/entities/agent-group/lib/remote-config.ts
@@ -1,0 +1,19 @@
+import type { AgentGroup } from '../model/types';
+
+/**
+ * Describe how a group currently sources its remote config (a named ref, an
+ * inline spec, or none), so the UI can show what applying a new config would
+ * overwrite.
+ */
+export function describeRemoteConfigSource(g: AgentGroup): string {
+  const rc = g.spec.agentConfig?.agentRemoteConfig;
+  if (!rc) return 'none';
+  if (rc.agentRemoteConfigRef) return `ref → ${rc.agentRemoteConfigRef}`;
+  if (rc.agentRemoteConfigName) return `inline (${rc.agentRemoteConfigName})`;
+  return 'none';
+}
+
+/** The remote-config ref a group currently points at, or '' if none. */
+export function currentRemoteConfigRef(g: AgentGroup | null | undefined): string {
+  return g?.spec.agentConfig?.agentRemoteConfig?.agentRemoteConfigRef ?? '';
+}

--- a/web/src/features/apply-remote-config/index.ts
+++ b/web/src/features/apply-remote-config/index.ts
@@ -1,1 +1,2 @@
 export { default as ApplyToGroupDialog } from './ui/ApplyToGroupDialog';
+export { default as SelectRemoteConfigDialog } from './ui/SelectRemoteConfigDialog';

--- a/web/src/features/apply-remote-config/ui/ApplyToGroupDialog.tsx
+++ b/web/src/features/apply-remote-config/ui/ApplyToGroupDialog.tsx
@@ -17,7 +17,7 @@ import {
 } from '@mui/material';
 import { useEffect, useState } from 'react';
 import { api, useApi, type ListResponse } from '@shared/api';
-import type { AgentGroup } from '@entities/agent-group';
+import { describeRemoteConfigSource, type AgentGroup } from '@entities/agent-group';
 import type { AgentRemoteConfig } from '@entities/agent-remote-config';
 
 interface Props {
@@ -26,16 +26,6 @@ interface Props {
   config: AgentRemoteConfig | null;
   onClose: () => void;
   onApplied: () => void;
-}
-
-// Describe how a group currently sources its remote config, so the user can
-// see what an apply would overwrite.
-function currentRemoteConfig(g: AgentGroup): string {
-  const rc = g.spec.agentConfig?.agentRemoteConfig;
-  if (!rc) return 'none';
-  if (rc.agentRemoteConfigRef) return `ref → ${rc.agentRemoteConfigRef}`;
-  if (rc.agentRemoteConfigName) return `inline (${rc.agentRemoteConfigName})`;
-  return 'none';
 }
 
 export default function ApplyToGroupDialog({ open, namespace, config, onClose, onApplied }: Props) {
@@ -132,7 +122,7 @@ export default function ApplyToGroupDialog({ open, namespace, config, onClose, o
           </FormControl>
           {selectedGroup && (
             <Typography variant="body2" color="text.secondary">
-              Current remote config: <code>{currentRemoteConfig(selectedGroup)}</code> ·{' '}
+              Current remote config: <code>{describeRemoteConfigSource(selectedGroup)}</code> ·{' '}
               {selectedGroup.status.numAgents} agent(s) matched
             </Typography>
           )}

--- a/web/src/features/apply-remote-config/ui/SelectRemoteConfigDialog.tsx
+++ b/web/src/features/apply-remote-config/ui/SelectRemoteConfigDialog.tsx
@@ -1,0 +1,158 @@
+'use client';
+
+import {
+  Alert,
+  Button,
+  Dialog,
+  DialogActions,
+  DialogContent,
+  DialogContentText,
+  DialogTitle,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  Stack,
+  Typography,
+} from '@mui/material';
+import { useEffect, useState } from 'react';
+import { api, useApi, type ListResponse } from '@shared/api';
+import type { AgentGroup } from '@entities/agent-group';
+import type { AgentRemoteConfig } from '@entities/agent-remote-config';
+
+interface Props {
+  open: boolean;
+  namespace: string;
+  group: AgentGroup | null;
+  onClose: () => void;
+  onApplied: () => void;
+}
+
+// Describe how a group currently sources its remote config, so the user can
+// see what an apply would overwrite.
+function currentRemoteConfig(g: AgentGroup): string {
+  const rc = g.spec.agentConfig?.agentRemoteConfig;
+  if (!rc) return 'none';
+  if (rc.agentRemoteConfigRef) return `ref → ${rc.agentRemoteConfigRef}`;
+  if (rc.agentRemoteConfigName) return `inline (${rc.agentRemoteConfigName})`;
+  return 'none';
+}
+
+export default function SelectRemoteConfigDialog({
+  open,
+  namespace,
+  group,
+  onClose,
+  onApplied,
+}: Props) {
+  const [selected, setSelected] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [applyError, setApplyError] = useState<string | null>(null);
+
+  // Only fetch while the dialog is open (null key disables the request).
+  const {
+    data,
+    error: fetchError,
+    isLoading: loading,
+  } = useApi<ListResponse<AgentRemoteConfig>>(
+    open ? [`/api/v1/namespaces/${namespace}/agentremoteconfigs`, { limit: 200 }] : null,
+  );
+  const configs = data?.items ?? [];
+  const error =
+    applyError ??
+    (fetchError instanceof Error
+      ? fetchError.message
+      : fetchError
+        ? 'Failed to fetch remote configs'
+        : null);
+
+  // Preselect the group's current ref (if any) when the dialog opens.
+  useEffect(() => {
+    if (!open) {
+      setSelected('');
+      setApplyError(null);
+      return;
+    }
+    setSelected(group?.spec.agentConfig?.agentRemoteConfig?.agentRemoteConfigRef ?? '');
+  }, [open, group]);
+
+  const apply = async () => {
+    if (!group || !selected) return;
+    setBusy(true);
+    setApplyError(null);
+    try {
+      // Re-fetch the group to apply on top of its latest state, then point its
+      // remote config at the selected resource via agentRemoteConfigRef
+      // (clearing any inline config so the reference takes effect unambiguously).
+      const latest = await api.get<AgentGroup>(
+        `/api/v1/namespaces/${namespace}/agentgroups/${group.metadata.name}`,
+      );
+      const body: AgentGroup = {
+        ...latest,
+        spec: {
+          ...latest.spec,
+          agentConfig: {
+            ...latest.spec.agentConfig,
+            agentRemoteConfig: { agentRemoteConfigRef: selected },
+          },
+        },
+      };
+      await api.put(`/api/v1/namespaces/${namespace}/agentgroups/${group.metadata.name}`, body);
+      onApplied();
+    } catch (err) {
+      setApplyError(err instanceof Error ? err.message : 'Failed to apply');
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+      <DialogTitle>Apply remote config</DialogTitle>
+      <DialogContent>
+        <Stack spacing={2} mt={1}>
+          <DialogContentText>
+            Point agent group <code>{group?.metadata.name}</code> at a remote config. The group&apos;s
+            matching agents will receive this config. Any existing remote config on the group will be
+            replaced.
+          </DialogContentText>
+          {group && (
+            <Typography variant="body2" color="text.secondary">
+              Current remote config: <code>{currentRemoteConfig(group)}</code> ·{' '}
+              {group.status.numAgents} agent(s) matched
+            </Typography>
+          )}
+          {error && <Alert severity="error">{error}</Alert>}
+          <FormControl fullWidth disabled={loading || busy}>
+            <InputLabel id="select-remote-config-label">Remote config</InputLabel>
+            <Select
+              labelId="select-remote-config-label"
+              label="Remote config"
+              value={selected}
+              onChange={(e) => setSelected(e.target.value)}
+            >
+              {configs.length === 0 && (
+                <MenuItem value="" disabled>
+                  {loading ? 'Loading…' : 'No remote configs in this namespace'}
+                </MenuItem>
+              )}
+              {configs.map((c) => (
+                <MenuItem key={c.metadata.name} value={c.metadata.name}>
+                  {c.metadata.name}
+                </MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+        </Stack>
+      </DialogContent>
+      <DialogActions>
+        <Button onClick={onClose} disabled={busy}>
+          Cancel
+        </Button>
+        <Button variant="contained" onClick={apply} disabled={busy || !selected}>
+          Apply
+        </Button>
+      </DialogActions>
+    </Dialog>
+  );
+}

--- a/web/src/features/apply-remote-config/ui/SelectRemoteConfigDialog.tsx
+++ b/web/src/features/apply-remote-config/ui/SelectRemoteConfigDialog.tsx
@@ -15,9 +15,13 @@ import {
   Stack,
   Typography,
 } from '@mui/material';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { api, useApi, type ListResponse } from '@shared/api';
-import type { AgentGroup } from '@entities/agent-group';
+import {
+  currentRemoteConfigRef,
+  describeRemoteConfigSource,
+  type AgentGroup,
+} from '@entities/agent-group';
 import type { AgentRemoteConfig } from '@entities/agent-remote-config';
 
 interface Props {
@@ -26,16 +30,6 @@ interface Props {
   group: AgentGroup | null;
   onClose: () => void;
   onApplied: () => void;
-}
-
-// Describe how a group currently sources its remote config, so the user can
-// see what an apply would overwrite.
-function currentRemoteConfig(g: AgentGroup): string {
-  const rc = g.spec.agentConfig?.agentRemoteConfig;
-  if (!rc) return 'none';
-  if (rc.agentRemoteConfigRef) return `ref → ${rc.agentRemoteConfigRef}`;
-  if (rc.agentRemoteConfigName) return `inline (${rc.agentRemoteConfigName})`;
-  return 'none';
 }
 
 export default function SelectRemoteConfigDialog({
@@ -66,15 +60,21 @@ export default function SelectRemoteConfigDialog({
         ? 'Failed to fetch remote configs'
         : null);
 
-  // Preselect the group's current ref (if any) when the dialog opens.
+  // Read the latest group through a ref so the preselect effect can key on
+  // `open` alone: re-running it on every `group` change would clobber an
+  // in-progress selection whenever SWR revalidates the group in the background.
+  const groupRef = useRef(group);
+  groupRef.current = group;
+
+  // Preselect the group's current ref (if any) only when the dialog opens.
   useEffect(() => {
     if (!open) {
       setSelected('');
       setApplyError(null);
       return;
     }
-    setSelected(group?.spec.agentConfig?.agentRemoteConfig?.agentRemoteConfigRef ?? '');
-  }, [open, group]);
+    setSelected(currentRemoteConfigRef(groupRef.current));
+  }, [open]);
 
   const apply = async () => {
     if (!group || !selected) return;
@@ -112,13 +112,13 @@ export default function SelectRemoteConfigDialog({
       <DialogContent>
         <Stack spacing={2} mt={1}>
           <DialogContentText>
-            Point agent group <code>{group?.metadata.name}</code> at a remote config. The group&apos;s
-            matching agents will receive this config. Any existing remote config on the group will be
-            replaced.
+            Point agent group <code>{group?.metadata.name}</code> at a remote config. The
+            group&apos;s matching agents will receive this config. Any existing remote config on the
+            group will be replaced.
           </DialogContentText>
           {group && (
             <Typography variant="body2" color="text.secondary">
-              Current remote config: <code>{currentRemoteConfig(group)}</code> ·{' '}
+              Current remote config: <code>{describeRemoteConfigSource(group)}</code> ·{' '}
               {group.status.numAgents} agent(s) matched
             </Typography>
           )}

--- a/web/src/views/agent-group-detail/ui/AgentGroupDetailPage.tsx
+++ b/web/src/views/agent-group-detail/ui/AgentGroupDetailPage.tsx
@@ -22,6 +22,7 @@ import {
   Edit as EditIcon,
   PeopleAlt as PeopleAltIcon,
   CalendarToday as CalendarIcon,
+  PlaylistAddCheck as ApplyIcon,
 } from '@mui/icons-material';
 import Link from 'next/link';
 import { useParams, useRouter, useSearchParams } from 'next/navigation';
@@ -38,6 +39,11 @@ import dynamic from 'next/dynamic';
 const AgentGroupEditDialog = dynamic(
   () => import('@features/agent-group-edit/ui/AgentGroupEditDialog'),
 );
+// Lazy-loaded: the remote-config picker fetches the namespace's configs, only
+// needed once the user opens it — keep it out of the initial route bundle.
+const SelectRemoteConfigDialog = dynamic(
+  () => import('@features/apply-remote-config/ui/SelectRemoteConfigDialog'),
+);
 
 function AgentGroupDetailInner() {
   const params = useParams<{ name: string }>();
@@ -46,6 +52,7 @@ function AgentGroupDetailInner() {
   const { namespace } = useNamespace();
   const [tab, setTab] = useState(0);
   const [editing, setEditing] = useState(false);
+  const [applyingConfig, setApplyingConfig] = useState(false);
   const [deleting, setDeleting] = useState(false);
   const [actionHandled, setActionHandled] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
@@ -74,6 +81,8 @@ function AgentGroupDetailInner() {
     setActionHandled(true);
     if (action === 'edit') {
       setEditing(true);
+    } else if (action === 'apply') {
+      setApplyingConfig(true);
     } else if (action === 'delete') {
       setDeleting(true);
     }
@@ -134,6 +143,13 @@ function AgentGroupDetailInner() {
               variant="outlined"
             >
               View agents
+            </Button>
+            <Button
+              startIcon={<ApplyIcon />}
+              variant="outlined"
+              onClick={() => setApplyingConfig(true)}
+            >
+              Apply remote config
             </Button>
             <Button startIcon={<EditIcon />} variant="contained" onClick={() => setEditing(true)}>
               Edit
@@ -274,6 +290,18 @@ function AgentGroupDetailInner() {
           onClose={() => setEditing(false)}
           onSaved={() => {
             setEditing(false);
+            void fetchGroup();
+          }}
+        />
+      )}
+      {applyingConfig && (
+        <SelectRemoteConfigDialog
+          open
+          namespace={namespace}
+          group={group}
+          onClose={() => setApplyingConfig(false)}
+          onApplied={() => {
+            setApplyingConfig(false);
             void fetchGroup();
           }}
         />

--- a/web/src/views/agent-groups/ui/AgentGroupsPage.tsx
+++ b/web/src/views/agent-groups/ui/AgentGroupsPage.tsx
@@ -23,6 +23,7 @@ import {
   Delete as DeleteIcon,
   Edit as EditIcon,
   PeopleAlt as PeopleAltIcon,
+  PlaylistAddCheck as ApplyIcon,
   Visibility as ViewIcon,
 } from '@mui/icons-material';
 import Link from 'next/link';
@@ -242,6 +243,11 @@ export default function AgentGroupsPage() {
                           label: 'Edit',
                           icon: <EditIcon fontSize="small" />,
                           href: `/agentgroups/${g.metadata.name}?action=edit`,
+                        },
+                        {
+                          label: 'Apply remote config',
+                          icon: <ApplyIcon fontSize="small" />,
+                          href: `/agentgroups/${g.metadata.name}?action=apply`,
                         },
                         {
                           label: 'Delete',


### PR DESCRIPTION
## Summary
Adds the ability to select and apply an agent remote config **from an agent group** in the web UI.

Previously a remote config could only be wired to a group from the remote-config list (`ApplyToGroupDialog` — remote config → pick group). This adds the reverse direction so operators can start from a group and choose which remote config to apply.

## Changes
- **`SelectRemoteConfigDialog`** (new, in the `apply-remote-config` feature): lists the namespace's remote configs, preselects the group's current ref, and on apply re-fetches the group then points `spec.agentConfig.agentRemoteConfig` at the chosen config via `agentRemoteConfigRef` (clearing any inline config so the reference takes effect unambiguously).
- **Agent group detail page**: new "Apply remote config" action button; also wired the `?action=apply` auto-trigger.
- **Agent groups list**: new "Apply remote config" row-menu action that routes to the detail page with `?action=apply`.

## Testing
- `npx tsc --noEmit` ✅
- `npm run lint` ✅
- `npm test` ✅ (60 passed)
- `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)