### PR TITLE
feat(endpoint): add metrics-query port for endpoint throughput

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -54,6 +54,7 @@ linters:
         - "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/port.ServerEventReceiverPort" # cannot handle without interface
         - "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port.ServerEventSenderPort" # cannot handle without interface
         - "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port.ServerEventReceiverPort" # cannot handle without interface
+        - "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port.EndpointMetricsQueryPort" # conditional impl (prometheus | noop)
         - "k8s.io/utils/clock.Timer"
         - "github.com/minuk-dev/opampcommander/pkg/utils/clock.Timer"
         # test
@@ -116,6 +117,10 @@ linters:
             - go.opentelemetry.io/otel
             - go.opentelemetry.io/contrib/instrumentation/github.com/gin-gonic/gin/otelgin
             - github.com/prometheus/client_golang/prometheus
+            # metrics backend query client (endpoint throughput)
+            - github.com/prometheus/client_golang/api
+            - github.com/prometheus/client_golang/api/prometheus/v1
+            - github.com/prometheus/common/model
             - go.opentelemetry.io/contrib/instrumentation/runtime
             - go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp
             - github.com/cloudevents/sdk-go/observability/opentelemetry/v2/client

--- a/api/v1/endpoint.go
+++ b/api/v1/endpoint.go
@@ -32,7 +32,24 @@ type EndpointSpec struct {
 	Signals EndpointSignals `json:"signals"`
 	// Tenants is the multi-tenant breakdown of the endpoint.
 	Tenants []EndpointTenant `json:"tenants,omitempty"`
+	// MetricsQuery configures how to measure, from a metrics backend, how much
+	// telemetry collectors are sending to this endpoint. Omitted when throughput
+	// is not tracked.
+	MetricsQuery *EndpointMetricsQuery `json:"metricsQuery,omitempty"`
 } // @name EndpointSpec
