### PR TITLE
feat(bootstrap): seed Endpoint resources from manifests

### DIFF
--- a/pkg/apiserver/internal/module/infrastructure/bootstrap.go
+++ b/pkg/apiserver/internal/module/infrastructure/bootstrap.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"maps"
 	"path/filepath"
+	"reflect"
 	"slices"
 	"sort"
 	"strings"
@@ -20,6 +21,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	v1 "github.com/minuk-dev/opampcommander/api/v1"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/application/helper"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/config"
 	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
 	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
@@ -45,10 +47,12 @@ var errUnsupportedAPIVersion = errors.New("unsupported manifest apiVersion")
 // errEmptyNamespaceName / errEmptyRoleName / errEmptyUser* are returned when a manifest
 // omits a required identifying field.
 var (
-	errEmptyNamespaceName = errors.New("namespace manifest has empty metadata.name")
-	errEmptyRoleName      = errors.New("role manifest has empty spec.displayName")
-	errEmptyUserName      = errors.New("user manifest has empty spec.username")
-	errEmptyUserEmail     = errors.New("user manifest has empty spec.email")
+	errEmptyNamespaceName     = errors.New("namespace manifest has empty metadata.name")
+	errEmptyRoleName          = errors.New("role manifest has empty spec.displayName")
+	errEmptyUserName          = errors.New("user manifest has empty spec.username")
+	errEmptyUserEmail         = errors.New("user manifest has empty spec.email")
+	errEmptyEndpointName      = errors.New("endpoint manifest has empty metadata.name")
+	errEmptyEndpointNamespace = errors.New("endpoint manifest has empty metadata.namespace")
 )
 
 // bootstrapUIDNamespace is a fixed UUID namespace used to derive deterministic UIDs
