### PR TITLE
feat(web): remove a group's remote config, with confirmation

### DIFF
--- a/web/src/entities/agent-group/lib/remote-config.ts
+++ b/web/src/entities/agent-group/lib/remote-config.ts
@@ -17,3 +17,9 @@ export function describeRemoteConfigSource(g: AgentGroup): string {
 export function currentRemoteConfigRef(g: AgentGroup | null | undefined): string {
   return g?.spec.agentConfig?.agentRemoteConfig?.agentRemoteConfigRef ?? '';
 }
+
+/** Whether the group currently has any remote config (a ref or inline) set. */
+export function hasRemoteConfig(g: AgentGroup | null | undefined): boolean {
+  const rc = g?.spec.agentConfig?.agentRemoteConfig;
+  return !!(rc?.agentRemoteConfigRef || rc?.agentRemoteConfigName || rc?.agentRemoteConfigSpec);
+}

--- a/web/src/features/apply-remote-config/ui/SelectRemoteConfigDialog.tsx
+++ b/web/src/features/apply-remote-config/ui/SelectRemoteConfigDialog.tsx
@@ -20,6 +20,7 @@ import { api, useApi, type ListResponse } from '@shared/api';
 import {
   currentRemoteConfigRef,
   describeRemoteConfigSource,
+  hasRemoteConfig,
   type AgentGroup,
 } from '@entities/agent-group';
 import type { AgentRemoteConfig } from '@entities/agent-remote-config';
@@ -76,14 +77,16 @@ export default function SelectRemoteConfigDialog({
     setSelected(currentRemoteConfigRef(groupRef.current));
   }, [open]);
 
-  const apply = async () => {
-    if (!group || !selected) return;
+  // Write the group's remote config: a ref points it at the named resource,
+  // null clears any existing remote config off the group.
+  const save = async (ref: string | null) => {
+    if (!group) return;
     setBusy(true);
     setApplyError(null);
     try {
-      // Re-fetch the group to apply on top of its latest state, then point its
-      // remote config at the selected resource via agentRemoteConfigRef
-      // (clearing any inline config so the reference takes effect unambiguously).
+      // Re-fetch the group to apply on top of its latest state. Setting a ref
+      // clears any inline config so the reference takes effect unambiguously;
+      // clearing drops the agentRemoteConfig entirely.
       const latest = await api.get<AgentGroup>(
         `/api/v1/namespaces/${namespace}/agentgroups/${group.metadata.name}`,
       );
@@ -93,7 +96,7 @@ export default function SelectRemoteConfigDialog({
           ...latest.spec,
           agentConfig: {
             ...latest.spec.agentConfig,
-            agentRemoteConfig: { agentRemoteConfigRef: selected },
+            agentRemoteConfig: ref ? { agentRemoteConfigRef: ref } : undefined,
           },
         },
       };
@@ -114,7 +117,7 @@ export default function SelectRemoteConfigDialog({
           <DialogContentText>
             Point agent group <code>{group?.metadata.name}</code> at a remote config. The
             group&apos;s matching agents will receive this config. Any existing remote config on the
-            group will be replaced.
+            group will be replaced, or use Remove to clear it.
           </DialogContentText>
           {group && (
             <Typography variant="body2" color="text.secondary">
@@ -146,10 +149,15 @@ export default function SelectRemoteConfigDialog({
         </Stack>
       </DialogContent>
       <DialogActions>
+        {hasRemoteConfig(group) && (
+          <Button color="error" onClick={() => save(null)} disabled={busy} sx={{ mr: 'auto' }}>
+            Remove
+          </Button>
+        )}
         <Button onClick={onClose} disabled={busy}>
           Cancel
         </Button>
-        <Button variant="contained" onClick={apply} disabled={busy || !selected}>
+        <Button variant="contained" onClick={() => save(selected)} disabled={busy || !selected}>
           Apply
         </Button>
       </DialogActions>

--- a/web/src/features/apply-remote-config/ui/SelectRemoteConfigDialog.tsx
+++ b/web/src/features/apply-remote-config/ui/SelectRemoteConfigDialog.tsx
@@ -63,21 +63,31 @@ export default function SelectRemoteConfigDialog({
         ? 'Failed to fetch remote configs'
         : null);
 
-  // Read the latest group through a ref so the preselect effect can key on
-  // `open` alone: re-running it on every `group` change would clobber an
+  // Read the latest group through a ref so the preselect effect doesn't have to
+  // depend on `group`: re-running it on every `group` change would clobber an
   // in-progress selection whenever SWR revalidates the group in the background.
   const groupRef = useRef(group);
   groupRef.current = group;
 
-  // Preselect the group's current ref (if any) only when the dialog opens.
+  // Preselect the group's current ref once per open. We wait for the config
+  // list and only preselect when the ref is actually in it, so the Select never
+  // holds an out-of-range value (e.g. the referenced config was deleted, or
+  // sits beyond the fetch limit). `didPreselect` keeps a later SWR revalidation
+  // from clobbering the user's pick.
+  const didPreselect = useRef(false);
   useEffect(() => {
     if (!open) {
       setSelected('');
       setApplyError(null);
+      didPreselect.current = false;
       return;
     }
-    setSelected(currentRemoteConfigRef(groupRef.current));
-  }, [open]);
+    if (loading || didPreselect.current) return;
+    didPreselect.current = true;
+    const ref = currentRemoteConfigRef(groupRef.current);
+    const items = data?.items ?? [];
+    setSelected(items.some((c) => c.metadata.name === ref) ? ref : '');
+  }, [open, loading, data]);
 
   // Write the group's remote config: a ref points it at the named resource,
   // null clears any existing remote config off the group.

--- a/web/src/features/apply-remote-config/ui/SelectRemoteConfigDialog.tsx
+++ b/web/src/features/apply-remote-config/ui/SelectRemoteConfigDialog.tsx
@@ -17,6 +17,7 @@ import {
 } from '@mui/material';
 import { useEffect, useRef, useState } from 'react';
 import { api, useApi, type ListResponse } from '@shared/api';
+import { ConfirmDialog } from '@shared/ui';
 import {
   currentRemoteConfigRef,
   describeRemoteConfigSource,
@@ -42,6 +43,7 @@ export default function SelectRemoteConfigDialog({
 }: Props) {
   const [selected, setSelected] = useState('');
   const [busy, setBusy] = useState(false);
+  const [confirmingRemove, setConfirmingRemove] = useState(false);
   const [applyError, setApplyError] = useState<string | null>(null);
 
   // Only fetch while the dialog is open (null key disables the request).
@@ -110,57 +112,76 @@ export default function SelectRemoteConfigDialog({
   };
 
   return (
-    <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
-      <DialogTitle>Apply remote config</DialogTitle>
-      <DialogContent>
-        <Stack spacing={2} mt={1}>
-          <DialogContentText>
-            Point agent group <code>{group?.metadata.name}</code> at a remote config. The
-            group&apos;s matching agents will receive this config. Any existing remote config on the
-            group will be replaced, or use Remove to clear it.
-          </DialogContentText>
-          {group && (
-            <Typography variant="body2" color="text.secondary">
-              Current remote config: <code>{describeRemoteConfigSource(group)}</code> ·{' '}
-              {group.status.numAgents} agent(s) matched
-            </Typography>
-          )}
-          {error && <Alert severity="error">{error}</Alert>}
-          <FormControl fullWidth disabled={loading || busy}>
-            <InputLabel id="select-remote-config-label">Remote config</InputLabel>
-            <Select
-              labelId="select-remote-config-label"
-              label="Remote config"
-              value={selected}
-              onChange={(e) => setSelected(e.target.value)}
+    <>
+      <Dialog open={open} onClose={onClose} fullWidth maxWidth="sm">
+        <DialogTitle>Apply remote config</DialogTitle>
+        <DialogContent>
+          <Stack spacing={2} mt={1}>
+            <DialogContentText>
+              Point agent group <code>{group?.metadata.name}</code> at a remote config. The
+              group&apos;s matching agents will receive this config. Any existing remote config on
+              the group will be replaced, or use Remove to clear it.
+            </DialogContentText>
+            {group && (
+              <Typography variant="body2" color="text.secondary">
+                Current remote config: <code>{describeRemoteConfigSource(group)}</code> ·{' '}
+                {group.status.numAgents} agent(s) matched
+              </Typography>
+            )}
+            {error && <Alert severity="error">{error}</Alert>}
+            <FormControl fullWidth disabled={loading || busy}>
+              <InputLabel id="select-remote-config-label">Remote config</InputLabel>
+              <Select
+                labelId="select-remote-config-label"
+                label="Remote config"
+                value={selected}
+                onChange={(e) => setSelected(e.target.value)}
+              >
+                {configs.length === 0 && (
+                  <MenuItem value="" disabled>
+                    {loading ? 'Loading…' : 'No remote configs in this namespace'}
+                  </MenuItem>
+                )}
+                {configs.map((c) => (
+                  <MenuItem key={c.metadata.name} value={c.metadata.name}>
+                    {c.metadata.name}
+                  </MenuItem>
+                ))}
+              </Select>
+            </FormControl>
+          </Stack>
+        </DialogContent>
+        <DialogActions>
+          {hasRemoteConfig(group) && (
+            <Button
+              color="error"
+              onClick={() => setConfirmingRemove(true)}
+              disabled={busy}
+              sx={{ mr: 'auto' }}
             >
-              {configs.length === 0 && (
-                <MenuItem value="" disabled>
-                  {loading ? 'Loading…' : 'No remote configs in this namespace'}
-                </MenuItem>
-              )}
-              {configs.map((c) => (
-                <MenuItem key={c.metadata.name} value={c.metadata.name}>
-                  {c.metadata.name}
-                </MenuItem>
-              ))}
-            </Select>
-          </FormControl>
-        </Stack>
-      </DialogContent>
-      <DialogActions>
-        {hasRemoteConfig(group) && (
-          <Button color="error" onClick={() => save(null)} disabled={busy} sx={{ mr: 'auto' }}>
-            Remove
+              Remove
+            </Button>
+          )}
+          <Button onClick={onClose} disabled={busy}>
+            Cancel
           </Button>
-        )}
-        <Button onClick={onClose} disabled={busy}>
-          Cancel
-        </Button>
-        <Button variant="contained" onClick={() => save(selected)} disabled={busy || !selected}>
-          Apply
-        </Button>
-      </DialogActions>
-    </Dialog>
+          <Button variant="contained" onClick={() => save(selected)} disabled={busy || !selected}>
+            Apply
+          </Button>
+        </DialogActions>
+      </Dialog>
+      <ConfirmDialog
+        open={confirmingRemove}
+        title="Remove remote config"
+        message={`Clear the remote config from "${group?.metadata.name}"? Matching agents will stop receiving it.`}
+        confirmLabel="Remove"
+        destructive
+        onClose={() => setConfirmingRemove(false)}
+        onConfirm={async () => {
+          setConfirmingRemove(false);
+          await save(null);
+        }}
+      />
+    </>
   );
 }


### PR DESCRIPTION
## Summary
Follow-ups to #449 (already merged). Lets operators **clear** a remote config from an agent group, not just apply one, and hardens the picker.

## Changes
- **Remove action**: `SelectRemoteConfigDialog` gains a destructive "Remove" button (shown only when the group currently has a remote config). Apply/remove now share one `save(ref | null)` helper — `null` PUTs the group with `agentRemoteConfig` dropped (preserving any `connectionSettings`).
- **Confirmation**: the Remove action routes through the shared `ConfirmDialog` so a group's config can't be cleared in one misclick.
- **Robust preselect**: preselect the group's current ref only after the config list loads and only when the ref is actually in it, so the Select never holds an out-of-range value (referenced config deleted / beyond the fetch limit / still loading). A `didPreselect` guard keeps a background SWR revalidation from clobbering the user's pick.

## Testing
- `tsc --noEmit` ✅
- `npm run lint` ✅
- `npm run format:check` ✅
- `npm test` ✅ (60 passed)
- `npm run build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)