+
+// EndpointMetricsQuery holds a PromQL query template per telemetry signal used to
+// measure how much data collectors are sending to this endpoint. Each template is
+// rendered with the rate window and endpoint identity before execution; an empty
+// template means that signal is not measured.
+type EndpointMetricsQuery struct {
+	// Metrics is the PromQL template measuring metric data points per second.
+	Metrics string `json:"metrics,omitempty"`
+	// Logs is the PromQL template measuring log records per second.
+	Logs string `json:"logs,omitempty"`
+	// Traces is the PromQL template measuring spans per second.
+	Traces string `json:"traces,omitempty"`
+} // @name EndpointMetricsQuery
 
 // EndpointSignals declares which telemetry signals are supported.
 type EndpointSignals struct {

--- a/pkg/apiserver/adapter/secondary/metrics/noop.go
+++ b/pkg/apiserver/adapter/secondary/metrics/noop.go
@@ -1,0 +1,41 @@
+// Package metrics provides outbound adapters for querying a metrics backend for
+// endpoint throughput, plus a no-op fallback used when no backend is configured.
+package metrics
+
+import (
+	"context"
+	"time"
+
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
+	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
+)
+
+var _ agentport.EndpointMetricsQueryPort = (*NoopAdapter)(nil)
+
+// NoopAdapter is an [agentport.EndpointMetricsQueryPort] that measures nothing.
+// It is wired when no metrics backend is configured (e.g. standalone mode) so
+// the port is always satisfiable; every signal comes back unmeasured.
+type NoopAdapter struct{}
+
+// NewNoopAdapter creates a NoopAdapter.
+func NewNoopAdapter() *NoopAdapter {
+	return &NoopAdapter{}
+}
+
+// QueryEndpointThroughput returns a result with every signal unmeasured.
+func (a *NoopAdapter) QueryEndpointThroughput(
+	_ context.Context,
+	endpoint *agentmodel.Endpoint,
+	window time.Duration,
+	at time.Time,
+) (*agentmodel.EndpointThroughput, error) {
+	return &agentmodel.EndpointThroughput{
+		Namespace:   endpoint.Metadata.Namespace,
+		Name:        endpoint.Metadata.Name,
+		EvaluatedAt: at,
+		Window:      window,
+		Metrics:     agentmodel.SignalThroughput{Measured: false, PerSecond: 0, SeriesCount: 0},
+		Logs:        agentmodel.SignalThroughput{Measured: false, PerSecond: 0, SeriesCount: 0},
+		Traces:      agentmodel.SignalThroughput{Measured: false, PerSecond: 0, SeriesCount: 0},
+	}, nil
+}

--- a/pkg/apiserver/adapter/secondary/metrics/prometheus/prometheus.go
+++ b/pkg/apiserver/adapter/secondary/metrics/prometheus/prometheus.go
@@ -1,0 +1,211 @@
+// Package prometheus provides an outbound adapter that implements
+// [agentport.EndpointMetricsQueryPort] against a Prometheus-compatible HTTP API
+// (Prometheus, VictoriaMetrics, Mimir, ...). It evaluates an endpoint's
+// per-signal PromQL templates to measure how much telemetry collectors are
+// sending to that endpoint.
+package prometheus
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"math"
+	"strings"
+	"text/template"
+	"time"
+
+	promapi "github.com/prometheus/client_golang/api"
+	promv1 "github.com/prometheus/client_golang/api/prometheus/v1"
+	"github.com/prometheus/common/model"
+
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
+	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
+)
+
+var _ agentport.EndpointMetricsQueryPort = (*Adapter)(nil)
+
+// Adapter queries a Prometheus-compatible backend for endpoint throughput.
+type Adapter struct {
+	api    promv1.API
+	logger *slog.Logger
+}
+
+// NewAdapter creates an Adapter targeting the Prometheus-compatible HTTP API at
+// address (e.g. "http://prometheus:9090" or a VictoriaMetrics vmselect URL).
+func NewAdapter(address string, logger *slog.Logger) (*Adapter, error) {
+	//exhaustruct:ignore // only Address is needed; Client/RoundTripper default.
+	client, err := promapi.NewClient(promapi.Config{Address: address})
+	if err != nil {
+		return nil, fmt.Errorf("failed to create prometheus client for %q: %w", address, err)
+	}
+
+	return newAdapterWithAPI(promv1.NewAPI(client), logger), nil
+}
+
+// newAdapterWithAPI builds an Adapter from an already-constructed API. It exists
+// so tests can inject a client pointed at an httptest server.
+func newAdapterWithAPI(api promv1.API, logger *slog.Logger) *Adapter {
+	return &Adapter{api: api, logger: logger}
+}
+
+// queryTemplateData is the context exposed to an endpoint's PromQL templates.
+type queryTemplateData struct {
+	// Namespace and Name are the endpoint identity.
+	Namespace string
+	Name      string
+	// URL and Protocol come from the endpoint spec.
+	URL      string
+	Protocol string
+	// Attributes are the endpoint's user-supplied attributes.
+	Attributes map[string]string
+	// Window is the rate window as a PromQL duration literal (e.g. "300s"),
+	// suitable for direct use inside a range selector like rate(...[{{.Window}}]).
+	Window string
+}
+
+// QueryEndpointThroughput implements [agentport.EndpointMetricsQueryPort].
+func (a *Adapter) QueryEndpointThroughput(
+	ctx context.Context,
+	endpoint *agentmodel.Endpoint,
+	window time.Duration,
+	evaluatedAt time.Time,
+) (*agentmodel.EndpointThroughput, error) {
+	result := &agentmodel.EndpointThroughput{
+		Namespace:   endpoint.Metadata.Namespace,
+		Name:        endpoint.Metadata.Name,
+		EvaluatedAt: evaluatedAt,
+		Window:      window,
+		Metrics:     agentmodel.SignalThroughput{Measured: false, PerSecond: 0, SeriesCount: 0},
+		Logs:        agentmodel.SignalThroughput{Measured: false, PerSecond: 0, SeriesCount: 0},
+		Traces:      agentmodel.SignalThroughput{Measured: false, PerSecond: 0, SeriesCount: 0},
+	}
+
+	query := endpoint.Spec.MetricsQuery
+	if query.IsZero() {
+		return result, nil
+	}
+
+	data := newQueryTemplateData(endpoint, window)
+
+	var err error
+
+	result.Metrics, err = a.querySignal(ctx, "metrics", query.Metrics, data, evaluatedAt)
+	if err != nil {
+		return nil, err
+	}
+
+	result.Logs, err = a.querySignal(ctx, "logs", query.Logs, data, evaluatedAt)
+	if err != nil {
+		return nil, err
+	}
+
+	result.Traces, err = a.querySignal(ctx, "traces", query.Traces, data, evaluatedAt)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+func newQueryTemplateData(endpoint *agentmodel.Endpoint, window time.Duration) queryTemplateData {
+	return queryTemplateData{
+		Namespace:  endpoint.Metadata.Namespace,
+		Name:       endpoint.Metadata.Name,
+		URL:        endpoint.Spec.URL,
+		Protocol:   endpoint.Spec.Protocol,
+		Attributes: endpoint.Metadata.Attributes,
+		Window:     promQLDuration(window),
+	}
+}
+
+func (a *Adapter) querySignal(
+	ctx context.Context,
+	signal string,
+	tmpl string,
+	data queryTemplateData,
+	evaluatedAt time.Time,
+) (agentmodel.SignalThroughput, error) {
+	unmeasured := agentmodel.SignalThroughput{Measured: false, PerSecond: 0, SeriesCount: 0}
+	if strings.TrimSpace(tmpl) == "" {
+		return unmeasured, nil
+	}
+
+	query, err := renderQuery(signal, tmpl, data)
+	if err != nil {
+		return unmeasured, err
+	}
+
+	value, warnings, err := a.api.Query(ctx, query, evaluatedAt)
+	if err != nil {
+		return unmeasured, fmt.Errorf("failed to query %s throughput: %w", signal, err)
+	}
+
+	for _, warning := range warnings {
+		a.logger.Warn("prometheus query warning",
+			slog.String("signal", signal),
+			slog.String("warning", warning),
+		)
+	}
+
+	sum, count := sumValue(value)
+
+	return agentmodel.SignalThroughput{Measured: true, PerSecond: sum, SeriesCount: count}, nil
+}
+
+func renderQuery(signal, tmpl string, data queryTemplateData) (string, error) {
+	parsed, err := template.New(signal).Option("missingkey=error").Parse(tmpl)
+	if err != nil {
+		return "", fmt.Errorf("failed to parse %s query template: %w", signal, err)
+	}
+
+	var buf strings.Builder
+
+	err = parsed.Execute(&buf, data)
+	if err != nil {
+		return "", fmt.Errorf("failed to render %s query template: %w", signal, err)
+	}
+
+	return buf.String(), nil
+}
+
+// sumValue aggregates a PromQL result into a single total and the number of
+// contributing series. It sums instant-vector samples (the expected shape: a
+// per-series rate to be totaled) and accepts a bare scalar; NaN samples (e.g. a
+// rate over a gap) are skipped and not counted. Any other value type yields zero.
+func sumValue(value model.Value) (float64, int) {
+	switch typed := value.(type) {
+	case model.Vector:
+		var (
+			sum   float64
+			count int
+		)
+
+		for _, sample := range typed {
+			if sample == nil || math.IsNaN(float64(sample.Value)) {
+				continue
+			}
+
+			sum += float64(sample.Value)
+			count++
+		}
+
+		return sum, count
+	case *model.Scalar:
+		if math.IsNaN(float64(typed.Value)) {
+			return 0, 0
+		}
+
+		return float64(typed.Value), 1
+	default:
+		return 0, 0
+	}
+}
+
+// promQLDuration renders a duration as a PromQL duration literal. It uses whole
+// seconds (e.g. "300s"), which PromQL always accepts inside a range selector and
+// avoids the "5m0s" form produced by time.Duration.String that PromQL rejects.
+func promQLDuration(d time.Duration) string {
+	seconds := max(int64(d.Seconds()), 1)
+
+	return fmt.Sprintf("%ds", seconds)
+}

--- a/pkg/apiserver/adapter/secondary/metrics/prometheus/prometheus_test.go
+++ b/pkg/apiserver/adapter/secondary/metrics/prometheus/prometheus_test.go
@@ -1,0 +1,142 @@
+package prometheus_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/secondary/metrics/prometheus"
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
+)
+
+// vectorResponse builds a Prometheus HTTP API instant-vector response body with
+// the given scalar sample values.
+func vectorResponse(values ...string) string {
+	results := make([]string, 0, len(values))
+	for i, v := range values {
+		results = append(results, `{"metric":{"exporter":"e`+string(rune('0'+i))+`"},"value":[1700000000,"`+v+`"]}`)
+	}
+
+	return `{"status":"success","data":{"resultType":"vector","result":[` +
+		strings.Join(results, ",") + `]}}`
+}
+
+func newFakeBackend(t *testing.T, body string, capture *url.Values) *httptest.Server {
+	t.Helper()
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.Body = http.MaxBytesReader(w, r.Body, 1<<20)
+		assert.NoError(t, r.ParseForm())
+
+		if capture != nil {
+			*capture = r.Form
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, body)
+	}))
+}
+
+func newEndpoint(query *agentmodel.EndpointMetricsQuery) *agentmodel.Endpoint {
+	return &agentmodel.Endpoint{
+		Metadata: agentmodel.EndpointMetadata{
+			Name:       "victoria",
+			Namespace:  "monitoring",
+			Attributes: agentmodel.Attributes{"exporter": "prometheusremotewrite"},
+			CreatedAt:  time.Now(),
+			DeletedAt:  nil,
+		},
+		Spec: agentmodel.EndpointSpec{
+			URL:          "http://vm/insert",
+			Protocol:     "prometheusremotewrite",
+			Signals:      agentmodel.EndpointSignals{Metrics: true, Logs: false, Traces: false},
+			Tenants:      nil,
+			MetricsQuery: query,
+		},
+		Status: agentmodel.EndpointStatus{Conditions: nil},
+	}
+}
+
+func TestQueryEndpointThroughput_SumsVectorPerSignal(t *testing.T) {
+	t.Parallel()
+
+	server := newFakeBackend(t, vectorResponse("1.5", "2.5"), nil)
+	defer server.Close()
+
+	adapter, err := prometheus.NewAdapter(server.URL, slog.New(slog.DiscardHandler))
+	require.NoError(t, err)
+
+	endpoint := newEndpoint(&agentmodel.EndpointMetricsQuery{
+		Metrics: `sum(rate(otelcol_exporter_sent_metric_points_total[{{.Window}}]))`,
+		Logs:    "",
+		Traces:  "",
+	})
+
+	got, err := adapter.QueryEndpointThroughput(context.Background(), endpoint, 5*time.Minute, time.Unix(1700000000, 0))
+	require.NoError(t, err)
+
+	assert.True(t, got.Metrics.Measured)
+	assert.InDelta(t, 4.0, got.Metrics.PerSecond, 1e-9)
+	assert.Equal(t, 2, got.Metrics.SeriesCount)
+
+	// Signals without a template stay unmeasured.
+	assert.False(t, got.Logs.Measured)
+	assert.False(t, got.Traces.Measured)
+	assert.Equal(t, "monitoring", got.Namespace)
+	assert.Equal(t, 5*time.Minute, got.Window)
+}
+
+func TestQueryEndpointThroughput_RendersWindowAndIdentity(t *testing.T) {
+	t.Parallel()
+
+	var captured url.Values
+
+	server := newFakeBackend(t, vectorResponse("1"), &captured)
+	defer server.Close()
+
+	adapter, err := prometheus.NewAdapter(server.URL, slog.New(slog.DiscardHandler))
+	require.NoError(t, err)
+
+	endpoint := newEndpoint(&agentmodel.EndpointMetricsQuery{
+		Metrics: `sum(rate(otelcol_exporter_sent_metric_points_total{exporter="{{.Attributes.exporter}}"}[{{.Window}}]))`,
+		Logs:    "",
+		Traces:  "",
+	})
+
+	_, err = adapter.QueryEndpointThroughput(context.Background(), endpoint, 90*time.Second, time.Unix(1700000000, 0))
+	require.NoError(t, err)
+
+	rendered := captured.Get("query")
+	assert.Contains(t, rendered, `exporter="prometheusremotewrite"`)
+	assert.Contains(t, rendered, "[90s]")
+}
+
+func TestQueryEndpointThroughput_NilQuerySkipsBackend(t *testing.T) {
+	t.Parallel()
+
+	called := false
+
+	server := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, _ *http.Request) {
+		called = true
+	}))
+	defer server.Close()
+
+	adapter, err := prometheus.NewAdapter(server.URL, slog.New(slog.DiscardHandler))
+	require.NoError(t, err)
+
+	got, err := adapter.QueryEndpointThroughput(
+		context.Background(), newEndpoint(nil), time.Minute, time.Unix(1700000000, 0))
+	require.NoError(t, err)
+
+	assert.False(t, called, "backend must not be queried when no template is configured")
+	assert.False(t, got.Metrics.Measured)
+}

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/clone.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/clone.go
@@ -250,6 +250,11 @@ func cloneEndpoint(endpoint *agentmodel.Endpoint) *agentmodel.Endpoint {
 	cloned.Metadata.DeletedAt = cloneTimePtr(endpoint.Metadata.DeletedAt)
 	cloned.Status.Conditions = slices.Clone(endpoint.Status.Conditions)
 
+	if endpoint.Spec.MetricsQuery != nil {
+		metricsQuery := *endpoint.Spec.MetricsQuery
+		cloned.Spec.MetricsQuery = &metricsQuery
+	}
+
 	if endpoint.Spec.Tenants != nil {
 		tenants := make([]agentmodel.EndpointTenant, len(endpoint.Spec.Tenants))
 		for i := range endpoint.Spec.Tenants {

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/entity/endpoint.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/entity/endpoint.go
@@ -32,10 +32,19 @@ type EndpointResourceMetadata struct {
 
 // EndpointResourceSpec represents the specification of an endpoint resource.
 type EndpointResourceSpec struct {
-	URL      string                   `bson:"url"`
-	Protocol string                   `bson:"protocol"`
-	Signals  EndpointResourceSignals  `bson:"signals"`
-	Tenants  []EndpointResourceTenant `bson:"tenants,omitempty"`
+	URL          string                        `bson:"url"`
+	Protocol     string                        `bson:"protocol"`
+	Signals      EndpointResourceSignals       `bson:"signals"`
+	Tenants      []EndpointResourceTenant      `bson:"tenants,omitempty"`
+	MetricsQuery *EndpointResourceMetricsQuery `bson:"metricsQuery,omitempty"`
+}
+
+// EndpointResourceMetricsQuery represents the per-signal PromQL templates used to
+// measure endpoint throughput.
+type EndpointResourceMetricsQuery struct {
+	Metrics string `bson:"metrics,omitempty"`
+	Logs    string `bson:"logs,omitempty"`
+	Traces  string `bson:"traces,omitempty"`
 }
 
 // EndpointResourceSignals represents the supported signals of an endpoint resource.
@@ -75,12 +84,25 @@ func (e *EndpointResourceEntity) ToDomain() *agentmodel.Endpoint {
 			Tenants: lo.Map(e.Spec.Tenants, func(t EndpointResourceTenant, _ int) agentmodel.EndpointTenant {
 				return t.toDomain()
 			}),
+			MetricsQuery: e.Spec.MetricsQuery.toDomain(),
 		},
 		Status: agentmodel.EndpointStatus{
 			Conditions: lo.Map(e.Status.Conditions, func(c Condition, _ int) model.Condition {
 				return c.ToDomain()
 			}),
 		},
+	}
+}
+
+func (q *EndpointResourceMetricsQuery) toDomain() *agentmodel.EndpointMetricsQuery {
+	if q == nil {
+		return nil
+	}
+
+	return &agentmodel.EndpointMetricsQuery{
+		Metrics: q.Metrics,
+		Logs:    q.Logs,
+		Traces:  q.Traces,
 	}
 }
 
@@ -128,12 +150,27 @@ func EndpointResourceEntityFromDomain(
 			Tenants: lo.Map(endpoint.Spec.Tenants, func(t agentmodel.EndpointTenant, _ int) EndpointResourceTenant {
 				return endpointResourceTenantFromDomain(t)
 			}),
+			MetricsQuery: endpointResourceMetricsQueryFromDomain(endpoint.Spec.MetricsQuery),
 		},
 		Status: EndpointResourceEntityStatus{
 			Conditions: lo.Map(endpoint.Status.Conditions, func(c model.Condition, _ int) Condition {
 				return NewConditionFromDomain(c)
 			}),
 		},
+	}
+}
+
+func endpointResourceMetricsQueryFromDomain(
+	query *agentmodel.EndpointMetricsQuery,
+) *EndpointResourceMetricsQuery {
+	if query == nil {
+		return nil
+	}
+
+	return &EndpointResourceMetricsQuery{
+		Metrics: query.Metrics,
+		Logs:    query.Logs,
+		Traces:  query.Traces,
 	}
 }
 

