### PR TITLE
feat(reconcile): add opampctl reconcile for remote configs, agent groups, agents

### DIFF
--- a/pkg/apiserver/adapter/primary/http/v1/agent/controller.go
+++ b/pkg/apiserver/adapter/primary/http/v1/agent/controller.go
@@ -82,6 +82,12 @@ func (c *Controller) RoutesInfo() gin.RoutesInfo {
 			Handler:     "http.v1.agent.Delete",
 			HandlerFunc: c.Delete,
 		},
+		{
+			Method:      http.MethodPost,
+			Path:        "/api/v1/namespaces/:namespace/agents/:id/reconcile",
+			Handler:     "http.v1.agent.Reconcile",
+			HandlerFunc: c.Reconcile,
+		},
 	}
 }
 
@@ -311,6 +317,45 @@ func (c *Controller) ListEndpoints(ctx *gin.Context) {
 	}
 
 	ctx.JSON(http.StatusOK, endpoints)
+}
+
+// Reconcile re-applies the agent groups that match the agent on demand, so it picks up its
+// assigned remote configs and connection settings without waiting for a group update.
+//
+// @Summary  Reconcile Agent
+// @Tags agent
+// @Description Re-apply the matching agent groups' remote configs and connection settings to the agent.
+// @Produce  json
+// @Param  namespace path string true "Namespace"
+// @Param  id path string true "Instance UID of the agent"
+// @Success  204 "No Content"
+// @Failure  400 {object} ErrorModel
+// @Failure  404 {object} ErrorModel
+// @Failure  500 {object} ErrorModel
+// @Router  /api/v1/namespaces/{namespace}/agents/{id}/reconcile [post].
+func (c *Controller) Reconcile(ctx *gin.Context) {
+	namespace, err := ginutil.ParseString(ctx, "namespace", true)
+	if err != nil {
+		ginutil.HandleValidationError(ctx, "namespace", ctx.Param("namespace"), err, true)
+
+		return
+	}
+
+	instanceUID, err := ginutil.ParseUUID(ctx, "id")
+	if err != nil {
+		ginutil.HandleValidationError(ctx, "id", ctx.Param("id"), err, true)
+
+		return
+	}
+
+	err = c.agentUsecase.ReconcileAgent(ctx.Request.Context(), namespace, instanceUID)
+	if err != nil {
+		c.handleAgentError(ctx, err, "An error occurred while reconciling the agent.")
+
+		return
+	}
+
+	ctx.Status(http.StatusNoContent)
 }
 
 // Update updates an agent's metadata & spec.

--- a/pkg/apiserver/adapter/primary/http/v1/agent/usecasemock/mocks.go
+++ b/pkg/apiserver/adapter/primary/http/v1/agent/usecasemock/mocks.go
@@ -325,6 +325,69 @@ func (_c *MockManageUsecase_ListAgents_Call) RunAndReturn(run func(ctx context.C
 	return _c
 }
 
+// ReconcileAgent provides a mock function for the type MockManageUsecase
+func (_mock *MockManageUsecase) ReconcileAgent(ctx context.Context, namespace string, instanceUID uuid.UUID) error {
+	ret := _mock.Called(ctx, namespace, instanceUID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ReconcileAgent")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, uuid.UUID) error); ok {
+		r0 = returnFunc(ctx, namespace, instanceUID)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockManageUsecase_ReconcileAgent_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReconcileAgent'
+type MockManageUsecase_ReconcileAgent_Call struct {
+	*mock.Call
+}
+
+// ReconcileAgent is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespace string
+//   - instanceUID uuid.UUID
+func (_e *MockManageUsecase_Expecter) ReconcileAgent(ctx interface{}, namespace interface{}, instanceUID interface{}) *MockManageUsecase_ReconcileAgent_Call {
+	return &MockManageUsecase_ReconcileAgent_Call{Call: _e.mock.On("ReconcileAgent", ctx, namespace, instanceUID)}
+}
+
+func (_c *MockManageUsecase_ReconcileAgent_Call) Run(run func(ctx context.Context, namespace string, instanceUID uuid.UUID)) *MockManageUsecase_ReconcileAgent_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 uuid.UUID
+		if args[2] != nil {
+			arg2 = args[2].(uuid.UUID)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockManageUsecase_ReconcileAgent_Call) Return(err error) *MockManageUsecase_ReconcileAgent_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockManageUsecase_ReconcileAgent_Call) RunAndReturn(run func(ctx context.Context, namespace string, instanceUID uuid.UUID) error) *MockManageUsecase_ReconcileAgent_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // SearchAgents provides a mock function for the type MockManageUsecase
 func (_mock *MockManageUsecase) SearchAgents(ctx context.Context, namespace string, query string, options *port.ListOptions) (*v1.ListResponse[v1.Agent], error) {
 	ret := _mock.Called(ctx, namespace, query, options)

--- a/pkg/apiserver/adapter/primary/http/v1/agentgroup/controller.go
+++ b/pkg/apiserver/adapter/primary/http/v1/agentgroup/controller.go
@@ -77,6 +77,12 @@ func (c *Controller) RoutesInfo() gin.RoutesInfo {
 			Handler:     "http.v1.agentgroup.Delete",
 			HandlerFunc: c.Delete,
 		},
+		{
+			Method:      http.MethodPost,
+			Path:        "/api/v1/namespaces/:namespace/agentgroups/:name/reconcile",
+			Handler:     "http.v1.agentgroup.Reconcile",
+			HandlerFunc: c.Reconcile,
+		},
 	}
 }
 
@@ -404,6 +410,43 @@ func (c *Controller) Delete(ctx *gin.Context) {
 	if err != nil {
 		c.logger.Error("failed to delete agent group", "error", err.Error())
 		ginutil.HandleDomainError(ctx, err, "An error occurred while deleting the agent group.")
+
+		return
+	}
+
+	ctx.Status(http.StatusNoContent)
+}
+
+// Reconcile re-applies the agent group to its matching agents on demand.
+//
+// @Summary Reconcile Agent Group
+// @Tags agentgroup
+// @Description Re-apply the agent group's remote configs and connection settings to its matching agents.
+// @Param namespace path string true "Namespace"
+// @Param name path string true "Agent Group Name"
+// @Success 204 "No Content"
+// @Failure 404 {object} map[string]any
+// @Failure 500 {object} map[string]any
+// @Router /api/v1/namespaces/{namespace}/agentgroups/{name}/reconcile [post].
+func (c *Controller) Reconcile(ctx *gin.Context) {
+	namespace, err := ginutil.ParseString(ctx, "namespace", true)
+	if err != nil {
+		ginutil.HandleValidationError(ctx, "namespace", ctx.Param("namespace"), err, true)
+
+		return
+	}
+
+	name, err := ginutil.ParseString(ctx, "name", true)
+	if err != nil {
+		ginutil.HandleValidationError(ctx, "name", ctx.Param("name"), err, true)
+
+		return
+	}
+
+	err = c.agentGroupUsecase.ReconcileAgentGroup(ctx.Request.Context(), namespace, name)
+	if err != nil {
+		c.logger.Error("failed to reconcile agent group", "error", err.Error())
+		ginutil.HandleDomainError(ctx, err, "An error occurred while reconciling the agent group.")
 
 		return
 	}

--- a/pkg/apiserver/adapter/primary/http/v1/agentgroup/usecasemock/mocks.go
+++ b/pkg/apiserver/adapter/primary/http/v1/agentgroup/usecasemock/mocks.go
@@ -473,6 +473,69 @@ func (_c *MockUsecase_ListAgentsByAgentGroup_Call) RunAndReturn(run func(ctx con
 	return _c
 }
 
+// ReconcileAgentGroup provides a mock function for the type MockUsecase
+func (_mock *MockUsecase) ReconcileAgentGroup(ctx context.Context, namespace string, name string) error {
+	ret := _mock.Called(ctx, namespace, name)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ReconcileAgentGroup")
+	}
+
+	var r0 error
+	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
+		r0 = returnFunc(ctx, namespace, name)
+	} else {
+		r0 = ret.Error(0)
+	}
+	return r0
+}
+
+// MockUsecase_ReconcileAgentGroup_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReconcileAgentGroup'
+type MockUsecase_ReconcileAgentGroup_Call struct {
+	*mock.Call
+}
+
+// ReconcileAgentGroup is a helper method to define mock.On call
+//   - ctx context.Context
+//   - namespace string
+//   - name string
+func (_e *MockUsecase_Expecter) ReconcileAgentGroup(ctx interface{}, namespace interface{}, name interface{}) *MockUsecase_ReconcileAgentGroup_Call {
+	return &MockUsecase_ReconcileAgentGroup_Call{Call: _e.mock.On("ReconcileAgentGroup", ctx, namespace, name)}
+}
+
+func (_c *MockUsecase_ReconcileAgentGroup_Call) Run(run func(ctx context.Context, namespace string, name string)) *MockUsecase_ReconcileAgentGroup_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		var arg0 context.Context
+		if args[0] != nil {
+			arg0 = args[0].(context.Context)
+		}
+		var arg1 string
+		if args[1] != nil {
+			arg1 = args[1].(string)
+		}
+		var arg2 string
+		if args[2] != nil {
+			arg2 = args[2].(string)
+		}
+		run(
+			arg0,
+			arg1,
+			arg2,
+		)
+	})
+	return _c
+}
+
+func (_c *MockUsecase_ReconcileAgentGroup_Call) Return(err error) *MockUsecase_ReconcileAgentGroup_Call {
+	_c.Call.Return(err)
+	return _c
+}
+
+func (_c *MockUsecase_ReconcileAgentGroup_Call) RunAndReturn(run func(ctx context.Context, namespace string, name string) error) *MockUsecase_ReconcileAgentGroup_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // UpdateAgentGroup provides a mock function for the type MockUsecase
 func (_mock *MockUsecase) UpdateAgentGroup(ctx context.Context, namespace string, name string, agentGroup *v1.AgentGroup) (*v1.AgentGroup, error) {
 	ret := _mock.Called(ctx, namespace, name, agentGroup)

--- a/pkg/apiserver/adapter/primary/http/v1/agentremoteconfig/controller.go
+++ b/pkg/apiserver/adapter/primary/http/v1/agentremoteconfig/controller.go
@@ -65,6 +65,12 @@ func (c *Controller) RoutesInfo() gin.RoutesInfo {
 			Handler:     "http.v1.agentremoteconfig.Delete",
 			HandlerFunc: c.Delete,
 		},
+		{
+			Method:      http.MethodPost,
+			Path:        "/api/v1/namespaces/:namespace/agentremoteconfigs/:name/reconcile",
+			Handler:     "http.v1.agentremoteconfig.Reconcile",
+			HandlerFunc: c.Reconcile,
+		},
 	}
 }
 
