### PR TITLE
feat(agent): classify agent type from service.name

### DIFF
--- a/api/v1/agent.go
+++ b/api/v1/agent.go
@@ -28,6 +28,12 @@ type AgentMetadata struct {
 	// Namespace is the namespace the agent belongs to.
 	Namespace string `json:"namespace"`
 
+	// Type classifies the agent and, for OpenTelemetry Collectors, its
+	// distribution (e.g. "otelcol", "otelcol-contrib"). It is derived from the
+	// reported "service.name" identifying attribute and is "unknown" when the
+	// agent does not follow the OpenTelemetry Collector naming convention.
+	Type string `json:"type,omitempty"`
+
 	// Description is a human-readable description of the agent.
 	Description AgentDescription `json:"description,omitzero"`
 

--- a/pkg/apiserver/application/helper/mapper.go
+++ b/pkg/apiserver/application/helper/mapper.go
@@ -171,6 +171,7 @@ func (mapper *Mapper) MapAgentToAPI(agent *agentmodel.Agent) *v1.Agent {
 		Metadata: v1.AgentMetadata{
 			InstanceUID: agent.Metadata.InstanceUID,
 			Namespace:   agent.Metadata.Namespace,
+			Type:        string(agent.Metadata.Description.AgentType()),
 			Description: v1.AgentDescription{
 				IdentifyingAttributes:    agent.Metadata.Description.IdentifyingAttributes,
 				NonIdentifyingAttributes: agent.Metadata.Description.NonIdentifyingAttributes,

--- a/pkg/apiserver/docs/docs.go
+++ b/pkg/apiserver/docs/docs.go
@@ -3487,6 +3487,10 @@ const docTemplate = `{
                 "namespace": {
                     "description": "Namespace is the namespace the agent belongs to.",
                     "type": "string"
+                },
+                "type": {
+                    "description": "Type classifies the agent and, for OpenTelemetry Collectors, its\ndistribution (e.g. \"otelcol\", \"otelcol-contrib\"). It is derived from the\nreported \"service.name\" identifying attribute and is \"unknown\" when the\nagent does not follow the OpenTelemetry Collector naming convention.",
+                    "type": "string"
                 }
             }
         },

--- a/pkg/apiserver/docs/swagger.json
+++ b/pkg/apiserver/docs/swagger.json
@@ -3479,6 +3479,10 @@
                 "namespace": {
                     "description": "Namespace is the namespace the agent belongs to.",
                     "type": "string"
+                },
+                "type": {
+                    "description": "Type classifies the agent and, for OpenTelemetry Collectors, its\ndistribution (e.g. \"otelcol\", \"otelcol-contrib\"). It is derived from the\nreported \"service.name\" identifying attribute and is \"unknown\" when the\nagent does not follow the OpenTelemetry Collector naming convention.",
+                    "type": "string"
                 }
             }
         },

--- a/pkg/apiserver/docs/swagger.yaml
+++ b/pkg/apiserver/docs/swagger.yaml
@@ -171,6 +171,13 @@ definitions:
       namespace:
         description: Namespace is the namespace the agent belongs to.
         type: string
+      type:
+        description: |-
+          Type classifies the agent and, for OpenTelemetry Collectors, its
+          distribution (e.g. "otelcol", "otelcol-contrib"). It is derived from the
+          reported "service.name" identifying attribute and is "unknown" when the
+          agent does not follow the OpenTelemetry Collector naming convention.
+        type: string
     type: object
   AgentPackage:
     properties:

--- a/pkg/apiserver/domain/agent/model/agent/agenttype.go
+++ b/pkg/apiserver/domain/agent/model/agent/agenttype.go
@@ -1,0 +1,38 @@
+package agent
+
+// Type is an extensible label for the agent's kind and, for OpenTelemetry
+// Collectors, its distribution. It is derived from the reported "service.name"
+// identifying attribute.
+//
+// Like Platform it is an open enum: the well-known OpenTelemetry Collector
+// distributions have named constants for documentation and comparison, but any
+// "otelcol"/"otelcol-<distro>" service.name is preserved verbatim so a new
+// distribution surfaces as its own value without a code change. Anything that
+// does not follow the Collector naming convention is TypeUnknown.
+type Type string
+
+const (
+	// TypeOTelCollector is the upstream OpenTelemetry Collector core
+	// distribution, which reports service.name "otelcol".
+	TypeOTelCollector Type = "otelcol"
+	// TypeOTelCollectorContrib is the contrib distribution, which reports
+	// service.name "otelcol-contrib".
+	TypeOTelCollectorContrib Type = "otelcol-contrib"
+	// TypeOTelCollectorK8s is the Kubernetes distribution, which reports
+	// service.name "otelcol-k8s".
+	TypeOTelCollectorK8s Type = "otelcol-k8s"
+	// TypeUnknown means the agent kind could not be determined from
+	// service.name.
+	TypeUnknown Type = "unknown"
+)
+
+// otelCollectorPrefix is the naming convention shared by every official
+// OpenTelemetry Collector distribution: the core binary is "otelcol" and each
+// distribution appends a "-<distro>" suffix (e.g. "otelcol-contrib").
+const otelCollectorPrefix = "otelcol"
+
+// IsOTelCollector reports whether the type denotes an OpenTelemetry Collector of
+// any distribution.
+func (t Type) IsOTelCollector() bool {
+	return t != TypeUnknown
+}

--- a/pkg/apiserver/domain/agent/model/agent/agenttype_test.go
+++ b/pkg/apiserver/domain/agent/model/agent/agenttype_test.go
@@ -1,0 +1,78 @@
+package agent_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model/agent"
+)
+
+func TestDescriptionAgentType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		serviceName string
+		want        agent.Type
+		isCollector bool
+	}{
+		{
+			name:        "otel collector core",
+			serviceName: "otelcol",
+			want:        agent.TypeOTelCollector,
+			isCollector: true,
+		},
+		{
+			name:        "otel collector contrib",
+			serviceName: "otelcol-contrib",
+			want:        agent.TypeOTelCollectorContrib,
+			isCollector: true,
+		},
+		{
+			name:        "otel collector k8s",
+			serviceName: "otelcol-k8s",
+			want:        agent.TypeOTelCollectorK8s,
+			isCollector: true,
+		},
+		{
+			name:        "unknown distribution is preserved verbatim",
+			serviceName: "otelcol-mydistro",
+			want:        agent.Type("otelcol-mydistro"),
+			isCollector: true,
+		},
+		{
+			name:        "custom-branded collector is not recognized",
+			serviceName: "splunk-otel-collector",
+			want:        agent.TypeUnknown,
+			isCollector: false,
+		},
+		{
+			name:        "non collector service",
+			serviceName: "my-app",
+			want:        agent.TypeUnknown,
+			isCollector: false,
+		},
+		{
+			name:        "empty service name",
+			serviceName: "",
+			want:        agent.TypeUnknown,
+			isCollector: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			d := agent.Description{
+				IdentifyingAttributes:    map[string]string{"service.name": tt.serviceName},
+				NonIdentifyingAttributes: map[string]string{},
+			}
+
+			got := d.AgentType()
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.isCollector, got.IsOTelCollector())
+		})
+	}
+}

--- a/pkg/apiserver/domain/agent/model/agent/description.go
+++ b/pkg/apiserver/domain/agent/model/agent/description.go
@@ -1,6 +1,10 @@
 package agent
 
-import "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model/vo"
+import (
+	"strings"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model/vo"
+)
 
 // Description represents the description of an agent.
 // It contains identifying and non-identifying attributes.
@@ -112,6 +116,25 @@ func (ad *Description) Platform() Platform {
 	}
 
 	return PlatformUnknown
+}
+
+// AgentType classifies the agent and, for OpenTelemetry Collectors, its
+// distribution from the "service.name" identifying attribute. Every official
+// Collector distribution reports a service.name of "otelcol" or
+// "otelcol-<distro>" (e.g. "otelcol-contrib"); any such value is treated as a
+// Collector and preserved as the distribution. Everything else is
+// AgentTypeUnknown.
+//
+// Only service.name is consulted, so custom-branded distributions that rename
+// the binary (e.g. "splunk-otel-collector") are intentionally reported as
+// AgentTypeUnknown rather than guessed at.
+func (ad *Description) AgentType() Type {
+	name := ad.Service().Name
+	if name == otelCollectorPrefix || strings.HasPrefix(name, otelCollectorPrefix+"-") {
+		return Type(name)
+	}
+
+	return TypeUnknown
 }
 
 // attr returns the value for key, preferring non-identifying attributes and


### PR DESCRIPTION
## What

Adds an agent **type** classification so registered agents are distinguishable as OpenTelemetry Collectors (and which distribution) vs. others.

- New extensible `agent.Type` enum derived from the reported `service.name` identifying attribute, mirroring the existing `EnvironmentKind` / `Platform` derived classifiers.
  - `otelcol`, `otelcol-contrib`, `otelcol-k8s`, …, `unknown`.
  - Open enum: any `otelcol-<distro>` value is preserved verbatim, so a new distribution surfaces without a code change.
  - `(Type).IsOTelCollector()` answers the coarse "is this a Collector?" question.
- `Description.AgentType()` derives the value; exposed as `AgentMetadata.Type` in the v1 API.
- Swagger docs regenerated.

## Design notes / tradeoffs

- **Derived, not stored** — consistent with `EnvironmentKind`/`Platform`. No migration. Consequence: not yet queryable/filterable in MongoDB; promote to a stored field if filtering by type is needed later.
- **service.name only** — custom-branded distributions that rename the binary (e.g. `splunk-otel-collector`, `adot`, `grafana-alloy`) are intentionally reported as `unknown` rather than guessed at. `AvailableComponents` could corroborate later, but it is empty when an agent disables `ReportsAvailableComponents`.

## Test

- `go test ./pkg/apiserver/domain/agent/model/agent/ ./pkg/apiserver/application/helper/`
- `golangci-lint run` on changed packages — clean.

Follow-up PR: surface the type in the web UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)