--- a/pkg/apiserver/application/helper/mapper.go
+++ b/pkg/apiserver/application/helper/mapper.go
@@ -412,10 +412,23 @@ func (mapper *Mapper) MapEndpointToAPI(
 			Tenants: lo.Map(domain.Spec.Tenants, func(t agentmodel.EndpointTenant, _ int) v1.EndpointTenant {
 				return mapEndpointTenantToAPI(t)
 			}),
+			MetricsQuery: mapEndpointMetricsQueryToAPI(domain.Spec.MetricsQuery),
 		},
 		Status: v1.EndpointStatus{
 			Conditions: mapper.mapConditionsToAPI(domain.Status.Conditions),
 		},
+	}
+}
+
+func mapEndpointMetricsQueryToAPI(query *agentmodel.EndpointMetricsQuery) *v1.EndpointMetricsQuery {
+	if query == nil {
+		return nil
+	}
+
+	return &v1.EndpointMetricsQuery{
+		Metrics: query.Metrics,
+		Logs:    query.Logs,
+		Traces:  query.Traces,
 	}
 }
 
@@ -466,10 +479,23 @@ func (mapper *Mapper) MapAPIToEndpoint(
 			Tenants: lo.Map(api.Spec.Tenants, func(t v1.EndpointTenant, _ int) agentmodel.EndpointTenant {
 				return mapAPIToEndpointTenant(t)
 			}),
+			MetricsQuery: mapAPIToEndpointMetricsQuery(api.Spec.MetricsQuery),
 		},
 		Status: agentmodel.EndpointStatus{
 			Conditions: nil,
 		},
