### PR TITLE
feat(opampctl): hide disconnected agents from `get agent` by default

### DIFF
--- a/pkg/client/option.go
+++ b/pkg/client/option.go
@@ -78,6 +78,9 @@ type ListSettings struct {
 	continueToken *string
 	// includeDeleted asks the server to include soft-deleted resources.
 	includeDeleted *bool
+	// connectedOnly asks the server to return only currently-connected agents;
+	// nil means no connection filter.
+	connectedOnly *bool
 	// selector filters agents by identifying attributes (exact key=value match);
 	// nil or empty means no attribute filter.
 	selector map[string]string
@@ -116,6 +119,15 @@ func WithContinueToken(token string) ListOption {
 func WithIncludeDeleted(includeDeleted bool) ListOption {
 	return ListOptionFunc(func(opt *ListSettings) {
 		opt.includeDeleted = &includeDeleted
+	})
+}
+
+// WithConnectedOnly restricts an agent listing to currently-connected agents
+// when set to true. False (the default) returns both connected and disconnected
+// agents.
+func WithConnectedOnly(connectedOnly bool) ListOption {
+	return ListOptionFunc(func(opt *ListSettings) {
+		opt.connectedOnly = &connectedOnly
 	})
 }
 
@@ -174,6 +186,10 @@ func (s ListSettings) applyTo(req *resty.Request) {
 
 	if mo.PointerToOption(s.includeDeleted).OrElse(false) {
 		req.SetQueryParam("includeDeleted", "true")
+	}
+
+	if mo.PointerToOption(s.connectedOnly).OrElse(false) {
+		req.SetQueryParam("connected", "true")
 	}
 
 	values := url.Values{}

--- a/pkg/clientutil/list.go
+++ b/pkg/clientutil/list.go
@@ -54,11 +54,13 @@ func ListAgentFully(
 // ListAgentFullyByAgentGroup lists all agents in a specific agent group and applies
 // the provided function to each agent.
 // It continues to fetch agents until there are no more agents to fetch.
+// Extra list options (e.g. client.WithConnectedOnly) are applied to every page request.
 func ListAgentFullyByAgentGroup(
 	ctx context.Context,
 	cli *client.Client,
 	namespace string,
 	agentGroupName string,
+	extraOpts ...client.ListOption,
 ) ([]v1.Agent, error) {
 	var agents []v1.Agent
 	// Initialize the continue token to an empty string
@@ -68,6 +70,8 @@ func ListAgentFullyByAgentGroup(
 		opts := []client.ListOption{
 			client.WithLimit(ChunkSize),
 		}
+		opts = append(opts, extraOpts...)
+
 		if continueToken != "" {
 			opts = append(opts, client.WithContinueToken(continueToken))
 		}

--- a/pkg/cmd/opampctl/get/agent/agent.go
+++ b/pkg/cmd/opampctl/get/agent/agent.go
@@ -40,6 +40,7 @@ type CommandOptions struct {
 	namespace              string
 	allNamespaces          bool
 	decodeCapabilities     bool
+	includeDisconnected    bool
 	selector               map[string]string
 	nonIdentifyingSelector map[string]string
 
@@ -75,6 +76,10 @@ func NewCommand(options CommandOptions) *cobra.Command {
 	cmd.Flags().BoolVar(
 		&options.decodeCapabilities, "decode-capabilities", false,
 		"Decode the capabilities bitmask into human-readable flag names",
+	)
+	cmd.Flags().BoolVar(
+		&options.includeDisconnected, "include-disconnected", false,
+		"Include disconnected agents in the listing (by default only connected agents are shown)",
 	)
 	cmd.Flags().StringToStringVarP(
 		&options.selector, "selector", "l", nil,
@@ -266,13 +271,25 @@ func (opt *CommandOptions) ValidArgsFunction(
 	return instanceUIDs, cobra.ShellCompDirectiveNoFileComp
 }
 
+// listOptions builds the per-page list options shared by every list path. By
+// default it asks the server for connected agents only; --include-disconnected
+// drops that filter so disconnected agents are returned as well.
+func (opt *CommandOptions) listOptions() []client.ListOption {
+	if opt.includeDisconnected {
+		return nil
+	}
+
+	return []client.ListOption{client.WithConnectedOnly(true)}
+}
+
 func (opt *CommandOptions) listSingleNamespace(cmd *cobra.Command) ([]v1.Agent, error) {
 	if opt.byAgentGroup == "" {
-		agents, err := clientutil.ListAgentFully(
-			cmd.Context(), opt.client, opt.namespace,
+		opts := append([]client.ListOption{
 			client.WithSelector(opt.selector),
 			client.WithNonIdentifyingSelector(opt.nonIdentifyingSelector),
-		)
+		}, opt.listOptions()...)
+
+		agents, err := clientutil.ListAgentFully(cmd.Context(), opt.client, opt.namespace, opts...)
 		if err != nil {
 			return nil, fmt.Errorf("failed to list agents: %w", err)
 		}
@@ -281,7 +298,7 @@ func (opt *CommandOptions) listSingleNamespace(cmd *cobra.Command) ([]v1.Agent, 
 	}
 
 	agents, err := clientutil.ListAgentFullyByAgentGroup(
-		cmd.Context(), opt.client, opt.namespace, opt.byAgentGroup,
+		cmd.Context(), opt.client, opt.namespace, opt.byAgentGroup, opt.listOptions()...,
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list agents by agent group: %w", err)
@@ -295,12 +312,16 @@ func (opt *CommandOptions) listAllNamespaces(cmd *cobra.Command) ([]v1.Agent, er
 		cmd.Context(), opt.client,
 		func(ctx context.Context, namespace string) ([]v1.Agent, error) {
 			if opt.byAgentGroup == "" {
-				return clientutil.ListAgentFully(ctx, opt.client, namespace,
+				opts := append([]client.ListOption{
 					client.WithSelector(opt.selector),
-					client.WithNonIdentifyingSelector(opt.nonIdentifyingSelector))
+					client.WithNonIdentifyingSelector(opt.nonIdentifyingSelector),
+				}, opt.listOptions()...)
+
+				return clientutil.ListAgentFully(ctx, opt.client, namespace, opts...)
 			}
 
-			return clientutil.ListAgentFullyByAgentGroup(ctx, opt.client, namespace, opt.byAgentGroup)
+			return clientutil.ListAgentFullyByAgentGroup(ctx, opt.client, namespace, opt.byAgentGroup,
+				opt.listOptions()...)
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
## What

`opampctl get agent` now lists only currently-connected agents by default. A new `--include-disconnected` flag restores the previous behaviour of listing disconnected agents too.

```sh
opampctl get agent                        # connected agents only (new default)
opampctl get agent --include-disconnected # all agents
opampctl get agent <uid>                  # unchanged — returns the agent regardless of state
```

## How

Filtering is delegated to the server via the existing `connected` query parameter — already supported by both the agent list (`/agents`) and agent-group (`/agentgroups/{name}/agents`) list endpoints — rather than dropping agents client-side. This means disconnected agents are never fetched over the wire or counted against pagination.

- Add `client.WithConnectedOnly` list option (emits `connected=true`).
- Thread `extraOpts ...client.ListOption` through `clientutil.ListAgentFullyByAgentGroup` (mirrors `ListAgentFully`).
- Pass `WithConnectedOnly(true)` on every list path (plain, by-agent-group, all-namespaces) unless `--include-disconnected` is set.

`get agent <uid>` and shell completion (`SearchAgents`) are intentionally untouched.

## Test

- `go build ./...` on affected packages
- `golangci-lint run` → 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)