### PR TITLE
feat(web): show agent type on agents list and detail

### DIFF
--- a/api/v1/agent.go
+++ b/api/v1/agent.go
@@ -28,6 +28,12 @@ type AgentMetadata struct {
 	// Namespace is the namespace the agent belongs to.
 	Namespace string `json:"namespace"`
 
+	// Type classifies the agent and, for OpenTelemetry Collectors, its
+	// distribution (e.g. "otelcol", "otelcol-contrib"). It is derived from the
+	// reported "service.name" identifying attribute and is "unknown" when the
+	// agent does not follow the OpenTelemetry Collector naming convention.
+	Type string `json:"type,omitempty"`
+
 	// Description is a human-readable description of the agent.
 	Description AgentDescription `json:"description,omitzero"`
 

--- a/pkg/apiserver/application/helper/mapper.go
+++ b/pkg/apiserver/application/helper/mapper.go
@@ -171,6 +171,7 @@ func (mapper *Mapper) MapAgentToAPI(agent *agentmodel.Agent) *v1.Agent {
 		Metadata: v1.AgentMetadata{
 			InstanceUID: agent.Metadata.InstanceUID,
 			Namespace:   agent.Metadata.Namespace,
+			Type:        string(agent.Metadata.Description.AgentType()),
 			Description: v1.AgentDescription{
 				IdentifyingAttributes:    agent.Metadata.Description.IdentifyingAttributes,
 				NonIdentifyingAttributes: agent.Metadata.Description.NonIdentifyingAttributes,

--- a/pkg/apiserver/docs/docs.go
+++ b/pkg/apiserver/docs/docs.go
@@ -3487,6 +3487,10 @@ const docTemplate = `{
                 "namespace": {
                     "description": "Namespace is the namespace the agent belongs to.",
                     "type": "string"
+                },
+                "type": {
+                    "description": "Type classifies the agent and, for OpenTelemetry Collectors, its\ndistribution (e.g. \"otelcol\", \"otelcol-contrib\"). It is derived from the\nreported \"service.name\" identifying attribute and is \"unknown\" when the\nagent does not follow the OpenTelemetry Collector naming convention.",
+                    "type": "string"
                 }
             }
         },

--- a/pkg/apiserver/docs/swagger.json
+++ b/pkg/apiserver/docs/swagger.json
@@ -3479,6 +3479,10 @@
                 "namespace": {
                     "description": "Namespace is the namespace the agent belongs to.",
                     "type": "string"
+                },
+                "type": {
+                    "description": "Type classifies the agent and, for OpenTelemetry Collectors, its\ndistribution (e.g. \"otelcol\", \"otelcol-contrib\"). It is derived from the\nreported \"service.name\" identifying attribute and is \"unknown\" when the\nagent does not follow the OpenTelemetry Collector naming convention.",
+                    "type": "string"
                 }
             }
         },

--- a/pkg/apiserver/docs/swagger.yaml
+++ b/pkg/apiserver/docs/swagger.yaml
@@ -171,6 +171,13 @@ definitions:
       namespace:
         description: Namespace is the namespace the agent belongs to.
         type: string
+      type:
+        description: |-
+          Type classifies the agent and, for OpenTelemetry Collectors, its
+          distribution (e.g. "otelcol", "otelcol-contrib"). It is derived from the
+          reported "service.name" identifying attribute and is "unknown" when the
+          agent does not follow the OpenTelemetry Collector naming convention.
+        type: string
     type: object
   AgentPackage:
     properties:

--- a/pkg/apiserver/domain/agent/model/agent/agenttype.go
+++ b/pkg/apiserver/domain/agent/model/agent/agenttype.go
@@ -1,0 +1,38 @@
+package agent
+
+// Type is an extensible label for the agent's kind and, for OpenTelemetry
+// Collectors, its distribution. It is derived from the reported "service.name"
+// identifying attribute.
+//
+// Like Platform it is an open enum: the well-known OpenTelemetry Collector
+// distributions have named constants for documentation and comparison, but any
+// "otelcol"/"otelcol-<distro>" service.name is preserved verbatim so a new
+// distribution surfaces as its own value without a code change. Anything that
+// does not follow the Collector naming convention is TypeUnknown.
+type Type string
+
+const (
+	// TypeOTelCollector is the upstream OpenTelemetry Collector core
+	// distribution, which reports service.name "otelcol".
+	TypeOTelCollector Type = "otelcol"
+	// TypeOTelCollectorContrib is the contrib distribution, which reports
+	// service.name "otelcol-contrib".
+	TypeOTelCollectorContrib Type = "otelcol-contrib"
+	// TypeOTelCollectorK8s is the Kubernetes distribution, which reports
+	// service.name "otelcol-k8s".
+	TypeOTelCollectorK8s Type = "otelcol-k8s"
+	// TypeUnknown means the agent kind could not be determined from
+	// service.name.
+	TypeUnknown Type = "unknown"
+)
+
+// otelCollectorPrefix is the naming convention shared by every official
+// OpenTelemetry Collector distribution: the core binary is "otelcol" and each
+// distribution appends a "-<distro>" suffix (e.g. "otelcol-contrib").
+const otelCollectorPrefix = "otelcol"
+
+// IsOTelCollector reports whether the type denotes an OpenTelemetry Collector of
+// any distribution.
+func (t Type) IsOTelCollector() bool {
+	return t != TypeUnknown
+}

--- a/pkg/apiserver/domain/agent/model/agent/agenttype_test.go
+++ b/pkg/apiserver/domain/agent/model/agent/agenttype_test.go
@@ -1,0 +1,78 @@
+package agent_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model/agent"
+)
+
+func TestDescriptionAgentType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		serviceName string
+		want        agent.Type
+		isCollector bool
+	}{
+		{
+			name:        "otel collector core",
+			serviceName: "otelcol",
+			want:        agent.TypeOTelCollector,
+			isCollector: true,
+		},
+		{
+			name:        "otel collector contrib",
+			serviceName: "otelcol-contrib",
+			want:        agent.TypeOTelCollectorContrib,
+			isCollector: true,
+		},
+		{
+			name:        "otel collector k8s",
+			serviceName: "otelcol-k8s",
+			want:        agent.TypeOTelCollectorK8s,
+			isCollector: true,
+		},
+		{
+			name:        "unknown distribution is preserved verbatim",
+			serviceName: "otelcol-mydistro",
+			want:        agent.Type("otelcol-mydistro"),
+			isCollector: true,
+		},
+		{
+			name:        "custom-branded collector is not recognized",
+			serviceName: "splunk-otel-collector",
+			want:        agent.TypeUnknown,
+			isCollector: false,
+		},
+		{
+			name:        "non collector service",
+			serviceName: "my-app",
+			want:        agent.TypeUnknown,
+			isCollector: false,
+		},
+		{
+			name:        "empty service name",
+			serviceName: "",
+			want:        agent.TypeUnknown,
+			isCollector: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			d := agent.Description{
+				IdentifyingAttributes:    map[string]string{"service.name": tt.serviceName},
+				NonIdentifyingAttributes: map[string]string{},
+			}
+
+			got := d.AgentType()
+			assert.Equal(t, tt.want, got)
+			assert.Equal(t, tt.isCollector, got.IsOTelCollector())
+		})
+	}
+}

--- a/pkg/apiserver/domain/agent/model/agent/description.go
+++ b/pkg/apiserver/domain/agent/model/agent/description.go
@@ -1,6 +1,10 @@
 package agent
 
-import "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model/vo"
+import (
+	"strings"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model/vo"
+)
 
 // Description represents the description of an agent.
 // It contains identifying and non-identifying attributes.
@@ -112,6 +116,25 @@ func (ad *Description) Platform() Platform {
 	}
 
 	return PlatformUnknown
+}
+
+// AgentType classifies the agent and, for OpenTelemetry Collectors, its
+// distribution from the "service.name" identifying attribute. Every official
+// Collector distribution reports a service.name of "otelcol" or
+// "otelcol-<distro>" (e.g. "otelcol-contrib"); any such value is treated as a
+// Collector and preserved as the distribution. Everything else is
+// AgentTypeUnknown.
+//
+// Only service.name is consulted, so custom-branded distributions that rename
+// the binary (e.g. "splunk-otel-collector") are intentionally reported as
+// AgentTypeUnknown rather than guessed at.
+func (ad *Description) AgentType() Type {
+	name := ad.Service().Name
+	if name == otelCollectorPrefix || strings.HasPrefix(name, otelCollectorPrefix+"-") {
+		return Type(name)
+	}
+
+	return TypeUnknown
 }
 
 // attr returns the value for key, preferring non-identifying attributes and

--- a/web/src/entities/agent/index.ts
+++ b/web/src/entities/agent/index.ts
@@ -1,3 +1,4 @@
 export * from './model/types';
 export * from './api/delete-agent';
 export * from './lib/capabilities';
+export * from './lib/agent-type';

--- a/web/src/entities/agent/lib/agent-type.ts
+++ b/web/src/entities/agent/lib/agent-type.ts
@@ -1,0 +1,20 @@
+// Helpers for the agent `metadata.type` classification (the OpenTelemetry
+// Collector distribution derived from `service.name`). Shared by the agents list
+// and detail pages so the "is this a Collector?" rule lives in one place.
+
+/** The server's sentinel for an unclassified agent. */
+export const AGENT_TYPE_UNKNOWN = 'unknown';
+
+/**
+ * Whether the agent is an OpenTelemetry Collector of any distribution. Mirrors
+ * the server-side `(Type).IsOTelCollector()`: any non-empty, non-`unknown` type
+ * follows the `otelcol`/`otelcol-<distro>` naming convention.
+ */
+export function isOtelCollector(type: string | undefined): boolean {
+  return Boolean(type) && type !== AGENT_TYPE_UNKNOWN;
+}
+
+/** Display label for an agent type, falling back to `unknown` when absent. */
+export function agentTypeLabel(type: string | undefined): string {
+  return type || AGENT_TYPE_UNKNOWN;
+}

--- a/web/src/entities/agent/model/types.ts
+++ b/web/src/entities/agent/model/types.ts
@@ -12,6 +12,12 @@ export interface AgentCustomCapabilities {
 export interface AgentMetadata {
   instanceUid: string;
   namespace: string;
+  /**
+   * Agent kind / OpenTelemetry Collector distribution derived from the reported
+   * `service.name` (e.g. `otelcol`, `otelcol-contrib`). `unknown` when the agent
+   * does not follow the Collector naming convention. Absent on older servers.
+   */
+  type?: string;
   description?: AgentDescription;
   capabilities?: number;
   customCapabilities?: AgentCustomCapabilities;

--- a/web/src/views/agent-detail/ui/AgentDetailPage.tsx
+++ b/web/src/views/agent-detail/ui/AgentDetailPage.tsx
@@ -30,8 +30,10 @@ import { useNamespace } from '@entities/namespace';
 import { api, useApi } from '@shared/api';
 import {
   agentDeleteConfirmMessage,
+  agentTypeLabel,
   capabilityNames,
   deleteAgent,
+  isOtelCollector,
   type Agent,
 } from '@entities/agent';
 import dynamic from 'next/dynamic';
@@ -162,6 +164,18 @@ function AgentDetailInner() {
           </>
         }
       />
+
+      <Stack direction="row" gap={1} alignItems="center" sx={{ mb: 2 }} flexWrap="wrap">
+        <Typography variant="overline" color="text.secondary">
+          Type
+        </Typography>
+        <Chip
+          label={agentTypeLabel(agent.metadata.type)}
+          color={isOtelCollector(agent.metadata.type) ? 'info' : 'default'}
+          size="small"
+          variant={isOtelCollector(agent.metadata.type) ? 'filled' : 'outlined'}
+        />
+      </Stack>
 
       <Grid container spacing={2} sx={{ mb: 2 }}>
         <Grid size={{ xs: 12, md: 4 }}>

--- a/web/src/views/agents/ui/AgentsPage.tsx
+++ b/web/src/views/agents/ui/AgentsPage.tsx
@@ -49,8 +49,10 @@ import { TimeDisplay } from '@shared/preferences';
 import { useNamespace } from '@entities/namespace';
 import {
   agentDeleteConfirmMessage,
+  agentTypeLabel,
   capabilityNames,
   deleteAgent,
+  isOtelCollector,
   type Agent,
 } from '@entities/agent';
 import { type ColumnConfig, useColumnVisibility, useCursorPagination } from '@shared/lib';
@@ -79,7 +81,10 @@ const AGENT_COLUMNS: ColumnConfig[] = [
   { id: 'instanceUid', label: 'Instance UID', locked: true },
   { id: 'connected', label: 'Connected' },
   { id: 'healthy', label: 'Healthy' },
-  { id: 'type', label: 'Type' },
+  { id: 'agentType', label: 'Type' },
+  // `type` predates the agent Type column and shows the connection transport
+  // (HTTP/WebSocket); keep the id for persisted visibility, clarify the label.
+  { id: 'type', label: 'Connection' },
   { id: 'lastReported', label: 'Last Reported' },
   { id: 'sequence', label: 'Sequence', defaultVisible: false },
   { id: 'capabilities', label: 'Capabilities', defaultVisible: false },
@@ -561,7 +566,8 @@ function AgentsInner() {
               {isVisible('instanceUid') && <TableCell>Instance UID</TableCell>}
               {isVisible('connected') && <TableCell>Connected</TableCell>}
               {isVisible('healthy') && <TableCell>Healthy</TableCell>}
-              {isVisible('type') && <TableCell>Type</TableCell>}
+              {isVisible('agentType') && <TableCell>Type</TableCell>}
+              {isVisible('type') && <TableCell>Connection</TableCell>}
               {isVisible('lastReported') && <TableCell>Last Reported</TableCell>}
               {isVisible('sequence') && <TableCell>Sequence</TableCell>}
               {isVisible('capabilities') && <TableCell>Capabilities</TableCell>}
@@ -622,6 +628,16 @@ function AgentsInner() {
                         label={agent.status.componentHealth?.healthy ? 'Healthy' : 'Unhealthy'}
                         color={agent.status.componentHealth?.healthy ? 'success' : 'warning'}
                         size="small"
+                      />
+                    </TableCell>
+                  )}
+                  {isVisible('agentType') && (
+                    <TableCell>
+                      <Chip
+                        label={agentTypeLabel(agent.metadata.type)}
+                        color={isOtelCollector(agent.metadata.type) ? 'info' : 'default'}
+                        size="small"
+                        variant={isOtelCollector(agent.metadata.type) ? 'filled' : 'outlined'}
                       />
                     </TableCell>
                   )}


### PR DESCRIPTION
## What

Surfaces the new agent **type** (`metadata.type`, the OpenTelemetry Collector distribution derived from `service.name`) in the web UI.

- Adds `type` to the Agent metadata TS type and shared `isOtelCollector` / `agentTypeLabel` helpers in `entities/agent`.
- **Agents list:** new "Type" column rendering the distribution as a chip (highlighted for Collectors).
  - The pre-existing "Type" column actually showed the connection transport (HTTP/WebSocket); it is **relabeled "Connection"** while keeping its column id so persisted column-visibility preferences are preserved.
- **Agent detail:** a Type chip above the status cards.

## Stacked PR

Depends on #454 (adds `AgentMetadata.type` to the v1 API). **Base this on `feat/agent-type-classifier`; merge #454 first**, then this retargets to `main`.

## Checks

`cd web && npx tsc --noEmit && npm run lint && npm test && npm run build` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)