+	}
+}
+
+func mapAPIToEndpointMetricsQuery(query *v1.EndpointMetricsQuery) *agentmodel.EndpointMetricsQuery {
+	if query == nil {
+		return nil
+	}
+
+	return &agentmodel.EndpointMetricsQuery{
+		Metrics: query.Metrics,
+		Logs:    query.Logs,
+		Traces:  query.Traces,
 	}
 }
 

--- a/pkg/apiserver/config/config.go
+++ b/pkg/apiserver/config/config.go
@@ -23,6 +23,7 @@ type ServerSettings struct {
 	EventSettings      EventSettings
 	CacheSettings      CacheSettings
 	BootstrapSettings  BootstrapSettings
+	MetricsBackend     MetricsBackendSettings
 	RBACModelPath      string
 }
 

--- a/pkg/apiserver/config/metrics.go
+++ b/pkg/apiserver/config/metrics.go
@@ -1,0 +1,27 @@
+package config
+
+import "time"
+
+// MetricsBackendSettings configures the metrics backend that endpoint-throughput
+// queries run against. When Type is empty or "none", the no-op adapter is wired
+// and every endpoint's throughput is reported as unmeasured.
+type MetricsBackendSettings struct {
+	// Type selects the backend implementation. "prometheus" enables PromQL
+	// queries against a Prometheus-compatible HTTP API; "" / "none" disables them.
+	Type MetricsBackendType
+	// Address is the base URL of the Prometheus-compatible HTTP API
+	// (e.g. "http://prometheus:9090" or a VictoriaMetrics vmselect endpoint).
+	Address string
+	// DefaultWindow is the rate window used when a caller does not specify one.
+	DefaultWindow time.Duration
+}
+
+// MetricsBackendType is the type of metrics backend used for throughput queries.
+type MetricsBackendType string
+
+const (
+	// MetricsBackendTypePrometheus queries a Prometheus-compatible HTTP API.
+	MetricsBackendTypePrometheus MetricsBackendType = "prometheus"
+	// MetricsBackendTypeNone disables throughput queries (no-op adapter).
+	MetricsBackendTypeNone MetricsBackendType = "none"
+)

