### PR TITLE
fix(web): prompt browser to save credentials on basic login

### DIFF
--- a/web/src/views/login/ui/LoginPage.tsx
+++ b/web/src/views/login/ui/LoginPage.tsx
@@ -18,6 +18,26 @@ import { Suspense, useEffect, useState } from 'react';
 import { useAuth, type OAuth2AuthCodeURLResponse } from '@entities/session';
 import { api } from '@shared/api';
 
+// Ask the browser's password manager to save these credentials. Uses the
+// Credential Management API, which only exists in Chromium-based browsers; it's
+// silently skipped elsewhere. Failures (e.g. the user declining) are ignored so
+// they never block the post-login redirect.
+async function storePasswordCredential(username: string, password: string): Promise<void> {
+  if (typeof window === 'undefined') return;
+  const PasswordCredentialCtor = (
+    window as unknown as {
+      PasswordCredential?: new (data: { id: string; password: string }) => Credential;
+    }
+  ).PasswordCredential;
+  if (!PasswordCredentialCtor || !navigator.credentials?.store) return;
+  try {
+    const credential = new PasswordCredentialCtor({ id: username, password });
+    await navigator.credentials.store(credential);
+  } catch {
+    // Ignore — saving credentials is best-effort.
+  }
+}
+
 function LoginInner() {
   const router = useRouter();
   const search = useSearchParams();
@@ -48,6 +68,12 @@ function LoginInner() {
     setSubmitting(true);
     try {
       await loginBasic(username, password);
+      // This is an AJAX login with a client-side (SPA) redirect, so the browser's
+      // heuristic for offering to save credentials — which keys off a real form
+      // navigation — never fires. Explicitly hand the credentials to the browser's
+      // password manager via the Credential Management API (Chromium-only; a no-op
+      // elsewhere) so it can prompt to save them.
+      await storePasswordCredential(username, password);
       router.replace(from);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Login failed');


### PR DESCRIPTION
## What

Fixes the issue where the browser would not offer to save the username/password on basic login.

## Why

Login is an AJAX request (`fetch` to `/api/v1/auth/basic`) followed by a client-side (SPA) redirect via `router.replace()`, so no real form navigation occurs. The browser's (especially Chrome's) "save password" prompt relies on a heuristic that detects a real page navigation after a form submission — which never fires in an SPA, so the save prompt was never shown. (The `autoComplete` attributes themselves were already set correctly.)

## How

Right after a successful login, explicitly hand the credentials to the browser's password manager via the **Credential Management API** (`navigator.credentials.store(new PasswordCredential(...))`).

- The save prompt appears in Chromium-based browsers (Chrome/Edge).
- On unsupported browsers (Firefox/Safari) it is skipped via feature detection.
- Failures / user dismissal are ignored so they never block the post-login redirect.

## Notes

- Saving credentials only works in a secure context (https or localhost). It will not work when accessed over an IP (e.g. `http://192.168.x.x`).
- Not applicable to GitHub OAuth login (no password); only affects basic login.

## Test

- `npx tsc --noEmit` ✅
- `npm run lint` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)