@@ -286,6 +292,58 @@ func (c *Controller) Delete(ctx *gin.Context) {
 		ginutil.HandleDomainError(
 			ctx, err,
 			"An error occurred while deleting the agent remote config.",
+		)
+
+		return
+	}
+
+	ctx.Status(http.StatusNoContent)
+}
+
+// Reconcile re-runs the side effects of an agent remote config on demand: telemetry endpoint
+// detection from its collector exporters and re-propagation to the agent groups that reference
+// it. Use it to repair drift for configs that predate those triggers.
+//
+// @Summary  Reconcile Agent Remote Config
+// @Description Re-detect endpoints from the config's exporters and re-propagate it to referencing agent groups.
+// @Tags  agentremoteconfig
+// @Produce  json
+// @Param  namespace path string true "Namespace"
+// @Param  name path string true "Agent Remote Config Name"
+// @Success  204 "No Content"
+// @Failure  404 {object} map[string]any
+// @Failure  500 {object} map[string]any
+// @Router  /api/v1/namespaces/{namespace}/agentremoteconfigs/{name}/reconcile [post].
+func (c *Controller) Reconcile(ctx *gin.Context) {
+	namespace, err := ginutil.ParseString(ctx, "namespace", true)
+	if err != nil {
+		ginutil.HandleValidationError(
+			ctx, "namespace", ctx.Param("namespace"), err, true,
+		)
+
+		return
+	}
+
+	name, err := ginutil.ParseString(ctx, "name", true)
+	if err != nil {
+		ginutil.HandleValidationError(
+			ctx, "name", ctx.Param("name"), err, true,
+		)
+
+		return
+	}
+
+	err = c.agentRemoteConfigUsecase.ReconcileAgentRemoteConfig(
+		ctx.Request.Context(), namespace, name,
+	)
+	if err != nil {
+		c.logger.Error(
+			"failed to reconcile agent remote config",
+			"name", name, "error", err.Error(),
+		)
+		ginutil.HandleDomainError(
+			ctx, err,
+			"An error occurred while reconciling the agent remote config.",
 		)
 
 		return

--- a/pkg/apiserver/application/port/in.go
+++ b/pkg/apiserver/application/port/in.go
@@ -89,6 +89,10 @@ type AgentManageUsecase interface {
 	// to, extracted from its reported effective configuration (not persisted).
 	ListAgentEndpoints(ctx context.Context, namespace string,
 		instanceUID uuid.UUID) (*v1.ListResponse[v1.Endpoint], error)
+	// ReconcileAgent re-applies the agent groups that match the agent on demand, so it
+	// picks up its assigned remote configs and connection settings without waiting for a
+	// group update or the background reconcile loop.
+	ReconcileAgent(ctx context.Context, namespace string, instanceUID uuid.UUID) error
 }
 
 // AgentGroupManageUsecase is a use case that handles agent group management operations.
@@ -113,6 +117,9 @@ type AgentGroupManageUsecase interface {
 	UpdateAgentGroup(ctx context.Context, namespace string, name string,
 		agentGroup *v1.AgentGroup) (*v1.AgentGroup, error)
 	DeleteAgentGroup(ctx context.Context, namespace string, name string) error
+	// ReconcileAgentGroup re-applies the named agent group to its matching agents on demand,
+	// the same work the background reconcile loop performs.
+	ReconcileAgentGroup(ctx context.Context, namespace string, name string) error
 }
 
 // HostManageUsecase is a use case that handles host management operations.
@@ -153,6 +160,9 @@ type AgentRemoteConfigManageUsecase interface {
 	UpdateAgentRemoteConfig(ctx context.Context, namespace string, name string,
 		agentRemoteConfig *v1.AgentRemoteConfig) (*v1.AgentRemoteConfig, error)
 	DeleteAgentRemoteConfig(ctx context.Context, namespace string, name string) error
+	// ReconcileAgentRemoteConfig re-detects telemetry endpoints from the config's collector
+	// exporters and re-propagates the config to the agent groups that reference it.
+	ReconcileAgentRemoteConfig(ctx context.Context, namespace string, name string) error
 }
 
 // EndpointManageUsecase is a use case that handles endpoint management operations.

--- a/pkg/apiserver/application/service/agent/agent.go
+++ b/pkg/apiserver/application/service/agent/agent.go
@@ -104,9 +104,9 @@ func (s *Service) ReconcileAgent(
 		return err
 	}
 
-	err = s.agentGroupUsecase.ApplyMatchingAgentGroupsToAgent(ctx, agent)
+	err = s.agentGroupUsecase.ReconcileAgent(ctx, agent)
 	if err != nil {
-		return fmt.Errorf("apply matching agent groups to agent: %w", err)
+		return fmt.Errorf("reconcile agent: %w", err)
 	}
 
 	return nil

--- a/pkg/apiserver/application/service/agent/agent.go
+++ b/pkg/apiserver/application/service/agent/agent.go
@@ -35,6 +35,7 @@ type Service struct {
 	agentUsecase             agentport.AgentUsecase
 	agentNotificationUsecase agentport.AgentNotificationUsecase
 	endpointDetectionUsecase agentport.EndpointDetectionUsecase
+	agentGroupUsecase        agentport.AgentGroupUsecase
 
 	// mapper
 	mapper *helper.Mapper
@@ -46,6 +47,7 @@ func New(
 	agentUsecase agentport.AgentUsecase,
 	agentNotificationUsecase agentport.AgentNotificationUsecase,
 	endpointDetectionUsecase agentport.EndpointDetectionUsecase,
+	agentGroupUsecase agentport.AgentGroupUsecase,
 	logger *slog.Logger,
 ) *Service {
 	realClock := clock.RealClock{}
@@ -54,6 +56,7 @@ func New(
 		agentUsecase:             agentUsecase,
 		agentNotificationUsecase: agentNotificationUsecase,
 		endpointDetectionUsecase: endpointDetectionUsecase,
+		agentGroupUsecase:        agentGroupUsecase,
 
 		mapper: helper.NewMapper(realClock, agentmodel.DefaultConnectionStaleness),
 		logger: logger,
@@ -86,6 +89,27 @@ func (s *Service) ListAgentEndpoints(
 			return *s.mapper.MapEndpointToAPI(item)
 		}),
 	}, nil
+}
+
+// ReconcileAgent implements port.AgentManageUsecase. It loads the agent (enforcing the
+// namespace) and re-applies every agent group whose selector matches it, so the agent picks
+// up its assigned remote configs and connection settings on demand.
+func (s *Service) ReconcileAgent(
+	ctx context.Context,
+	namespace string,
+	instanceUID uuid.UUID,
+) error {
+	agent, err := s.getAgentInNamespace(ctx, namespace, instanceUID)
+	if err != nil {
+		return err
+	}
+
+	err = s.agentGroupUsecase.ApplyMatchingAgentGroupsToAgent(ctx, agent)
+	if err != nil {
+		return fmt.Errorf("apply matching agent groups to agent: %w", err)
+	}
+
+	return nil
 }
 
 // GetAgent implements port.AgentManageUsecase.

--- a/pkg/apiserver/application/service/agent/agent_test.go
+++ b/pkg/apiserver/application/service/agent/agent_test.go
@@ -14,6 +14,7 @@ import (
 	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/agent"
 	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
+	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
 )
 
@@ -136,6 +137,11 @@ func (stubEndpointDetectionUsecase) ExtractEndpointsFromAgent(
 	return nil, nil
 }
 
+// stubAgentGroupUsecase is a no-op agentport.AgentGroupUsecase for the agent-service tests,
+// which do not exercise agent-group reconciliation. The embedded interface satisfies the
+// contract; any unexpected call would panic, surfacing untested coverage.
+type stubAgentGroupUsecase struct{ agentport.AgentGroupUsecase }
+
 func TestService_SearchAgents(t *testing.T) {
 	t.Parallel()
 
@@ -146,7 +152,10 @@ func TestService_SearchAgents(t *testing.T) {
 		ctx := t.Context()
 		mockAgentUsecase := new(MockAgentUsecase)
 		mockNotificationUsecase := new(MockAgentNotificationUsecase)
-		service := agent.New(mockAgentUsecase, mockNotificationUsecase, stubEndpointDetectionUsecase{}, slog.Default())
+		service := agent.New(
+			mockAgentUsecase, mockNotificationUsecase,
+			stubEndpointDetectionUsecase{}, stubAgentGroupUsecase{}, slog.Default(),
+		)
 
 		instanceUID := uuid.New()
 		domainAgents := []*agentmodel.Agent{
@@ -178,7 +187,10 @@ func TestService_SearchAgents(t *testing.T) {
 		ctx := t.Context()
 		mockAgentUsecase := new(MockAgentUsecase)
 		mockNotificationUsecase := new(MockAgentNotificationUsecase)
-		service := agent.New(mockAgentUsecase, mockNotificationUsecase, stubEndpointDetectionUsecase{}, slog.Default())
+		service := agent.New(
+			mockAgentUsecase, mockNotificationUsecase,
+			stubEndpointDetectionUsecase{}, stubAgentGroupUsecase{}, slog.Default(),
+		)
 
 		mockAgentUsecase.On("SearchAgents", ctx, "default", "test", mock.Anything).Return(nil, errMockError)
 
@@ -199,7 +211,10 @@ func TestService_SearchAgents(t *testing.T) {
 		ctx := t.Context()
 		mockAgentUsecase := new(MockAgentUsecase)
 		mockNotificationUsecase := new(MockAgentNotificationUsecase)
-		service := agent.New(mockAgentUsecase, mockNotificationUsecase, stubEndpointDetectionUsecase{}, slog.Default())
+		service := agent.New(
+			mockAgentUsecase, mockNotificationUsecase,
+			stubEndpointDetectionUsecase{}, stubAgentGroupUsecase{}, slog.Default(),
+		)
 
 		domainAgents := []*agentmodel.Agent{
 			agentmodel.NewAgent(uuid.New()),
@@ -241,7 +256,10 @@ func TestService_DeleteAgent(t *testing.T) {
 		ctx := t.Context()
 		mockAgentUsecase := new(MockAgentUsecase)
 		mockNotificationUsecase := new(MockAgentNotificationUsecase)
-		service := agent.New(mockAgentUsecase, mockNotificationUsecase, stubEndpointDetectionUsecase{}, slog.Default())
+		service := agent.New(
+			mockAgentUsecase, mockNotificationUsecase,
+			stubEndpointDetectionUsecase{}, stubAgentGroupUsecase{}, slog.Default(),
+		)
 
 		instanceUID := uuid.New()
 		domainAgent := agentmodel.NewAgent(instanceUID) // Status.Connected defaults to false
@@ -265,7 +283,10 @@ func TestService_DeleteAgent(t *testing.T) {
 		ctx := t.Context()
 		mockAgentUsecase := new(MockAgentUsecase)
 		mockNotificationUsecase := new(MockAgentNotificationUsecase)
-		service := agent.New(mockAgentUsecase, mockNotificationUsecase, stubEndpointDetectionUsecase{}, slog.Default())
+		service := agent.New(
+			mockAgentUsecase, mockNotificationUsecase,
+			stubEndpointDetectionUsecase{}, stubAgentGroupUsecase{}, slog.Default(),
+		)
 
 		instanceUID := uuid.New()
 		domainAgent := agentmodel.NewAgent(instanceUID) // namespace "default"
@@ -288,7 +309,10 @@ func TestService_DeleteAgent(t *testing.T) {
 		ctx := t.Context()
 		mockAgentUsecase := new(MockAgentUsecase)
 		mockNotificationUsecase := new(MockAgentNotificationUsecase)
-		service := agent.New(mockAgentUsecase, mockNotificationUsecase, stubEndpointDetectionUsecase{}, slog.Default())
+		service := agent.New(
+			mockAgentUsecase, mockNotificationUsecase,
+			stubEndpointDetectionUsecase{}, stubAgentGroupUsecase{}, slog.Default(),
+		)
 
 		instanceUID := uuid.New()
 		domainAgent := agentmodel.NewAgent(instanceUID) // namespace defaults to "default"
@@ -311,7 +335,10 @@ func TestService_DeleteAgent(t *testing.T) {
 		ctx := t.Context()
 		mockAgentUsecase := new(MockAgentUsecase)
 		mockNotificationUsecase := new(MockAgentNotificationUsecase)
-		service := agent.New(mockAgentUsecase, mockNotificationUsecase, stubEndpointDetectionUsecase{}, slog.Default())
+		service := agent.New(
+			mockAgentUsecase, mockNotificationUsecase,
+			stubEndpointDetectionUsecase{}, stubAgentGroupUsecase{}, slog.Default(),
+		)
 
 		instanceUID := uuid.New()
 		domainAgent := agentmodel.NewAgent(instanceUID)

--- a/pkg/apiserver/application/service/agentgroup/agentgroup_manage_service.go
+++ b/pkg/apiserver/application/service/agentgroup/agentgroup_manage_service.go
@@ -280,3 +280,14 @@ func (s *ManageService) DeleteAgentGroup(
 
 	return nil
 }
+
+// ReconcileAgentGroup implements [port.AgentGroupManageUsecase]. It delegates to the domain
+// use case to re-apply the named group to its matching agents on demand.
+func (s *ManageService) ReconcileAgentGroup(ctx context.Context, namespace string, name string) error {
+	err := s.agentgroupUsecase.ReconcileAgentGroup(ctx, namespace, name)
+	if err != nil {
+		return fmt.Errorf("reconcile agent group: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/apiserver/application/service/agentremoteconfig/agentremoteconfig.go
+++ b/pkg/apiserver/application/service/agentremoteconfig/agentremoteconfig.go
@@ -201,6 +201,19 @@ func (s *Service) DeleteAgentRemoteConfig(
 	return nil
 }
 
+// ReconcileAgentRemoteConfig implements [port.AgentRemoteConfigManageUsecase]. It delegates
+// to the domain use case, which re-detects endpoints from the config's collector exporters
+// and re-propagates the config to the agent groups that reference it. Unlike the create/update
+// path (which fires these as detached goroutines), this runs synchronously and surfaces errors.
+func (s *Service) ReconcileAgentRemoteConfig(ctx context.Context, namespace string, name string) error {
+	err := s.agentRemoteConfigUsecase.ReconcileAgentRemoteConfig(ctx, namespace, name)
+	if err != nil {
+		return fmt.Errorf("reconcile agent remote config: %w", err)
+	}
+
+	return nil
+}
+
 // triggerGroupPropagation asks the agent group service to re-apply any groups in the
 // namespace that reference this config. Runs in its own goroutine so a slow
 // changedAgentGroupCh consumer cannot block the HTTP handler; the periodic

--- a/pkg/apiserver/application/service/namespace/namespace_manage_service_test.go
+++ b/pkg/apiserver/application/service/namespace/namespace_manage_service_test.go
@@ -124,6 +124,12 @@ func (f *fakeAgentGroupUsecase) ApplyMatchingAgentGroupsToAgent(
 	return nil
 }
 
+func (f *fakeAgentGroupUsecase) ReconcileAgent(
+	context.Context, *agentmodel.Agent,
+) error {
+	return nil
+}
+
 func (f *fakeAgentGroupUsecase) ReconcileAgentGroup(
 	context.Context, string, string,
 ) error {

--- a/pkg/apiserver/application/service/namespace/namespace_manage_service_test.go
+++ b/pkg/apiserver/application/service/namespace/namespace_manage_service_test.go
@@ -124,6 +124,12 @@ func (f *fakeAgentGroupUsecase) ApplyMatchingAgentGroupsToAgent(
 	return nil
 }
 
+func (f *fakeAgentGroupUsecase) ReconcileAgentGroup(
+	context.Context, string, string,
+) error {
+	return nil
+}
+
 type fakeCertificateUsecase struct{}
 
 func (f *fakeCertificateUsecase) GetCertificate(
@@ -198,6 +204,12 @@ func (f *fakeAgentRemoteConfigUsecase) SaveAgentRemoteConfig(
 
 func (f *fakeAgentRemoteConfigUsecase) DeleteAgentRemoteConfig(
 	context.Context, string, string, time.Time, string,
+) error {
+	return nil
+}
+
+func (f *fakeAgentRemoteConfigUsecase) ReconcileAgentRemoteConfig(
+	context.Context, string, string,
 ) error {
 	return nil
 }

--- a/pkg/apiserver/docs/docs.go
+++ b/pkg/apiserver/docs/docs.go
@@ -885,6 +885,50 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/namespaces/{namespace}/agentgroups/{name}/reconcile": {
+            "post": {
+                "description": "Re-apply the agent group's remote configs and connection settings to its matching agents.",
+                "tags": [
+                    "agentgroup"
+                ],
+                "summary": "Reconcile Agent Group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Namespace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent Group Name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/namespaces/{namespace}/agentpackages": {
             "get": {
                 "description": "Retrieve a list of agent packages.",
@@ -1154,6 +1198,53 @@ const docTemplate = `{
                             "type": "object",
                             "additionalProperties": true
                         }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/namespaces/{namespace}/agentremoteconfigs/{name}/reconcile": {
+            "post": {
+                "description": "Re-detect endpoints from the config's exporters and re-propagate it to referencing agent groups.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "agentremoteconfig"
+                ],
+                "summary": "Reconcile Agent Remote Config",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Namespace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent Remote Config Name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
                     },
                     "404": {
                         "description": "Not Found",
@@ -1594,6 +1685,57 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/ListResponse-Endpoint"
                         }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorModel"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorModel"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorModel"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/namespaces/{namespace}/agents/{id}/reconcile": {
+            "post": {
+                "description": "Re-apply the matching agent groups' remote configs and connection settings to the agent.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "agent"
+                ],
+                "summary": "Reconcile Agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Namespace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Instance UID of the agent",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
                     },
                     "400": {
                         "description": "Bad Request",

--- a/pkg/apiserver/docs/swagger.json
+++ b/pkg/apiserver/docs/swagger.json
@@ -877,6 +877,50 @@
                 }
             }
         },
+        "/api/v1/namespaces/{namespace}/agentgroups/{name}/reconcile": {
+            "post": {
+                "description": "Re-apply the agent group's remote configs and connection settings to its matching agents.",
+                "tags": [
+                    "agentgroup"
+                ],
+                "summary": "Reconcile Agent Group",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Namespace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent Group Name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/namespaces/{namespace}/agentpackages": {
             "get": {
                 "description": "Retrieve a list of agent packages.",
@@ -1146,6 +1190,53 @@
                             "type": "object",
                             "additionalProperties": true
                         }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/namespaces/{namespace}/agentremoteconfigs/{name}/reconcile": {
+            "post": {
+                "description": "Re-detect endpoints from the config's exporters and re-propagate it to referencing agent groups.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "agentremoteconfig"
+                ],
+                "summary": "Reconcile Agent Remote Config",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Namespace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Agent Remote Config Name",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
                     },
                     "404": {
                         "description": "Not Found",
@@ -1586,6 +1677,57 @@
                         "schema": {
                             "$ref": "#/definitions/ListResponse-Endpoint"
                         }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorModel"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorModel"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/ErrorModel"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/namespaces/{namespace}/agents/{id}/reconcile": {
+            "post": {
+                "description": "Re-apply the matching agent groups' remote configs and connection settings to the agent.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "agent"
+                ],
+                "summary": "Reconcile Agent",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Namespace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Instance UID of the agent",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
                     },
                     "400": {
                         "description": "Bad Request",

--- a/pkg/apiserver/docs/swagger.yaml
+++ b/pkg/apiserver/docs/swagger.yaml
@@ -2073,6 +2073,37 @@ paths:
       summary: Update Agent Group
       tags:
       - agentgroup
+  /api/v1/namespaces/{namespace}/agentgroups/{name}/reconcile:
+    post:
+      description: Re-apply the agent group's remote configs and connection settings
+        to its matching agents.
+      parameters:
+      - description: Namespace
+        in: path
+        name: namespace
+        required: true
+        type: string
+      - description: Agent Group Name
+        in: path
+        name: name
+        required: true
+        type: string
+      responses:
+        "204":
+          description: No Content
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      summary: Reconcile Agent Group
+      tags:
+      - agentgroup
   /api/v1/namespaces/{namespace}/agentpackages:
     get:
       description: Retrieve a list of agent packages.
@@ -2269,6 +2300,39 @@ paths:
       summary: Update Agent Package
       tags:
       - agentpackage
+  /api/v1/namespaces/{namespace}/agentremoteconfigs/{name}/reconcile:
+    post:
+      description: Re-detect endpoints from the config's exporters and re-propagate
+        it to referencing agent groups.
+      parameters:
+      - description: Namespace
+        in: path
+        name: namespace
+        required: true
+        type: string
+      - description: Agent Remote Config Name
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      summary: Reconcile Agent Remote Config
+      tags:
+      - agentremoteconfig
   /api/v1/namespaces/{namespace}/agents:
     get:
       consumes:
@@ -2522,6 +2586,41 @@ paths:
           schema:
             $ref: '#/definitions/ErrorModel'
       summary: List Agent Endpoints
+      tags:
+      - agent
+  /api/v1/namespaces/{namespace}/agents/{id}/reconcile:
+    post:
+      description: Re-apply the matching agent groups' remote configs and connection
+        settings to the agent.
+      parameters:
+      - description: Namespace
+        in: path
+        name: namespace
+        required: true
+        type: string
+      - description: Instance UID of the agent
+        in: path
+        name: id
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/ErrorModel'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/ErrorModel'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/ErrorModel'
+      summary: Reconcile Agent
       tags:
       - agent
   /api/v1/namespaces/{namespace}/agents/search:

--- a/pkg/apiserver/domain/agent/port/in.go
+++ b/pkg/apiserver/domain/agent/port/in.go
@@ -104,6 +104,11 @@ type AgentRemoteConfigUsecase interface {
 	// DeleteAgentRemoteConfig deletes the agent remote config by its namespace and name.
 	DeleteAgentRemoteConfig(ctx context.Context, namespace string, name string,
 		deletedAt time.Time, deletedBy string) error
+	// ReconcileAgentRemoteConfig re-runs the side effects normally triggered when the named
+	// AgentRemoteConfig is created/updated: it detects telemetry endpoints from the config's
+	// collector exporters and re-propagates the config to every agent group that references it.
+	// Use this to repair drift for configs that predate those triggers (or were missed).
+	ReconcileAgentRemoteConfig(ctx context.Context, namespace string, name string) error
 }
 
 // EndpointUsecase is an interface that defines the methods for endpoint use cases.
@@ -178,6 +183,10 @@ type AgentGroupUsecase interface {
 	// applies their remote configs and connection settings. Use this when an agent reports a
 	// new description so it picks up its assigned configs without waiting for a group update.
 	ApplyMatchingAgentGroupsToAgent(ctx context.Context, agent *agentmodel.Agent) error
+	// ReconcileAgentGroup re-applies the named agent group to its matching agents on demand,
+	// the same work the background reconcile loop performs. Use this to force a refresh
+	// without waiting for the next tick or mutating the group.
+	ReconcileAgentGroup(ctx context.Context, namespace, name string) error
 }
 
 // AgentGroupRelatedUsecase is an interface that defines methods related to agent groups.

--- a/pkg/apiserver/domain/agent/port/in.go
+++ b/pkg/apiserver/domain/agent/port/in.go
@@ -182,7 +182,12 @@ type AgentGroupUsecase interface {
 	// ApplyMatchingAgentGroupsToAgent finds all agent groups that match the given agent and
 	// applies their remote configs and connection settings. Use this when an agent reports a
 	// new description so it picks up its assigned configs without waiting for a group update.
+	// It mutates the agent in place; the caller is responsible for persisting.
 	ApplyMatchingAgentGroupsToAgent(ctx context.Context, agent *agentmodel.Agent) error
+	// ReconcileAgent re-applies the matching agent groups to the given agent and persists the
+	// result. Unlike ApplyMatchingAgentGroupsToAgent it owns the save, so an on-demand
+	// reconcile of a single agent actually takes effect.
+	ReconcileAgent(ctx context.Context, agent *agentmodel.Agent) error
 	// ReconcileAgentGroup re-applies the named agent group to its matching agents on demand,
 	// the same work the background reconcile loop performs. Use this to force a refresh
 	// without waiting for the next tick or mutating the group.

--- a/pkg/apiserver/domain/agent/service/agentgroup.go
+++ b/pkg/apiserver/domain/agent/service/agentgroup.go
@@ -393,6 +393,24 @@ func (s *AgentGroupService) ApplyMatchingAgentGroupsToAgent(
 	return nil
 }
 
+// ReconcileAgent re-applies the matching agent groups to the agent and persists the result.
+// It mirrors the per-agent step of the background reconcile loop (apply then save), so an
+// on-demand reconcile of a single agent actually takes effect — ApplyMatchingAgentGroupsToAgent
+// alone only mutates the in-memory agent and leaves persistence to the caller.
+func (s *AgentGroupService) ReconcileAgent(ctx context.Context, agent *agentmodel.Agent) error {
+	err := s.ApplyMatchingAgentGroupsToAgent(ctx, agent)
+	if err != nil {
+		return fmt.Errorf("apply matching agent groups to agent %s: %w", agent.Metadata.InstanceUID, err)
+	}
+
+	err = s.agentUsecase.SaveAgent(ctx, agent)
+	if err != nil {
+		return fmt.Errorf("save reconciled agent %s: %w", agent.Metadata.InstanceUID, err)
+	}
+
+	return nil
+}
+
 // collectGroupRemoteConfigs resolves every remote config declared on the group into a
 // flat name → file map without mutating any agent. ApplyMatchingAgentGroupsToAgent
 // composes the result across all matching groups so an agent's spec reflects the

--- a/pkg/apiserver/domain/agent/service/agentgroup.go
+++ b/pkg/apiserver/domain/agent/service/agentgroup.go
@@ -137,6 +137,23 @@ func (s *AgentGroupService) GetAgentGroup(
 	return agentGroup, nil
 }
 
+// ReconcileAgentGroup re-applies the named agent group to its matching agents on demand.
+// It loads the (possibly deleted) group and runs the same update the background loop does,
+// so callers can force a refresh without mutating the group or waiting for the next tick.
+func (s *AgentGroupService) ReconcileAgentGroup(ctx context.Context, namespace, name string) error {
+	agentGroup, err := s.persistencePort.GetAgentGroup(ctx, namespace, name, &model.GetOptions{IncludeDeleted: true})
+	if err != nil {
+		return fmt.Errorf("get agent group: %w", err)
+	}
+
+	err = s.updateAgentsByAgentGroup(ctx, agentGroup)
+	if err != nil {
+		return fmt.Errorf("reconcile agent group %s/%s: %w", namespace, name, err)
+	}
+
+	return nil
+}
+
 // SaveAgentGroup saves the agent group.
 func (s *AgentGroupService) SaveAgentGroup(
 	ctx context.Context,

--- a/pkg/apiserver/domain/agent/service/agentgroup_test.go
+++ b/pkg/apiserver/domain/agent/service/agentgroup_test.go
@@ -597,3 +597,35 @@ func TestAgentGroupService_Name(t *testing.T) {
 
 	assert.Equal(t, "AgentGroupService", svc.Name())
 }
+
+func TestAgentGroupService_ReconcileAgent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("persists the agent after applying matching groups", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockPersistence := new(MockAgentGroupPersistencePort)
+		mockAgentUsecase := new(MockAgentUsecaseForGroup)
+		mockRemoteConfigPort := new(MockAgentRemoteConfigPersistencePort)
+		mockCertPersistence := new(MockCertificatePersistencePortForGroup)
+
+		svc := agentservice.NewAgentGroupService(
+			mockPersistence, mockRemoteConfigPort, mockCertPersistence, mockAgentUsecase, slog.Default())
+
+		agent := agentmodel.NewAgent(uuid.New())
+
+		// No groups match, but reconcile must still persist the (re-applied) agent — this is
+		// the regression guard against ReconcileAgent forgetting to save.
+		emptyGroups := &model.ListResponse[*agentmodel.AgentGroup]{Items: nil, Continue: "", RemainingItemCount: 0}
+		mockPersistence.On("ListAgentGroups", ctx, (*model.ListOptions)(nil)).Return(emptyGroups, nil)
+		mockAgentUsecase.On("SaveAgent", ctx, agent).Return(nil)
+
+		err := svc.ReconcileAgent(ctx, agent)
+
+		require.NoError(t, err)
+		mockAgentUsecase.AssertCalled(t, "SaveAgent", ctx, agent)
+		mockPersistence.AssertExpectations(t)
+		mockAgentUsecase.AssertExpectations(t)
+	})
+}

--- a/pkg/apiserver/domain/agent/service/agentremoteconfig.go
+++ b/pkg/apiserver/domain/agent/service/agentremoteconfig.go
@@ -15,12 +15,22 @@ var _ agentport.AgentRemoteConfigUsecase = (*AgentRemoteConfigService)(nil)
 // AgentRemoteConfigService provides operations for managing agent remote configs.
 type AgentRemoteConfigService struct {
 	persistence agentport.AgentRemoteConfigPersistencePort
+
+	// other domain usecases, used to re-run a config's side effects on reconcile.
+	endpointDetectionUsecase agentport.EndpointDetectionUsecase
+	agentGroupUsecase        agentport.AgentGroupUsecase
 }
 
 // NewAgentRemoteConfigService creates a new AgentRemoteConfigService.
-func NewAgentRemoteConfigService(persistence agentport.AgentRemoteConfigPersistencePort) *AgentRemoteConfigService {
+func NewAgentRemoteConfigService(
+	persistence agentport.AgentRemoteConfigPersistencePort,
+	endpointDetectionUsecase agentport.EndpointDetectionUsecase,
+	agentGroupUsecase agentport.AgentGroupUsecase,
+) *AgentRemoteConfigService {
 	return &AgentRemoteConfigService{
-		persistence: persistence,
+		persistence:              persistence,
+		endpointDetectionUsecase: endpointDetectionUsecase,
+		agentGroupUsecase:        agentGroupUsecase,
 	}
 }
 
@@ -89,6 +99,34 @@ func (s *AgentRemoteConfigService) DeleteAgentRemoteConfig(
 	_, err = s.persistence.PutAgentRemoteConfig(ctx, resource)
 	if err != nil {
 		return fmt.Errorf("failed to mark agent remote config as deleted: %w", err)
+	}
+
+	return nil
+}
+
+// ReconcileAgentRemoteConfig implements [agentport.AgentRemoteConfigUsecase]. It loads the
+// named config and re-runs the side effects that normally fire on create/update: telemetry
+// endpoint detection from the config's collector exporters, then re-propagation of the config
+// to every agent group that references it. Both run synchronously so the caller learns of
+// failures (unlike the fire-and-forget triggers on the write path).
+func (s *AgentRemoteConfigService) ReconcileAgentRemoteConfig(
+	ctx context.Context,
+	namespace string,
+	name string,
+) error {
+	remoteConfig, err := s.persistence.GetAgentRemoteConfig(ctx, namespace, name, nil)
+	if err != nil {
+		return fmt.Errorf("get agent remote config %s/%s: %w", namespace, name, err)
+	}
+
+	err = s.endpointDetectionUsecase.ReconcileEndpointsFromRemoteConfig(ctx, remoteConfig)
+	if err != nil {
+		return fmt.Errorf("reconcile endpoints from remote config %s/%s: %w", namespace, name, err)
+	}
+
+	err = s.agentGroupUsecase.PropagateAgentRemoteConfigChange(ctx, namespace, name)
+	if err != nil {
+		return fmt.Errorf("propagate remote config change %s/%s: %w", namespace, name, err)
 	}
 
 	return nil

--- a/pkg/apiserver/domain/agent/service/agentremoteconfig_reconcile_test.go
+++ b/pkg/apiserver/domain/agent/service/agentremoteconfig_reconcile_test.go
@@ -1,0 +1,123 @@
+package agentservice_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
+	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
+	agentservice "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/service"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/port"
+)
+
+// fakeARCPersistence is a minimal AgentRemoteConfigPersistencePort returning one stored config.
+type fakeARCPersistence struct {
+	stored *agentmodel.AgentRemoteConfig
+}
+
+func (f *fakeARCPersistence) GetAgentRemoteConfig(
+	_ context.Context, namespace, name string, _ *model.GetOptions,
+) (*agentmodel.AgentRemoteConfig, error) {
+	if f.stored == nil ||
+		f.stored.Metadata.Namespace != namespace ||
+		f.stored.Metadata.Name != name {
+		return nil, port.ErrResourceNotExist
+	}
+
+	return f.stored, nil
+}
+
+func (f *fakeARCPersistence) PutAgentRemoteConfig(
+	_ context.Context, config *agentmodel.AgentRemoteConfig,
+) (*agentmodel.AgentRemoteConfig, error) {
+	f.stored = config
+
+	return config, nil
+}
+
+func (f *fakeARCPersistence) ListAgentRemoteConfigs(
+	_ context.Context, _ *model.ListOptions,
+) (*model.ListResponse[*agentmodel.AgentRemoteConfig], error) {
+	return &model.ListResponse[*agentmodel.AgentRemoteConfig]{Items: nil, Continue: "", RemainingItemCount: 0}, nil
+}
+
+// spyEndpointDetection records whether endpoint detection ran for a remote config.
+type spyEndpointDetection struct {
+	reconciled *agentmodel.AgentRemoteConfig
+}
+
+func (s *spyEndpointDetection) ReconcileEndpointsFromRemoteConfig(
+	_ context.Context, remoteConfig *agentmodel.AgentRemoteConfig,
+) error {
+	s.reconciled = remoteConfig
+
+	return nil
+}
+
+func (s *spyEndpointDetection) ExtractEndpointsFromAgent(
+	*agentmodel.Agent,
+) ([]*agentmodel.Endpoint, error) {
+	return nil, nil
+}
+
+// spyAgentGroup records the propagation call; the embedded interface covers the rest.
+type spyAgentGroup struct {
+	agentport.AgentGroupUsecase
+
+	propagatedNamespace string
+	propagatedName      string
+}
+
+func (s *spyAgentGroup) PropagateAgentRemoteConfigChange(
+	_ context.Context, namespace, remoteConfigName string,
+) error {
+	s.propagatedNamespace = namespace
+	s.propagatedName = remoteConfigName
+
+	return nil
+}
+
+func TestAgentRemoteConfigService_ReconcileAgentRemoteConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("runs endpoint detection and group propagation for an existing config", func(t *testing.T) {
+		t.Parallel()
+
+		//exhaustruct:ignore
+		stored := &agentmodel.AgentRemoteConfig{
+			Metadata: agentmodel.AgentRemoteConfigMetadata{Namespace: "default", Name: "obs"},
+		}
+		persistence := &fakeARCPersistence{stored: stored}
+		detection := &spyEndpointDetection{}
+		group := &spyAgentGroup{}
+
+		service := agentservice.NewAgentRemoteConfigService(persistence, detection, group)
+
+		err := service.ReconcileAgentRemoteConfig(context.Background(), "default", "obs")
+
+		require.NoError(t, err)
+		assert.Same(t, stored, detection.reconciled, "endpoint detection should run for the loaded config")
+		assert.Equal(t, "default", group.propagatedNamespace)
+		assert.Equal(t, "obs", group.propagatedName)
+	})
+
+	t.Run("returns an error when the config does not exist", func(t *testing.T) {
+		t.Parallel()
+
+		persistence := &fakeARCPersistence{stored: nil}
+		detection := &spyEndpointDetection{}
+		group := &spyAgentGroup{}
+
+		service := agentservice.NewAgentRemoteConfigService(persistence, detection, group)
+
+		err := service.ReconcileAgentRemoteConfig(context.Background(), "default", "missing")
+
+		require.Error(t, err)
+		assert.Nil(t, detection.reconciled, "endpoint detection must not run when the config is missing")
+		assert.Empty(t, group.propagatedName, "propagation must not run when the config is missing")
+	})
+}

--- a/pkg/client/agent.go
+++ b/pkg/client/agent.go
@@ -170,7 +170,10 @@ func (s *AgentService) ReconcileAgent(
 	namespace string,
 	id uuid.UUID,
 ) error {
-	res, err := s.service.Resty.R().
+	// Reconcile runs synchronously on the server (re-applying matching groups and persisting
+	// the agent), which can outlast the shared client's 15s timeout in a large namespace.
+	// Clone the client and clear the timeout; the context deadline is the only limit.
+	res, err := s.service.Resty.Clone().SetTimeout(0).R().
 		SetContext(ctx).
 		SetPathParam("namespace", namespace).
 		SetPathParam("id", id.String()).

--- a/pkg/client/agent.go
+++ b/pkg/client/agent.go
@@ -26,6 +26,8 @@ const (
 	UpdateAgentURL = agentByIDURL
 	// DeleteAgentURL is the path to delete an agent by ID in a namespace.
 	DeleteAgentURL = agentByIDURL
+	// ReconcileAgentURL is the path to reconcile an agent by ID in a namespace.
+	ReconcileAgentURL = agentByIDURL + "/reconcile"
 )
 
 // AgentService provides methods to interact with agents.
@@ -153,6 +155,32 @@ func (s *AgentService) DeleteAgent(
 
 	if res.IsError() {
 		return fmt.Errorf("failed to delete agent: %w", &ResponseError{
+			StatusCode:   res.StatusCode(),
+			ErrorMessage: res.String(),
+		})
+	}
+
+	return nil
+}
+
+// ReconcileAgent re-applies the matching agent groups to an agent so it picks up its
+// assigned remote configs and connection settings on demand.
+func (s *AgentService) ReconcileAgent(
+	ctx context.Context,
+	namespace string,
+	id uuid.UUID,
+) error {
+	res, err := s.service.Resty.R().
+		SetContext(ctx).
+		SetPathParam("namespace", namespace).
+		SetPathParam("id", id.String()).
+		Post(ReconcileAgentURL)
+	if err != nil {
+		return fmt.Errorf("failed to reconcile agent: %w", err)
+	}
+
+	if res.IsError() {
+		return fmt.Errorf("failed to reconcile agent: %w", &ResponseError{
 			StatusCode:   res.StatusCode(),
 			ErrorMessage: res.String(),
 		})

--- a/pkg/client/agentgroup.go
+++ b/pkg/client/agentgroup.go
@@ -22,6 +22,8 @@ const (
 	UpdateAgentGroupURL = "/api/v1/namespaces/{namespace}/agentgroups/{id}"
 	// DeleteAgentGroupURL is the path to delete an agent group.
 	DeleteAgentGroupURL = "/api/v1/namespaces/{namespace}/agentgroups/{id}"
+	// ReconcileAgentGroupURL is the path to reconcile an agent group by name in a namespace.
+	ReconcileAgentGroupURL = "/api/v1/namespaces/{namespace}/agentgroups/{id}/reconcile"
 )
 
 // AgentGroupService provides methods to interact with agent groups.
@@ -238,6 +240,27 @@ func (s *AgentGroupService) DeleteAgentGroup(ctx context.Context, namespace stri
 
 	if res.IsError() {
 		return fmt.Errorf("failed to delete agent group(responseError): %w", &ResponseError{
+			StatusCode:   res.StatusCode(),
+			ErrorMessage: res.String(),
+		})
+	}
+
+	return nil
+}
+
+// ReconcileAgentGroup re-applies the named agent group to its matching agents on demand.
+func (s *AgentGroupService) ReconcileAgentGroup(ctx context.Context, namespace string, name string) error {
+	res, err := s.service.Resty.R().
+		SetContext(ctx).
+		SetPathParam("namespace", namespace).
+		SetPathParam("id", name).
+		Post(ReconcileAgentGroupURL)
+	if err != nil {
+		return fmt.Errorf("failed to reconcile agent group(restyError): %w", err)
+	}
+
+	if res.IsError() {
+		return fmt.Errorf("failed to reconcile agent group(responseError): %w", &ResponseError{
 			StatusCode:   res.StatusCode(),
 			ErrorMessage: res.String(),
 		})

--- a/pkg/client/agentgroup.go
+++ b/pkg/client/agentgroup.go
@@ -250,7 +250,10 @@ func (s *AgentGroupService) DeleteAgentGroup(ctx context.Context, namespace stri
 
 // ReconcileAgentGroup re-applies the named agent group to its matching agents on demand.
 func (s *AgentGroupService) ReconcileAgentGroup(ctx context.Context, namespace string, name string) error {
-	res, err := s.service.Resty.R().
+	// Reconcile runs synchronously on the server (re-applying the group to all its agents),
+	// which can outlast the shared client's 15s timeout in a large namespace. Clone the client
+	// and clear the timeout; the context deadline is the only limit.
+	res, err := s.service.Resty.Clone().SetTimeout(0).R().
 		SetContext(ctx).
 		SetPathParam("namespace", namespace).
 		SetPathParam("id", name).

--- a/pkg/client/agentremoteconfig.go
+++ b/pkg/client/agentremoteconfig.go
@@ -214,7 +214,10 @@ func (s *AgentRemoteConfigService) ReconcileAgentRemoteConfig(
 	namespace string,
 	name string,
 ) error {
-	res, err := s.service.Resty.R().
+	// Reconcile runs synchronously on the server (endpoint detection plus re-propagation to
+	// referencing groups), which can outlast the shared client's 15s timeout in a large
+	// namespace. Clone the client and clear the timeout; the context deadline is the only limit.
+	res, err := s.service.Resty.Clone().SetTimeout(0).R().
 		SetContext(ctx).
 		SetPathParam("namespace", namespace).
 		SetPathParam("id", name).

--- a/pkg/client/agentremoteconfig.go
+++ b/pkg/client/agentremoteconfig.go
@@ -1,4 +1,3 @@
-//nolint:dupl // Similar structure to other resource services is intentional
 package client
 
 import (
@@ -19,6 +18,8 @@ const (
 	UpdateAgentRemoteConfigURL = "/api/v1/namespaces/{namespace}/agentremoteconfigs/{id}"
 	// DeleteAgentRemoteConfigURL is the path to delete an agent remote config.
 	DeleteAgentRemoteConfigURL = "/api/v1/namespaces/{namespace}/agentremoteconfigs/{id}"
+	// ReconcileAgentRemoteConfigURL is the path to reconcile an agent remote config by name.
+	ReconcileAgentRemoteConfigURL = "/api/v1/namespaces/{namespace}/agentremoteconfigs/{id}/reconcile"
 )
 
 // AgentRemoteConfigService provides methods to interact with agent remote configs.
@@ -196,6 +197,37 @@ func (s *AgentRemoteConfigService) DeleteAgentRemoteConfig(
 	if res.IsError() {
 		return fmt.Errorf(
 			"failed to delete agent remote config(responseError): %w",
+			&ResponseError{
+				StatusCode:   res.StatusCode(),
+				ErrorMessage: res.String(),
+			},
+		)
+	}
+
+	return nil
+}
+
+// ReconcileAgentRemoteConfig re-detects telemetry endpoints from the config's collector
+// exporters and re-propagates it to the agent groups that reference it.
+func (s *AgentRemoteConfigService) ReconcileAgentRemoteConfig(
+	ctx context.Context,
+	namespace string,
+	name string,
+) error {
+	res, err := s.service.Resty.R().
+		SetContext(ctx).
+		SetPathParam("namespace", namespace).
+		SetPathParam("id", name).
+		Post(ReconcileAgentRemoteConfigURL)
+	if err != nil {
+		return fmt.Errorf(
+			"failed to reconcile agent remote config(restyError): %w", err,
+		)
+	}
+
+	if res.IsError() {
+		return fmt.Errorf(
+			"failed to reconcile agent remote config(responseError): %w",
 			&ResponseError{
 				StatusCode:   res.StatusCode(),
 				ErrorMessage: res.String(),

--- a/pkg/cmd/opampctl/opampctl.go
+++ b/pkg/cmd/opampctl/opampctl.go
@@ -15,6 +15,7 @@ import (
 	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/create"
 	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/deletecmd"
 	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/get"
+	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/reconcile"
 	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/restart"
 	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/set"
 	"github.com/minuk-dev/opampcommander/pkg/cmd/opampctl/template"
@@ -51,6 +52,7 @@ func NewCommand(options CommandOption) *cobra.Command {
 	cmd.AddCommand(create.NewCommand(create.CommandOptions{GlobalConfig: options.globalConfig}))
 	cmd.AddCommand(template.NewCommand(template.CommandOptions{GlobalConfig: options.globalConfig}))
 	cmd.AddCommand(restart.NewCommand(restart.CommandOptions{GlobalConfig: options.globalConfig}))
+	cmd.AddCommand(reconcile.NewCommand(reconcile.CommandOptions{GlobalConfig: options.globalConfig}))
 	cmd.AddCommand(configCmd.NewCommand(configCmd.CommandOptions{GlobalConfig: options.globalConfig}))
 	cmd.AddCommand(context.NewCommand(context.CommandOptions{GlobalConfig: options.globalConfig}))
 	cmd.AddCommand(whoami.NewCommand(whoami.CommandOptions{GlobalConfig: options.globalConfig}))

--- a/pkg/cmd/opampctl/reconcile/reconcile.go
+++ b/pkg/cmd/opampctl/reconcile/reconcile.go
@@ -1,0 +1,238 @@
+// Package reconcile provides the reconcile command for opampctl. It re-runs, on demand, the
+// side effects that normally fire when a resource is created or updated — useful for repairing
+// drift on resources that predate a feature or whose triggers were missed.
+package reconcile
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+	"github.com/samber/lo"
+	"github.com/spf13/cobra"
+
+	v1 "github.com/minuk-dev/opampcommander/api/v1"
+	"github.com/minuk-dev/opampcommander/pkg/client"
+	"github.com/minuk-dev/opampcommander/pkg/clientutil"
+	"github.com/minuk-dev/opampcommander/pkg/opampctl/config"
+)
+
+// MaxCompletionResults is the maximum number of completion results to return.
+const MaxCompletionResults = 20
+
+// CommandOptions contains the options for the reconcile command.
+type CommandOptions struct {
+	GlobalConfig *config.GlobalConfig
+}
+
+// NewCommand creates a new reconcile command.
+func NewCommand(options CommandOptions) *cobra.Command {
+	//exhaustruct:ignore
+	cmd := &cobra.Command{
+		Use:   "reconcile",
+		Short: "reconcile resources",
+		Long: "Re-run a resource's automatic side effects on demand (the same work performed when it is " +
+			"created/updated or by the background reconcile loop).",
+	}
+
+	cmd.AddCommand(newReconcileRemoteConfigCommand(options))
+	cmd.AddCommand(newReconcileAgentGroupCommand(options))
+	cmd.AddCommand(newReconcileAgentCommand(options))
+
+	return cmd
+}
+
+// newReconcileRemoteConfigCommand reconciles an agent remote config: it re-detects telemetry
+// endpoints from the config's collector exporters and re-propagates it to referencing groups.
+func newReconcileRemoteConfigCommand(options CommandOptions) *cobra.Command {
+	var namespace string
+
+	//exhaustruct:ignore
+	cmd := &cobra.Command{
+		Use:     "remoteconfig <name>",
+		Aliases: []string{"agentremoteconfig"},
+		Short:   "reconcile an agent remote config",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cli, err := clientutil.NewClient(options.GlobalConfig)
+			if err != nil {
+				return fmt.Errorf("failed to create API client: %w", err)
+			}
+
+			name := args[0]
+
+			err = cli.AgentRemoteConfigService.ReconcileAgentRemoteConfig(context.Background(), namespace, name)
+			if err != nil {
+				return fmt.Errorf("failed to reconcile agent remote config: %w", err)
+			}
+
+			cmd.Printf("AgentRemoteConfig %s/%s reconciled successfully\n", namespace, name)
+
+			return nil
+		},
+		ValidArgsFunction: remoteConfigNameCompletion(options, &namespace),
+	}
+
+	cmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "Namespace of the agent remote config")
+
+	return cmd
+}
+
+// newReconcileAgentGroupCommand reconciles an agent group: it re-applies the group's remote
+// configs and connection settings to its matching agents.
+func newReconcileAgentGroupCommand(options CommandOptions) *cobra.Command {
+	var namespace string
+
+	//exhaustruct:ignore
+	cmd := &cobra.Command{
+		Use:   "agentgroup <name>",
+		Short: "reconcile an agent group",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cli, err := clientutil.NewClient(options.GlobalConfig)
+			if err != nil {
+				return fmt.Errorf("failed to create API client: %w", err)
+			}
+
+			name := args[0]
+
+			err = cli.AgentGroupService.ReconcileAgentGroup(context.Background(), namespace, name)
+			if err != nil {
+				return fmt.Errorf("failed to reconcile agent group: %w", err)
+			}
+
+			cmd.Printf("AgentGroup %s/%s reconciled successfully\n", namespace, name)
+
+			return nil
+		},
+		ValidArgsFunction: agentGroupNameCompletion(options, &namespace),
+	}
+
+	cmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "Namespace of the agent group")
+
+	return cmd
+}
+
+// newReconcileAgentCommand reconciles an agent: it re-applies the agent groups that match the
+// agent so it picks up its assigned remote configs and connection settings.
+func newReconcileAgentCommand(options CommandOptions) *cobra.Command {
+	var namespace string
+
+	//exhaustruct:ignore
+	cmd := &cobra.Command{
+		Use:   "agent <id>",
+		Short: "reconcile an agent",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			cli, err := clientutil.NewClient(options.GlobalConfig)
+			if err != nil {
+				return fmt.Errorf("failed to create API client: %w", err)
+			}
+
+			agentUUID, err := uuid.Parse(args[0])
+			if err != nil {
+				return fmt.Errorf("invalid agent ID format: %w", err)
+			}
+
+			err = cli.AgentService.ReconcileAgent(context.Background(), namespace, agentUUID)
+			if err != nil {
+				return fmt.Errorf("failed to reconcile agent: %w", err)
+			}
+
+			cmd.Printf("Agent %s/%s reconciled successfully\n", namespace, agentUUID)
+
+			return nil
+		},
+		ValidArgsFunction: agentIDCompletion(options, &namespace),
+	}
+
+	cmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "Namespace of the agent")
+
+	return cmd
+}
+
+func remoteConfigNameCompletion(
+	options CommandOptions,
+	namespace *string,
+) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		cli, err := clientutil.NewClient(options.GlobalConfig)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		items, err := clientutil.ListAgentRemoteConfigFully(cmd.Context(), cli, *namespace)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		names := lo.Map(items, func(item v1.AgentRemoteConfig, _ int) string {
+			return item.Metadata.Name
+		})
+
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+func agentGroupNameCompletion(
+	options CommandOptions,
+	namespace *string,
+) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		cli, err := clientutil.NewClient(options.GlobalConfig)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		items, err := clientutil.ListAgentGroupFully(cmd.Context(), cli, *namespace)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		names := lo.Map(items, func(item v1.AgentGroup, _ int) string {
+			return item.Metadata.Name
+		})
+
+		return names, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+func agentIDCompletion(
+	options CommandOptions,
+	namespace *string,
+) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) != 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+
+		cli, err := clientutil.NewClient(options.GlobalConfig)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		resp, err := cli.AgentService.SearchAgents(
+			cmd.Context(),
+			*namespace,
+			toComplete,
+			client.WithLimit(MaxCompletionResults),
+		)
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveError
+		}
+
+		instanceUIDs := lo.Map(resp.Items, func(agent v1.Agent, _ int) string {
+			return agent.Metadata.InstanceUID.String()
+		})
+
+		return instanceUIDs, cobra.ShellCompDirectiveNoFileComp
+	}
+}

--- a/test/integration/restart_test.go
+++ b/test/integration/restart_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/agent"
 	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
 	modelagent "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model/agent"
+	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/port"
 )
@@ -39,6 +40,7 @@ func TestRestartAgentIntegration(t *testing.T) {
 			agentUsecase,
 			agentNotificationUsecase,
 			mockEndpointDetectionUsecase{},
+			stubAgentGroupUsecase{},
 			slog.Default(),
 		)
 
@@ -97,6 +99,7 @@ func TestRestartAgentIntegration(t *testing.T) {
 			agentUsecase,
 			agentNotificationUsecase,
 			mockEndpointDetectionUsecase{},
+			stubAgentGroupUsecase{},
 			slog.Default(),
 		)
 
@@ -212,3 +215,7 @@ func (mockEndpointDetectionUsecase) ExtractEndpointsFromAgent(
 ) ([]*agentmodel.Endpoint, error) {
 	return nil, nil
 }
+
+// stubAgentGroupUsecase is a no-op; these restart tests do not exercise agent-group
+// reconciliation. The embedded interface satisfies the contract.
+type stubAgentGroupUsecase struct{ agentport.AgentGroupUsecase }


### PR DESCRIPTION
## Why

Debugging endpoint detection on `opampcommander-alpha` revealed that **endpoint detection itself works**, but the *persisted* side effects only fire when an `AgentRemoteConfig` is created/updated:

- `ReconcileEndpointsFromRemoteConfig` (endpoint detection) and `PropagateAgentRemoteConfigChange` (group propagation) run only on create/update (`agentremoteconfig.go`).
- Unlike agent groups (which have a background reconcile loop as a safety net), there's no periodic/backfill path for these.

Result: a remote config created **before** the feature shipped (e.g. `prometheus-scrape`, which has a real `prometheusremotewrite` exporter) never reconciles, so `opampctl get endpoint` stays empty even though agents are exporting to that backend.

## What

Add an `opampctl reconcile` command that re-runs a resource's automatic side effects **on demand**:

```
opampctl reconcile remoteconfig <name> [-n ns]   # re-detect endpoints + re-propagate to groups
opampctl reconcile agentgroup   <name> [-n ns]   # re-apply the group to its matching agents
opampctl reconcile agent        <id>   [-n ns]   # re-apply matching groups to the agent
```

The reconcile orchestration lives in the **domain use cases** (which may call each other):

- `AgentRemoteConfigUsecase.ReconcileAgentRemoteConfig` — `AgentRemoteConfigService` gains `EndpointDetectionUsecase` + `AgentGroupUsecase` deps and runs endpoint detection then group propagation **synchronously** (surfacing errors, unlike the fire-and-forget triggers on the write path).
- `AgentGroupUsecase.ReconcileAgentGroup` — reuses the existing `updateAgentsByAgentGroup`.
- Agent reconcile reuses the existing `ApplyMatchingAgentGroupsToAgent`.

No dependency cycles: `AgentGroupService`/`EndpointDetectionService` do not depend back on `AgentRemoteConfigUsecase`.

These flow through the application layer, new `POST .../reconcile` HTTP endpoints, the client library, and three opampctl subcommands.

## Verification

- `make generate` (swagger + mocks), `go build ./...`, `make lint` (0 issues), `make unittest` (pass)
- Added a domain unit test for `ReconcileAgentRemoteConfig`
- `opampctl reconcile --help` shows the three subcommands

> Note: alpha runs an older server build without these endpoints. After this is deployed, `opampctl reconcile remoteconfig prometheus-scrape -n default` should create the missing persisted endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)