--- a/pkg/apiserver/docs/docs.go
+++ b/pkg/apiserver/docs/docs.go
@@ -4126,6 +4126,23 @@ const docTemplate = `{
                 }
             }
         },
+        "EndpointMetricsQuery": {
+            "type": "object",
+            "properties": {
+                "logs": {
+                    "description": "Logs is the PromQL template measuring log records per second.",
+                    "type": "string"
+                },
+                "metrics": {
+                    "description": "Metrics is the PromQL template measuring metric data points per second.",
+                    "type": "string"
+                },
+                "traces": {
+                    "description": "Traces is the PromQL template measuring spans per second.",
+                    "type": "string"
+                }
+            }
+        },
         "EndpointSignals": {
             "type": "object",
             "properties": {
@@ -4143,6 +4160,14 @@ const docTemplate = `{
         "EndpointSpec": {
             "type": "object",
             "properties": {
+                "metricsQuery": {
+                    "description": "MetricsQuery configures how to measure, from a metrics backend, how much\ntelemetry collectors are sending to this endpoint. Omitted when throughput\nis not tracked.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/EndpointMetricsQuery"
+                        }
+                    ]
+                },
                 "protocol": {
                     "description": "Protocol is the export protocol (e.g. \"otlp\", \"otlphttp\", \"prometheusremotewrite\").",
                     "type": "string"

--- a/pkg/apiserver/docs/swagger.json
+++ b/pkg/apiserver/docs/swagger.json
@@ -4118,6 +4118,23 @@
                 }
             }
         },