@@ -79,6 +83,7 @@ func builtinUserUID(username string) uuid.UUID {
 type bootstrapDeps struct {
 	fs                        afero.Fs
 	namespaceUsecase          agentport.NamespaceUsecase
+	endpointUsecase           agentport.EndpointUsecase
 	rolePersistencePort       userport.RolePersistencePort
 	permissionPersistencePort userport.PermissionPersistencePort
 	userPersistencePort       userport.UserPersistencePort
@@ -210,6 +215,8 @@ func applyManifests(ctx context.Context, docs []manifestDoc, deps bootstrapDeps)
 			err = applyRole(ctx, doc, deps)
 		case v1.UserKind:
 			err = applyUser(ctx, doc, deps)
+		case v1.EndpointKind:
+			err = applyEndpoint(ctx, doc, deps)
 		default:
 			return fmt.Errorf("%w: kind %q in %q", errUnsupportedKind, doc.kind, doc.source)
 		}
@@ -271,6 +278,70 @@ func applyNamespace(ctx context.Context, doc manifestDoc, deps bootstrapDeps) er
 	_, err = deps.namespaceUsecase.SaveNamespace(ctx, existing)
 	if err != nil {
 		return fmt.Errorf("save namespace %q: %w", name, err)
+	}
+
+	return nil
+}
+
+// applyEndpoint upserts an endpoint from a manifest. Like the other bootstrap
+// resources it is declarative: a missing endpoint is created with a Created
+// condition, and an existing one has its spec (URL/protocol/signals/tenants/
+// metricsQuery) and attributes overwritten from the manifest while its CreatedAt
+// and conditions are preserved. Redundant writes on unchanged manifests are
+// skipped so startup does not churn the store.
+func applyEndpoint(ctx context.Context, doc manifestDoc, deps bootstrapDeps) error {
+	var apiEndpoint v1.Endpoint
+
+	err := json.Unmarshal(doc.json, &apiEndpoint)
+	if err != nil {
+		return fmt.Errorf("decode Endpoint from %q: %w", doc.source, err)
+	}
+
+	name := apiEndpoint.Metadata.Name
+	if name == "" {
+		return fmt.Errorf("%w: %q", errEmptyEndpointName, doc.source)
+	}
+
+	namespace := apiEndpoint.Metadata.Namespace
+	if namespace == "" {
+		return fmt.Errorf("%w: %q", errEmptyEndpointNamespace, doc.source)
+	}
+
+	desired := helper.NewMapper(deps.clk, 0).MapAPIToEndpoint(&apiEndpoint)
+
+	existing, err := deps.endpointUsecase.GetEndpoint(ctx, namespace, name, nil)
+	if err != nil && !errors.Is(err, port.ErrResourceNotExist) {
+		return fmt.Errorf("check endpoint %q/%q: %w", namespace, name, err)
+	}
+
+	if errors.Is(err, port.ErrResourceNotExist) {
+		deps.logger.Info("bootstrap: creating endpoint",
+			slog.String("namespace", namespace), slog.String("name", name))
+
+		endpoint := agentmodel.NewEndpoint(namespace, name, desired.Metadata.Attributes, deps.clk.Now(), "system")
+		endpoint.Spec = desired.Spec
+
+		_, err = deps.endpointUsecase.SaveEndpoint(ctx, endpoint)
+		if err != nil {
+			return fmt.Errorf("save endpoint %q/%q: %w", namespace, name, err)
+		}
+
+		return nil
+	}
+
+	// Already exists: only re-save when the manifest actually changes the spec or
+	// attributes, to avoid a redundant write on every startup.
+	if reflect.DeepEqual(existing.Spec, desired.Spec) &&
+		maps.Equal(existing.Metadata.Attributes, desired.Metadata.Attributes) {
+		return nil
+	}
+
+	existing.Spec = desired.Spec
+	existing.Metadata.Attributes = desired.Metadata.Attributes
+
+	_, err = deps.endpointUsecase.SaveEndpoint(ctx, existing)
+	if err != nil {
+		return fmt.Errorf("save endpoint %q/%q: %w", namespace, name, err)
 	}
 
 	return nil
@@ -529,6 +600,7 @@ func ensurePermission(ctx context.Context, name string, deps bootstrapDeps) erro
 func registerBootstrapHook(
 	lifecycle fx.Lifecycle,
 	namespaceUsecase agentport.NamespaceUsecase,
+	endpointUsecase agentport.EndpointUsecase,
 	rolePersistencePort userport.RolePersistencePort,
 	permissionPersistencePort userport.PermissionPersistencePort,
 	userPersistencePort userport.UserPersistencePort,
@@ -539,6 +611,7 @@ func registerBootstrapHook(
 	deps := bootstrapDeps{
 		fs:                        afero.NewOsFs(),
 		namespaceUsecase:          namespaceUsecase,
+		endpointUsecase:           endpointUsecase,
 		rolePersistencePort:       rolePersistencePort,
 		permissionPersistencePort: permissionPersistencePort,
 		userPersistencePort:       userPersistencePort,

--- a/pkg/apiserver/internal/module/infrastructure/bootstrap_internal_test.go
+++ b/pkg/apiserver/internal/module/infrastructure/bootstrap_internal_test.go
@@ -71,6 +71,7 @@ func newTestDeps() (bootstrapDeps, *inmemory.RoleRepository, *inmemory.Permissio
 	return bootstrapDeps{
 		fs:                        afero.NewMemMapFs(),
 		namespaceUsecase:          nsService,
+		endpointUsecase:           agentservice.NewEndpointService(inmemory.NewEndpointRepository()),
 		rolePersistencePort:       roleRepo,
 		permissionPersistencePort: permRepo,
 		userPersistencePort:       userRepo,
@@ -321,6 +322,59 @@ func TestApplyManifests_UnknownKindFails(t *testing.T) {
 
 	err = applyManifests(t.Context(), docs, deps)
 	require.ErrorIs(t, err, errUnsupportedKind)
+}
+
+func TestApplyManifests_SeedsEndpointWithMetricsQuery(t *testing.T) {
+	t.Parallel()
+
+	deps, _, _ := newTestDeps()
+	endpointRepo := inmemory.NewEndpointRepository()
+	deps.endpointUsecase = agentservice.NewEndpointService(endpointRepo)
+
+	dir := writeManifests(t, deps.fs, map[string]string{
+		"30-endpoint.yaml": `kind: Endpoint
+apiVersion: v1
+metadata:
+  name: vm
+  namespace: default
+spec:
+  url: http://vm/insert
+  protocol: prometheusremotewrite
+  signals:
+    metrics: true
+  metricsQuery:
+    metrics: sum(rate(otelcol_exporter_sent_metric_points_total[{{.Window}}]))
+`,
+	})
+
+	docs, err := loadManifestDocs(deps.fs, dir)
+	require.NoError(t, err)
+	require.NoError(t, applyManifests(t.Context(), docs, deps))
+
+	got, err := endpointRepo.GetEndpoint(t.Context(), "default", "vm", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "http://vm/insert", got.Spec.URL)
+	assert.True(t, got.Spec.Signals.Metrics)
+	require.NotNil(t, got.Spec.MetricsQuery)
+	assert.Contains(t, got.Spec.MetricsQuery.Metrics, "otelcol_exporter_sent_metric_points_total")
+
+	// Reconciliation is idempotent: a second apply must not error.
+	require.NoError(t, applyManifests(t.Context(), docs, deps))
+}
+
+func TestApplyManifests_EndpointRequiresNamespace(t *testing.T) {
+	t.Parallel()
+
+	deps, _, _ := newTestDeps()
+	dir := writeManifests(t, deps.fs, map[string]string{
+		"30-endpoint.yaml": "kind: Endpoint\napiVersion: v1\nmetadata:\n  name: vm\n",
+	})
+
+	docs, err := loadManifestDocs(deps.fs, dir)
+	require.NoError(t, err)
+
+	err = applyManifests(t.Context(), docs, deps)
+	require.ErrorIs(t, err, errEmptyEndpointNamespace)
 }
 
 func TestEnsurePermission_RejectsMalformedName(t *testing.T) {


### PR DESCRIPTION
## What

Lets the bootstrap reconciler apply **Endpoint** manifests from the `initial/` dir, alongside the existing Namespace/Role/User kinds — the GitOps-friendly way to declaratively provision telemetry-backend endpoints (and their per-signal `metricsQuery` templates) whose throughput is measured by the endpoint-throughput feature (#456/#457, now in main).

## Changes

- `applyEndpoint` mirrors `applyNamespace`: create-if-missing (with a Created condition), otherwise overwrite spec + attributes from the manifest while preserving `CreatedAt`/conditions; unchanged manifests skip the write (declarative, idempotent).
- Wires `EndpointUsecase` into `bootstrapDeps` + `registerBootstrapHook`; adds `v1.EndpointKind` to the apply switch.
- Tests: seeds an Endpoint with a `metricsQuery` (round-trip + idempotency); rejects a manifest missing `metadata.namespace`.

## Verified end-to-end

Standalone server with `--bootstrap.dir` pointing at a dir containing a `kind: Endpoint` manifest:
- log: `bootstrap: creating endpoint namespace=default name=victoriametrics`
- `GET …/endpoints/victoriametrics` returns the seeded `url` + `metricsQuery`
- `GET …/endpoint-throughputs` lists it

`go build ./...`, `golangci-lint run` clean; infra tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)