+        "EndpointMetricsQuery": {
+            "type": "object",
+            "properties": {
+                "logs": {
+                    "description": "Logs is the PromQL template measuring log records per second.",
+                    "type": "string"
+                },
+                "metrics": {
+                    "description": "Metrics is the PromQL template measuring metric data points per second.",
+                    "type": "string"
+                },
+                "traces": {
+                    "description": "Traces is the PromQL template measuring spans per second.",
+                    "type": "string"
+                }
+            }
+        },
         "EndpointSignals": {
             "type": "object",
             "properties": {
@@ -4135,6 +4152,14 @@
         "EndpointSpec": {
             "type": "object",
             "properties": {
+                "metricsQuery": {
+                    "description": "MetricsQuery configures how to measure, from a metrics backend, how much\ntelemetry collectors are sending to this endpoint. Omitted when throughput\nis not tracked.",
+                    "allOf": [
+                        {
+                            "$ref": "#/definitions/EndpointMetricsQuery"
+                        }
+                    ]
+                },
                 "protocol": {
                     "description": "Protocol is the export protocol (e.g. \"otlp\", \"otlphttp\", \"prometheusremotewrite\").",
                     "type": "string"

--- a/pkg/apiserver/docs/swagger.yaml
+++ b/pkg/apiserver/docs/swagger.yaml
@@ -607,6 +607,19 @@ definitions:
       namespace:
         type: string
     type: object
+  EndpointMetricsQuery:
+    properties:
+      logs:
+        description: Logs is the PromQL template measuring log records per second.
+        type: string
+      metrics:
+        description: Metrics is the PromQL template measuring metric data points per
+          second.
+        type: string
+      traces:
+        description: Traces is the PromQL template measuring spans per second.
+        type: string
+    type: object
   EndpointSignals:
     properties:
       logs:
@@ -618,6 +631,13 @@ definitions:
     type: object
   EndpointSpec:
     properties:
+      metricsQuery:
+        allOf:
+        - $ref: '#/definitions/EndpointMetricsQuery'
+        description: |-
+          MetricsQuery configures how to measure, from a metrics backend, how much
+          telemetry collectors are sending to this endpoint. Omitted when throughput
+          is not tracked.
       protocol:
         description: Protocol is the export protocol (e.g. "otlp", "otlphttp", "prometheusremotewrite").
         type: string

--- a/pkg/apiserver/domain/agent/model/endpoint.go
+++ b/pkg/apiserver/domain/agent/model/endpoint.go
@@ -50,6 +50,34 @@ type EndpointSpec struct {
 	// Tenants is the multi-tenant breakdown. The same endpoint can be managed
 	// differently per tenant via per-tenant Headers and Tags.
 	Tenants []EndpointTenant
+	// MetricsQuery configures how to measure, from a metrics backend, how much
+	// telemetry collectors are sending to this endpoint. Nil means throughput is
+	// not tracked for this endpoint.
+	MetricsQuery *EndpointMetricsQuery
+}
+
+// EndpointMetricsQuery holds a PromQL query template per telemetry signal used
+// to measure how much data collectors are sending to this endpoint.
+//
+// Each template is rendered (text/template) with a small context — notably the
+// rate window and the endpoint's own identity — before being executed against
+// the metrics backend. An empty template means that signal is not measured. A
+// rendered query is expected to evaluate to an instant vector of per-second
+// rates (e.g. sum by (...) (rate(otelcol_exporter_sent_metric_points_total[...])));
+// the adapter sums the result series to get the endpoint's total throughput for
+// that signal.
+type EndpointMetricsQuery struct {
+	// Metrics is the PromQL template measuring metric data points per second.
+	Metrics string
+	// Logs is the PromQL template measuring log records per second.
+	Logs string
+	// Traces is the PromQL template measuring spans per second.
+	Traces string
+}
+
+// IsZero reports whether no per-signal template is configured.
+func (q *EndpointMetricsQuery) IsZero() bool {
+	return q == nil || (q.Metrics == "" && q.Logs == "" && q.Traces == "")
 }
 
 // EndpointSignals declares which telemetry signals are supported.
@@ -100,10 +128,11 @@ func NewEndpoint(
 			DeletedAt:  nil,
 		},
 		Spec: EndpointSpec{
-			URL:      "",
-			Protocol: "",
-			Signals:  EndpointSignals{Metrics: false, Logs: false, Traces: false},
-			Tenants:  nil,
+			URL:          "",
+			Protocol:     "",
+			Signals:      EndpointSignals{Metrics: false, Logs: false, Traces: false},
+			Tenants:      nil,
+			MetricsQuery: nil,
 		},
 		Status: EndpointStatus{
 			Conditions: []model.Condition{

--- a/pkg/apiserver/domain/agent/model/endpointmetrics.go
+++ b/pkg/apiserver/domain/agent/model/endpointmetrics.go
@@ -1,0 +1,41 @@
+package agentmodel
+
+import "time"
+
+// EndpointThroughput is the rate at which collectors are sending telemetry to a
+// single endpoint, broken down by signal. Each per-signal value is an aggregate
+// (sum) across every contributing collector/exporter time series, expressed as a
+// per-second rate evaluated over Window at instant EvaluatedAt.
+//
+// It is the result of evaluating an endpoint's EndpointMetricsQuery against the
+// metrics backend; the units differ per signal (metric data points, log records,
+// spans — all per second) and are intentionally not normalized.
+type EndpointThroughput struct {
+	// Namespace and Name identify the endpoint the throughput was measured for.
+	Namespace string
+	Name      string
+	// EvaluatedAt is the instant the rates were evaluated at.
+	EvaluatedAt time.Time
+	// Window is the rate window the per-second values were computed over.
+	Window time.Duration
+	// Metrics is the metric-data-point send rate (points/sec).
+	Metrics SignalThroughput
+	// Logs is the log-record send rate (records/sec).
+	Logs SignalThroughput
+	// Traces is the span send rate (spans/sec).
+	Traces SignalThroughput
+}
+
+// SignalThroughput is the aggregated send rate for one telemetry signal.
+type SignalThroughput struct {
+	// Measured reports whether a query was configured and executed for this
+	// signal. When false, PerSecond and SeriesCount are zero and meaningless: the
+	// signal is simply not tracked for the endpoint.
+	Measured bool
+	// PerSecond is the aggregated per-second rate summed across contributing
+	// time series.
+	PerSecond float64
+	// SeriesCount is the number of contributing time series (e.g. distinct
+	// collectors/exporters) that the rate was summed over.
+	SeriesCount int
+}

--- a/pkg/apiserver/domain/agent/port/out.go
+++ b/pkg/apiserver/domain/agent/port/out.go
@@ -2,6 +2,7 @@ package agentport
 
 import (
 	"context"
+	"time"
 
 	"github.com/google/uuid"
 
@@ -129,6 +130,25 @@ type EndpointPersistencePort interface {
 		namespace string,
 		options *model.ListOptions,
 	) (*model.ListResponse[*agentmodel.Endpoint], error)
+}
+
+// EndpointMetricsQueryPort queries a metrics backend (a Prometheus-compatible
+// store) for how much telemetry collectors are sending to an endpoint. It is an
+// outbound port implemented by a metrics-backend adapter; the endpoint's
+// EndpointMetricsQuery templates select and aggregate the relevant series.
+type EndpointMetricsQueryPort interface {
+	// QueryEndpointThroughput evaluates the endpoint's per-signal PromQL
+	// templates over the given rate window at instant `at`, returning the
+	// aggregated per-second send throughput. Signals without a configured
+	// template come back with Measured=false. An endpoint whose MetricsQuery is
+	// nil/empty yields a result with every signal unmeasured (and no backend
+	// call).
+	QueryEndpointThroughput(
+		ctx context.Context,
+		endpoint *agentmodel.Endpoint,
+		window time.Duration,
+		at time.Time,
+	) (*agentmodel.EndpointThroughput, error)
 }
 
 // HostPersistencePort is an interface that defines the methods for host persistence.

--- a/pkg/apiserver/internal/module/adapter/secondary/metrics.go
+++ b/pkg/apiserver/internal/module/adapter/secondary/metrics.go
@@ -1,0 +1,41 @@
+package secondary
+
+import (
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/secondary/metrics"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/secondary/metrics/prometheus"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/config"
+	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
+)
+
+// errMetricsBackendAddressEmpty is returned when a metrics backend is selected
+// but no address is configured for it.
+var errMetricsBackendAddressEmpty = errors.New("metrics backend address is empty")
+
+// newEndpointMetricsQueryAdapter selects the endpoint-throughput query adapter
+// from the configured metrics backend: a Prometheus-compatible client when
+// configured, otherwise a no-op so the port is always satisfiable.
+func newEndpointMetricsQueryAdapter(
+	settings *config.ServerSettings,
+	logger *slog.Logger,
+) (agentport.EndpointMetricsQueryPort, error) {
+	backend := settings.MetricsBackend
+
+	if backend.Type == config.MetricsBackendTypePrometheus {
+		if backend.Address == "" {
+			return nil, fmt.Errorf("%w (type %q)", errMetricsBackendAddressEmpty, backend.Type)
+		}
+
+		adapter, err := prometheus.NewAdapter(backend.Address, logger)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create prometheus metrics adapter: %w", err)
+		}
+
+		return adapter, nil
+	}
+
+	return metrics.NewNoopAdapter(), nil
+}

--- a/pkg/apiserver/internal/module/adapter/secondary/secondary.go
+++ b/pkg/apiserver/internal/module/adapter/secondary/secondary.go
@@ -22,5 +22,7 @@ func New(databaseType config.DatabaseType) fx.Option {
 		persistence,
 		// Outbound messaging: server-event sender.
 		fx.Provide(newEventSender),
+		// Outbound metrics: endpoint-throughput query port (Prometheus or no-op).
+		fx.Provide(newEndpointMetricsQueryAdapter),
 	)
 }

--- a/pkg/cmd/apiserver/apiserver.go
+++ b/pkg/cmd/apiserver/apiserver.go
@@ -113,6 +113,12 @@ type CommandOption struct {
 		DefaultRole      string `mapstructure:"defaultRole"`
 	} `mapstructure:"bootstrap"`
 
+	MetricsBackend struct {
+		Type          string        `mapstructure:"type"`
+		Address       string        `mapstructure:"address"`
+		DefaultWindow time.Duration `mapstructure:"defaultWindow"`
+	} `mapstructure:"metricsBackend"`
+
 	// viper
 	viper *viper.Viper
 
@@ -229,6 +235,12 @@ func NewCommand(opt CommandOption) *cobra.Command {
 		"namespace agents without a service.namespace are placed in, and where the default role is granted")
 	cmd.Flags().String("bootstrap.defaultRole", "default",
 		"name of the built-in role auto-granted to every user")
+	cmd.Flags().String("metricsBackend.type", "none",
+		"metrics backend for endpoint-throughput queries (none, prometheus)")
+	cmd.Flags().String("metricsBackend.address", "",
+		"base URL of the Prometheus-compatible HTTP API (required when metricsBackend.type=prometheus)")
+	cmd.Flags().Duration("metricsBackend.defaultWindow", 5*time.Minute,
+		"default rate window for endpoint-throughput queries")
 
 	return cmd
 }
@@ -378,6 +390,11 @@ func (opt *CommandOption) Prepare(_ *cobra.Command, _ []string) error {
 			Dir:              opt.Bootstrap.Dir,
 			DefaultNamespace: defaultString(opt.Bootstrap.DefaultNamespace, agentmodel.DefaultNamespaceName),
 			DefaultRole:      defaultString(opt.Bootstrap.DefaultRole, usermodel.RoleDefault),
+		},
+		MetricsBackend: appconfig.MetricsBackendSettings{
+			Type:          appconfig.MetricsBackendType(opt.MetricsBackend.Type),
+			Address:       opt.MetricsBackend.Address,
+			DefaultWindow: opt.MetricsBackend.DefaultWindow,
 		},
 		RBACModelPath: "",
 	})

--- a/pkg/testutil/apiserver.go
+++ b/pkg/testutil/apiserver.go
@@ -132,6 +132,11 @@ func buildServerSettings(
 	return config.ServerSettings{
 		Address:  fmt.Sprintf("0.0.0.0:%d", serverPort),
 		ServerID: agentmodel.ServerID(serverID),
+		MetricsBackend: config.MetricsBackendSettings{
+			Type:          config.MetricsBackendTypeNone,
+			Address:       "",
+			DefaultWindow: 0,
+		},
 		//exhaustruct:ignore
 		EventSettings: config.EventSettings{
 			ProtocolType: config.EventProtocolTypeInMemory,


### PR DESCRIPTION
## What

Foundation for measuring **how much data collectors are sending to each endpoint**. Adds an outbound port that queries a Prometheus-compatible metrics backend per endpoint, plus everything needed to wire it.

This is **PR 1 of 2**. PR 2 will add the application-layer aggregation service + HTTP endpoint that uses this port across all endpoints in a namespace.

## Design (per agreed decisions)

- **Source:** Prometheus-compatible PromQL HTTP API (Prometheus / VictoriaMetrics / Mimir).
- **Endpoint→series mapping:** each Endpoint carries an optional **per-signal PromQL template** (`spec.metricsQuery`). Templates are rendered with `text/template` (rate window `{{.Window}}`, plus `{{.Namespace}}/{{.Name}}/{{.URL}}/{{.Protocol}}/{{.Attributes}}`) before execution — so the operator explicitly defines how each endpoint's traffic is selected.
- **Metric:** per-signal send **rate** (`otelcol_exporter_sent_{metric_points,log_records,spans}` style), summed across contributing series.

## Changes

- **Domain:** `EndpointSpec.MetricsQuery` (optional, per-signal templates); `EndpointThroughput` / `SignalThroughput` result models.
- **Port:** `agentport.EndpointMetricsQueryPort.QueryEndpointThroughput(ctx, endpoint, window, at)`.
- **Adapter (`adapter/secondary/metrics`):** a Prometheus adapter (renders templates, runs instant queries, sums vector samples, skips NaN) + a `NoopAdapter` fallback. Unit-tested with `httptest`.
- **Config/wiring:** `MetricsBackendSettings` (`type`/`address`/`defaultWindow`), CLI flags (`--metricsBackend.*`), and an FX provider choosing Prometheus or no-op. Defaults to `none` (no-op), so existing deployments are unaffected.
- **Persistence/DTO:** `MetricsQuery` threaded through mongo entity, in-memory clone, v1 DTO, mapper; Swagger regenerated.

## Notes

- The port has **no consumer yet** (that's PR 2); it's wired and lazily constructed by FX. With `metricsBackend.type=none` the no-op is used.
- `service.name`-only / custom-distro caveats are irrelevant here since selection is operator-defined via the template.

## Test / checks

- `go build ./...`, `golangci-lint run ./...` — clean (added prometheus query pkgs to depguard allowlist; new port to ireturn allowlist).
- `go test ./pkg/apiserver/adapter/secondary/metrics/...` and affected packages pass (`httptest`-backed adapter test covers summation, template rendering, and the nil-template short-circuit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)