### PR TITLE
feat(reconcile): generalize reconcile into a domain Reconciler registry

### DIFF
--- a/pkg/apiserver/adapter/primary/http/v1/agent/controller.go
+++ b/pkg/apiserver/adapter/primary/http/v1/agent/controller.go
@@ -82,12 +82,6 @@ func (c *Controller) RoutesInfo() gin.RoutesInfo {
 			Handler:     "http.v1.agent.Delete",
 			HandlerFunc: c.Delete,
 		},
-		{
-			Method:      http.MethodPost,
-			Path:        "/api/v1/namespaces/:namespace/agents/:id/reconcile",
-			Handler:     "http.v1.agent.Reconcile",
-			HandlerFunc: c.Reconcile,
-		},
 	}
 }
 
@@ -317,45 +311,6 @@ func (c *Controller) ListEndpoints(ctx *gin.Context) {
 	}
 
 	ctx.JSON(http.StatusOK, endpoints)
-}
-
-// Reconcile re-applies the agent groups that match the agent on demand, so it picks up its
-// assigned remote configs and connection settings without waiting for a group update.
-//
-// @Summary  Reconcile Agent
-// @Tags agent
-// @Description Re-apply the matching agent groups' remote configs and connection settings to the agent.
-// @Produce  json
-// @Param  namespace path string true "Namespace"
-// @Param  id path string true "Instance UID of the agent"
-// @Success  204 "No Content"
-// @Failure  400 {object} ErrorModel
-// @Failure  404 {object} ErrorModel
-// @Failure  500 {object} ErrorModel
-// @Router  /api/v1/namespaces/{namespace}/agents/{id}/reconcile [post].
-func (c *Controller) Reconcile(ctx *gin.Context) {
-	namespace, err := ginutil.ParseString(ctx, "namespace", true)
-	if err != nil {
-		ginutil.HandleValidationError(ctx, "namespace", ctx.Param("namespace"), err, true)
-
-		return
-	}
-
-	instanceUID, err := ginutil.ParseUUID(ctx, "id")
-	if err != nil {
-		ginutil.HandleValidationError(ctx, "id", ctx.Param("id"), err, true)
-
-		return
-	}
-
-	err = c.agentUsecase.ReconcileAgent(ctx.Request.Context(), namespace, instanceUID)
-	if err != nil {
-		c.handleAgentError(ctx, err, "An error occurred while reconciling the agent.")
-
-		return
-	}
-
-	ctx.Status(http.StatusNoContent)
 }
 
 // Update updates an agent's metadata & spec.

--- a/pkg/apiserver/adapter/primary/http/v1/agent/usecasemock/mocks.go
+++ b/pkg/apiserver/adapter/primary/http/v1/agent/usecasemock/mocks.go
@@ -325,69 +325,6 @@ func (_c *MockManageUsecase_ListAgents_Call) RunAndReturn(run func(ctx context.C
 	return _c
 }
 
-// ReconcileAgent provides a mock function for the type MockManageUsecase
-func (_mock *MockManageUsecase) ReconcileAgent(ctx context.Context, namespace string, instanceUID uuid.UUID) error {
-	ret := _mock.Called(ctx, namespace, instanceUID)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ReconcileAgent")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, uuid.UUID) error); ok {
-		r0 = returnFunc(ctx, namespace, instanceUID)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockManageUsecase_ReconcileAgent_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReconcileAgent'
-type MockManageUsecase_ReconcileAgent_Call struct {
-	*mock.Call
-}
-
-// ReconcileAgent is a helper method to define mock.On call
-//   - ctx context.Context
-//   - namespace string
-//   - instanceUID uuid.UUID
-func (_e *MockManageUsecase_Expecter) ReconcileAgent(ctx interface{}, namespace interface{}, instanceUID interface{}) *MockManageUsecase_ReconcileAgent_Call {
-	return &MockManageUsecase_ReconcileAgent_Call{Call: _e.mock.On("ReconcileAgent", ctx, namespace, instanceUID)}
-}
-
-func (_c *MockManageUsecase_ReconcileAgent_Call) Run(run func(ctx context.Context, namespace string, instanceUID uuid.UUID)) *MockManageUsecase_ReconcileAgent_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 uuid.UUID
-		if args[2] != nil {
-			arg2 = args[2].(uuid.UUID)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-		)
-	})
-	return _c
-}
-
-func (_c *MockManageUsecase_ReconcileAgent_Call) Return(err error) *MockManageUsecase_ReconcileAgent_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockManageUsecase_ReconcileAgent_Call) RunAndReturn(run func(ctx context.Context, namespace string, instanceUID uuid.UUID) error) *MockManageUsecase_ReconcileAgent_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // SearchAgents provides a mock function for the type MockManageUsecase
 func (_mock *MockManageUsecase) SearchAgents(ctx context.Context, namespace string, query string, options *port.ListOptions) (*v1.ListResponse[v1.Agent], error) {
 	ret := _mock.Called(ctx, namespace, query, options)

--- a/pkg/apiserver/adapter/primary/http/v1/agentgroup/controller.go
+++ b/pkg/apiserver/adapter/primary/http/v1/agentgroup/controller.go
@@ -77,12 +77,6 @@ func (c *Controller) RoutesInfo() gin.RoutesInfo {
 			Handler:     "http.v1.agentgroup.Delete",
 			HandlerFunc: c.Delete,
 		},
-		{
-			Method:      http.MethodPost,
-			Path:        "/api/v1/namespaces/:namespace/agentgroups/:name/reconcile",
-			Handler:     "http.v1.agentgroup.Reconcile",
-			HandlerFunc: c.Reconcile,
-		},
 	}
 }
 
@@ -410,43 +404,6 @@ func (c *Controller) Delete(ctx *gin.Context) {
 	if err != nil {
 		c.logger.Error("failed to delete agent group", "error", err.Error())
 		ginutil.HandleDomainError(ctx, err, "An error occurred while deleting the agent group.")
-
-		return
-	}
-
-	ctx.Status(http.StatusNoContent)
-}
-
-// Reconcile re-applies the agent group to its matching agents on demand.
-//
-// @Summary Reconcile Agent Group
-// @Tags agentgroup
-// @Description Re-apply the agent group's remote configs and connection settings to its matching agents.
-// @Param namespace path string true "Namespace"
-// @Param name path string true "Agent Group Name"
-// @Success 204 "No Content"
-// @Failure 404 {object} map[string]any
-// @Failure 500 {object} map[string]any
-// @Router /api/v1/namespaces/{namespace}/agentgroups/{name}/reconcile [post].
-func (c *Controller) Reconcile(ctx *gin.Context) {
-	namespace, err := ginutil.ParseString(ctx, "namespace", true)
-	if err != nil {
-		ginutil.HandleValidationError(ctx, "namespace", ctx.Param("namespace"), err, true)
-
-		return
-	}
-
-	name, err := ginutil.ParseString(ctx, "name", true)
-	if err != nil {
-		ginutil.HandleValidationError(ctx, "name", ctx.Param("name"), err, true)
-
-		return
-	}
-
-	err = c.agentGroupUsecase.ReconcileAgentGroup(ctx.Request.Context(), namespace, name)
-	if err != nil {
-		c.logger.Error("failed to reconcile agent group", "error", err.Error())
-		ginutil.HandleDomainError(ctx, err, "An error occurred while reconciling the agent group.")
 
 		return
 	}

--- a/pkg/apiserver/adapter/primary/http/v1/agentgroup/usecasemock/mocks.go
+++ b/pkg/apiserver/adapter/primary/http/v1/agentgroup/usecasemock/mocks.go
@@ -473,69 +473,6 @@ func (_c *MockUsecase_ListAgentsByAgentGroup_Call) RunAndReturn(run func(ctx con
 	return _c
 }
 
-// ReconcileAgentGroup provides a mock function for the type MockUsecase
-func (_mock *MockUsecase) ReconcileAgentGroup(ctx context.Context, namespace string, name string) error {
-	ret := _mock.Called(ctx, namespace, name)
-
-	if len(ret) == 0 {
-		panic("no return value specified for ReconcileAgentGroup")
-	}
-
-	var r0 error
-	if returnFunc, ok := ret.Get(0).(func(context.Context, string, string) error); ok {
-		r0 = returnFunc(ctx, namespace, name)
-	} else {
-		r0 = ret.Error(0)
-	}
-	return r0
-}
-
-// MockUsecase_ReconcileAgentGroup_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ReconcileAgentGroup'
-type MockUsecase_ReconcileAgentGroup_Call struct {
-	*mock.Call
-}
-
-// ReconcileAgentGroup is a helper method to define mock.On call
-//   - ctx context.Context
-//   - namespace string
-//   - name string
-func (_e *MockUsecase_Expecter) ReconcileAgentGroup(ctx interface{}, namespace interface{}, name interface{}) *MockUsecase_ReconcileAgentGroup_Call {
-	return &MockUsecase_ReconcileAgentGroup_Call{Call: _e.mock.On("ReconcileAgentGroup", ctx, namespace, name)}
-}
-
-func (_c *MockUsecase_ReconcileAgentGroup_Call) Run(run func(ctx context.Context, namespace string, name string)) *MockUsecase_ReconcileAgentGroup_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		var arg0 context.Context
-		if args[0] != nil {
-			arg0 = args[0].(context.Context)
-		}
-		var arg1 string
-		if args[1] != nil {
-			arg1 = args[1].(string)
-		}
-		var arg2 string
-		if args[2] != nil {
-			arg2 = args[2].(string)
-		}
-		run(
-			arg0,
-			arg1,
-			arg2,
-		)
-	})
-	return _c
-}
-
-func (_c *MockUsecase_ReconcileAgentGroup_Call) Return(err error) *MockUsecase_ReconcileAgentGroup_Call {
-	_c.Call.Return(err)
-	return _c
-}
-
-func (_c *MockUsecase_ReconcileAgentGroup_Call) RunAndReturn(run func(ctx context.Context, namespace string, name string) error) *MockUsecase_ReconcileAgentGroup_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // UpdateAgentGroup provides a mock function for the type MockUsecase
 func (_mock *MockUsecase) UpdateAgentGroup(ctx context.Context, namespace string, name string, agentGroup *v1.AgentGroup) (*v1.AgentGroup, error) {
 	ret := _mock.Called(ctx, namespace, name, agentGroup)

--- a/pkg/apiserver/adapter/primary/http/v1/agentremoteconfig/controller.go
+++ b/pkg/apiserver/adapter/primary/http/v1/agentremoteconfig/controller.go
@@ -65,12 +65,6 @@ func (c *Controller) RoutesInfo() gin.RoutesInfo {
 			Handler:     "http.v1.agentremoteconfig.Delete",
 			HandlerFunc: c.Delete,
 		},
-		{
-			Method:      http.MethodPost,
-			Path:        "/api/v1/namespaces/:namespace/agentremoteconfigs/:name/reconcile",
-			Handler:     "http.v1.agentremoteconfig.Reconcile",
-			HandlerFunc: c.Reconcile,
-		},
 	}
 }
 
@@ -292,58 +286,6 @@ func (c *Controller) Delete(ctx *gin.Context) {
 		ginutil.HandleDomainError(
 			ctx, err,
 			"An error occurred while deleting the agent remote config.",
-		)
-
-		return
-	}
-
-	ctx.Status(http.StatusNoContent)
-}
-
-// Reconcile re-runs the side effects of an agent remote config on demand: telemetry endpoint
-// detection from its collector exporters and re-propagation to the agent groups that reference
-// it. Use it to repair drift for configs that predate those triggers.
-//
-// @Summary  Reconcile Agent Remote Config
-// @Description Re-detect endpoints from the config's exporters and re-propagate it to referencing agent groups.
-// @Tags  agentremoteconfig
-// @Produce  json
-// @Param  namespace path string true "Namespace"
-// @Param  name path string true "Agent Remote Config Name"
-// @Success  204 "No Content"
-// @Failure  404 {object} map[string]any
-// @Failure  500 {object} map[string]any
-// @Router  /api/v1/namespaces/{namespace}/agentremoteconfigs/{name}/reconcile [post].
-func (c *Controller) Reconcile(ctx *gin.Context) {
-	namespace, err := ginutil.ParseString(ctx, "namespace", true)
-	if err != nil {
-		ginutil.HandleValidationError(
-			ctx, "namespace", ctx.Param("namespace"), err, true,
-		)
-
-		return
-	}
-
-	name, err := ginutil.ParseString(ctx, "name", true)
-	if err != nil {
-		ginutil.HandleValidationError(
-			ctx, "name", ctx.Param("name"), err, true,
-		)
-
-		return
-	}
-
-	err = c.agentRemoteConfigUsecase.ReconcileAgentRemoteConfig(
-		ctx.Request.Context(), namespace, name,
-	)
-	if err != nil {
-		c.logger.Error(
-			"failed to reconcile agent remote config",
-			"name", name, "error", err.Error(),
-		)
-		ginutil.HandleDomainError(
-			ctx, err,
-			"An error occurred while reconciling the agent remote config.",
 		)
 
 		return

--- a/pkg/apiserver/adapter/primary/http/v1/reconcile/controller.go
+++ b/pkg/apiserver/adapter/primary/http/v1/reconcile/controller.go
@@ -1,0 +1,113 @@
+// Package reconcile contains the controller for the generic reconcile endpoint, which
+// re-enforces a domain object's invariants on demand by dispatching to a registered
+// reconciler for the requested kind.
+package reconcile
+
+import (
+	"log/slog"
+	"net/http"
+
+	"github.com/gin-gonic/gin"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/ginutil"
+)
+
+// Controller exposes the generic reconcile endpoint.
+type Controller struct {
+	logger *slog.Logger
+
+	reconcileUsecase port.ReconcileManageUsecase
+}
+
+// NewController creates a new reconcile Controller.
+func NewController(
+	usecase port.ReconcileManageUsecase,
+	logger *slog.Logger,
+) *Controller {
+	return &Controller{
+		logger:           logger,
+		reconcileUsecase: usecase,
+	}
+}
+
+// RoutesInfo returns the routes for the reconcile controller.
+func (c *Controller) RoutesInfo() gin.RoutesInfo {
+	return gin.RoutesInfo{
+		{
+			Method:      http.MethodPost,
+			Path:        "/api/v1/namespaces/:namespace/reconcile/:kind/:name",
+			Handler:     "http.v1.reconcile.Reconcile",
+			HandlerFunc: c.Reconcile,
+		},
+		{
+			Method:      http.MethodGet,
+			Path:        "/api/v1/reconcile/kinds",
+			Handler:     "http.v1.reconcile.ListKinds",
+			HandlerFunc: c.ListKinds,
+		},
+	}
+}
+
+// Reconcile re-enforces the named resource's domain invariants by dispatching to the
+// reconciler registered for the kind.
+//
+// @Summary  Reconcile a resource
+// @Tags  reconcile
+// @Description Re-run the side effects that normally fire on create/update for the resource.
+// @Produce  json
+// @Param  namespace path string true "Namespace"
+// @Param  kind path string true "Resource kind (e.g. agentremoteconfig, agentgroup, agent)"
+// @Param  name path string true "Resource name, or instance UID for kind=agent"
+// @Success  204 "No Content"
+// @Failure  400 {object} map[string]any
+// @Failure  404 {object} map[string]any
+// @Failure  500 {object} map[string]any
+// @Router  /api/v1/namespaces/{namespace}/reconcile/{kind}/{name} [post].
+func (c *Controller) Reconcile(ctx *gin.Context) {
+	namespace, err := ginutil.ParseString(ctx, "namespace", true)
+	if err != nil {
+		ginutil.HandleValidationError(ctx, "namespace", ctx.Param("namespace"), err, true)
+
+		return
+	}
+
+	kind, err := ginutil.ParseString(ctx, "kind", true)
+	if err != nil {
+		ginutil.HandleValidationError(ctx, "kind", ctx.Param("kind"), err, true)
+
+		return
+	}
+
+	name, err := ginutil.ParseString(ctx, "name", true)
+	if err != nil {
+		ginutil.HandleValidationError(ctx, "name", ctx.Param("name"), err, true)
+
+		return
+	}
+
+	err = c.reconcileUsecase.Reconcile(ctx.Request.Context(), kind, namespace, name)
+	if err != nil {
+		// HandleDomainError maps the application errors: an unknown kind / bad UID surfaces as
+		// port.ErrInvalidArgument (400), a missing resource as port.ErrResourceNotExist (404).
+		c.logger.Error("failed to reconcile resource",
+			"kind", kind, "name", name, "error", err.Error())
+		ginutil.HandleDomainError(ctx, err, "An error occurred while reconciling the resource.")
+
+		return
+	}
+
+	ctx.Status(http.StatusNoContent)
+}
+
+// ListKinds returns the reconcilable kinds.
+//
+// @Summary  List reconcilable kinds
+// @Tags  reconcile
+// @Description List the resource kinds that support reconcile.
+// @Produce  json
+// @Success  200 {array} string
+// @Router  /api/v1/reconcile/kinds [get].
+func (c *Controller) ListKinds(ctx *gin.Context) {
+	ctx.JSON(http.StatusOK, c.reconcileUsecase.ReconcileKinds(ctx.Request.Context()))
+}

--- a/pkg/apiserver/application/port/in.go
+++ b/pkg/apiserver/application/port/in.go
@@ -89,10 +89,6 @@ type AgentManageUsecase interface {
 	// to, extracted from its reported effective configuration (not persisted).
 	ListAgentEndpoints(ctx context.Context, namespace string,
 		instanceUID uuid.UUID) (*v1.ListResponse[v1.Endpoint], error)
-	// ReconcileAgent re-applies the agent groups that match the agent on demand, so it
-	// picks up its assigned remote configs and connection settings without waiting for a
-	// group update or the background reconcile loop.
-	ReconcileAgent(ctx context.Context, namespace string, instanceUID uuid.UUID) error
 }
 
 // AgentGroupManageUsecase is a use case that handles agent group management operations.
@@ -117,9 +113,6 @@ type AgentGroupManageUsecase interface {
 	UpdateAgentGroup(ctx context.Context, namespace string, name string,
 		agentGroup *v1.AgentGroup) (*v1.AgentGroup, error)
 	DeleteAgentGroup(ctx context.Context, namespace string, name string) error
-	// ReconcileAgentGroup re-applies the named agent group to its matching agents on demand,
-	// the same work the background reconcile loop performs.
-	ReconcileAgentGroup(ctx context.Context, namespace string, name string) error
 }
 
 // HostManageUsecase is a use case that handles host management operations.
@@ -160,9 +153,19 @@ type AgentRemoteConfigManageUsecase interface {
 	UpdateAgentRemoteConfig(ctx context.Context, namespace string, name string,
 		agentRemoteConfig *v1.AgentRemoteConfig) (*v1.AgentRemoteConfig, error)
 	DeleteAgentRemoteConfig(ctx context.Context, namespace string, name string) error
-	// ReconcileAgentRemoteConfig re-detects telemetry endpoints from the config's collector
-	// exporters and re-propagates the config to the agent groups that reference it.
-	ReconcileAgentRemoteConfig(ctx context.Context, namespace string, name string) error
+}
+
+// ReconcileManageUsecase re-enforces a domain object's invariants on demand. It dispatches a
+// (kind, namespace, name) request to the reconciler registered for that kind, re-running the
+// side effects that normally fire when the resource is created or updated. New reconcilable
+// kinds become available here without changing this interface.
+type ReconcileManageUsecase interface {
+	// Reconcile re-enforces the named resource's invariants. For namespace-scoped kinds name
+	// is the resource name; for the "agent" kind it is the instance UID. An unknown kind or a
+	// missing resource surfaces as an error mapped to 4xx by the transport.
+	Reconcile(ctx context.Context, kind string, namespace string, name string) error
+	// ReconcileKinds returns the reconcilable kinds, for discovery and CLI completion.
+	ReconcileKinds(ctx context.Context) []string
 }
 
 // EndpointManageUsecase is a use case that handles endpoint management operations.

--- a/pkg/apiserver/application/service/agent/agent.go
+++ b/pkg/apiserver/application/service/agent/agent.go
@@ -35,7 +35,6 @@ type Service struct {
 	agentUsecase             agentport.AgentUsecase
 	agentNotificationUsecase agentport.AgentNotificationUsecase
 	endpointDetectionUsecase agentport.EndpointDetectionUsecase
-	agentGroupUsecase        agentport.AgentGroupUsecase
 
 	// mapper
 	mapper *helper.Mapper
@@ -47,7 +46,6 @@ func New(
 	agentUsecase agentport.AgentUsecase,
 	agentNotificationUsecase agentport.AgentNotificationUsecase,
 	endpointDetectionUsecase agentport.EndpointDetectionUsecase,
-	agentGroupUsecase agentport.AgentGroupUsecase,
 	logger *slog.Logger,
 ) *Service {
 	realClock := clock.RealClock{}
@@ -56,7 +54,6 @@ func New(
 		agentUsecase:             agentUsecase,
 		agentNotificationUsecase: agentNotificationUsecase,
 		endpointDetectionUsecase: endpointDetectionUsecase,
-		agentGroupUsecase:        agentGroupUsecase,
 
 		mapper: helper.NewMapper(realClock, agentmodel.DefaultConnectionStaleness),
 		logger: logger,
@@ -89,27 +86,6 @@ func (s *Service) ListAgentEndpoints(
 			return *s.mapper.MapEndpointToAPI(item)
 		}),
 	}, nil
-}
-
-// ReconcileAgent implements port.AgentManageUsecase. It loads the agent (enforcing the
-// namespace) and re-applies every agent group whose selector matches it, so the agent picks
-// up its assigned remote configs and connection settings on demand.
-func (s *Service) ReconcileAgent(
-	ctx context.Context,
-	namespace string,
-	instanceUID uuid.UUID,
-) error {
-	agent, err := s.getAgentInNamespace(ctx, namespace, instanceUID)
-	if err != nil {
-		return err
-	}
-
-	err = s.agentGroupUsecase.ReconcileAgent(ctx, agent)
-	if err != nil {
-		return fmt.Errorf("reconcile agent: %w", err)
-	}
-
-	return nil
 }
 
 // GetAgent implements port.AgentManageUsecase.

--- a/pkg/apiserver/application/service/agent/agent_test.go
+++ b/pkg/apiserver/application/service/agent/agent_test.go
@@ -14,7 +14,6 @@ import (
 	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/agent"
 	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
-	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
 )
 
@@ -137,11 +136,6 @@ func (stubEndpointDetectionUsecase) ExtractEndpointsFromAgent(
 	return nil, nil
 }
 
-// stubAgentGroupUsecase is a no-op agentport.AgentGroupUsecase for the agent-service tests,
-// which do not exercise agent-group reconciliation. The embedded interface satisfies the
-// contract; any unexpected call would panic, surfacing untested coverage.
-type stubAgentGroupUsecase struct{ agentport.AgentGroupUsecase }
-
 func TestService_SearchAgents(t *testing.T) {
 	t.Parallel()
 
@@ -152,10 +146,7 @@ func TestService_SearchAgents(t *testing.T) {
 		ctx := t.Context()
 		mockAgentUsecase := new(MockAgentUsecase)
 		mockNotificationUsecase := new(MockAgentNotificationUsecase)
-		service := agent.New(
-			mockAgentUsecase, mockNotificationUsecase,
-			stubEndpointDetectionUsecase{}, stubAgentGroupUsecase{}, slog.Default(),
-		)
+		service := agent.New(mockAgentUsecase, mockNotificationUsecase, stubEndpointDetectionUsecase{}, slog.Default())
 
 		instanceUID := uuid.New()
 		domainAgents := []*agentmodel.Agent{
@@ -187,10 +178,7 @@ func TestService_SearchAgents(t *testing.T) {
 		ctx := t.Context()
 		mockAgentUsecase := new(MockAgentUsecase)
 		mockNotificationUsecase := new(MockAgentNotificationUsecase)
-		service := agent.New(
-			mockAgentUsecase, mockNotificationUsecase,
-			stubEndpointDetectionUsecase{}, stubAgentGroupUsecase{}, slog.Default(),
-		)
+		service := agent.New(mockAgentUsecase, mockNotificationUsecase, stubEndpointDetectionUsecase{}, slog.Default())
 
 		mockAgentUsecase.On("SearchAgents", ctx, "default", "test", mock.Anything).Return(nil, errMockError)
 
@@ -211,10 +199,7 @@ func TestService_SearchAgents(t *testing.T) {
 		ctx := t.Context()
 		mockAgentUsecase := new(MockAgentUsecase)
 		mockNotificationUsecase := new(MockAgentNotificationUsecase)
-		service := agent.New(
-			mockAgentUsecase, mockNotificationUsecase,
-			stubEndpointDetectionUsecase{}, stubAgentGroupUsecase{}, slog.Default(),
-		)
+		service := agent.New(mockAgentUsecase, mockNotificationUsecase, stubEndpointDetectionUsecase{}, slog.Default())
 
 		domainAgents := []*agentmodel.Agent{
 			agentmodel.NewAgent(uuid.New()),
@@ -256,10 +241,7 @@ func TestService_DeleteAgent(t *testing.T) {
 		ctx := t.Context()
 		mockAgentUsecase := new(MockAgentUsecase)
 		mockNotificationUsecase := new(MockAgentNotificationUsecase)
-		service := agent.New(
-			mockAgentUsecase, mockNotificationUsecase,
-			stubEndpointDetectionUsecase{}, stubAgentGroupUsecase{}, slog.Default(),
-		)
+		service := agent.New(mockAgentUsecase, mockNotificationUsecase, stubEndpointDetectionUsecase{}, slog.Default())
 
 		instanceUID := uuid.New()
 		domainAgent := agentmodel.NewAgent(instanceUID) // Status.Connected defaults to false
@@ -283,10 +265,7 @@ func TestService_DeleteAgent(t *testing.T) {
 		ctx := t.Context()
 		mockAgentUsecase := new(MockAgentUsecase)
 		mockNotificationUsecase := new(MockAgentNotificationUsecase)
-		service := agent.New(
-			mockAgentUsecase, mockNotificationUsecase,
-			stubEndpointDetectionUsecase{}, stubAgentGroupUsecase{}, slog.Default(),
-		)
+		service := agent.New(mockAgentUsecase, mockNotificationUsecase, stubEndpointDetectionUsecase{}, slog.Default())
 
 		instanceUID := uuid.New()
 		domainAgent := agentmodel.NewAgent(instanceUID) // namespace "default"
@@ -309,10 +288,7 @@ func TestService_DeleteAgent(t *testing.T) {
 		ctx := t.Context()
 		mockAgentUsecase := new(MockAgentUsecase)
 		mockNotificationUsecase := new(MockAgentNotificationUsecase)
-		service := agent.New(
-			mockAgentUsecase, mockNotificationUsecase,
-			stubEndpointDetectionUsecase{}, stubAgentGroupUsecase{}, slog.Default(),
-		)
+		service := agent.New(mockAgentUsecase, mockNotificationUsecase, stubEndpointDetectionUsecase{}, slog.Default())
 
 		instanceUID := uuid.New()
 		domainAgent := agentmodel.NewAgent(instanceUID) // namespace defaults to "default"
@@ -335,10 +311,7 @@ func TestService_DeleteAgent(t *testing.T) {
 		ctx := t.Context()
 		mockAgentUsecase := new(MockAgentUsecase)
 		mockNotificationUsecase := new(MockAgentNotificationUsecase)
-		service := agent.New(
-			mockAgentUsecase, mockNotificationUsecase,
-			stubEndpointDetectionUsecase{}, stubAgentGroupUsecase{}, slog.Default(),
-		)
+		service := agent.New(mockAgentUsecase, mockNotificationUsecase, stubEndpointDetectionUsecase{}, slog.Default())
 
 		instanceUID := uuid.New()
 		domainAgent := agentmodel.NewAgent(instanceUID)

--- a/pkg/apiserver/application/service/agentgroup/agentgroup_manage_service.go
+++ b/pkg/apiserver/application/service/agentgroup/agentgroup_manage_service.go
@@ -280,14 +280,3 @@ func (s *ManageService) DeleteAgentGroup(
 
 	return nil
 }
-
-// ReconcileAgentGroup implements [port.AgentGroupManageUsecase]. It delegates to the domain
-// use case to re-apply the named group to its matching agents on demand.
-func (s *ManageService) ReconcileAgentGroup(ctx context.Context, namespace string, name string) error {
-	err := s.agentgroupUsecase.ReconcileAgentGroup(ctx, namespace, name)
-	if err != nil {
-		return fmt.Errorf("reconcile agent group: %w", err)
-	}
-
-	return nil
-}

--- a/pkg/apiserver/application/service/agentremoteconfig/agentremoteconfig.go
+++ b/pkg/apiserver/application/service/agentremoteconfig/agentremoteconfig.go
@@ -201,19 +201,6 @@ func (s *Service) DeleteAgentRemoteConfig(
 	return nil
 }
 
-// ReconcileAgentRemoteConfig implements [port.AgentRemoteConfigManageUsecase]. It delegates
-// to the domain use case, which re-detects endpoints from the config's collector exporters
-// and re-propagates the config to the agent groups that reference it. Unlike the create/update
-// path (which fires these as detached goroutines), this runs synchronously and surfaces errors.
-func (s *Service) ReconcileAgentRemoteConfig(ctx context.Context, namespace string, name string) error {
-	err := s.agentRemoteConfigUsecase.ReconcileAgentRemoteConfig(ctx, namespace, name)
-	if err != nil {
-		return fmt.Errorf("reconcile agent remote config: %w", err)
-	}
-
-	return nil
-}
-
 // triggerGroupPropagation asks the agent group service to re-apply any groups in the
 // namespace that reference this config. Runs in its own goroutine so a slow
 // changedAgentGroupCh consumer cannot block the HTTP handler; the periodic

--- a/pkg/apiserver/application/service/reconcile/reconcile.go
+++ b/pkg/apiserver/application/service/reconcile/reconcile.go
@@ -1,0 +1,47 @@
+// Package reconcile provides the application service that exposes the generic domain
+// reconcile registry as a management use case.
+package reconcile
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
+	domainport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/port"
+	domainreconcile "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/reconcile"
+)
+
+var _ port.ReconcileManageUsecase = (*Service)(nil)
+
+// Service implements port.ReconcileManageUsecase by delegating to the domain reconcile
+// registry. It owns no logic of its own — each kind's behavior lives in its Reconciler.
+type Service struct {
+	registry *domainreconcile.Service
+}
+
+// New creates a new reconcile application Service.
+func New(registry *domainreconcile.Service) *Service {
+	return &Service{registry: registry}
+}
+
+// Reconcile implements port.ReconcileManageUsecase. It translates an unknown-kind error to
+// an invalid-argument so the transport maps it to 400 rather than 500; not-found and other
+// errors from the reconciler propagate unchanged for their normal status mapping.
+func (s *Service) Reconcile(ctx context.Context, kind string, namespace string, name string) error {
+	err := s.registry.Reconcile(ctx, kind, namespace, name)
+	if err != nil {
+		if errors.Is(err, domainreconcile.ErrUnknownKind) {
+			return fmt.Errorf("%w: %w", domainport.ErrInvalidArgument, err)
+		}
+
+		return fmt.Errorf("reconcile: %w", err)
+	}
+
+	return nil
+}
+
+// ReconcileKinds implements port.ReconcileManageUsecase.
+func (s *Service) ReconcileKinds(_ context.Context) []string {
+	return s.registry.Kinds()
+}

--- a/pkg/apiserver/docs/docs.go
+++ b/pkg/apiserver/docs/docs.go
@@ -885,50 +885,6 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/v1/namespaces/{namespace}/agentgroups/{name}/reconcile": {
-            "post": {
-                "description": "Re-apply the agent group's remote configs and connection settings to its matching agents.",
-                "tags": [
-                    "agentgroup"
-                ],
-                "summary": "Reconcile Agent Group",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Namespace",
-                        "name": "namespace",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Agent Group Name",
-                        "name": "name",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    }
-                }
-            }
-        },
         "/api/v1/namespaces/{namespace}/agentpackages": {
             "get": {
                 "description": "Retrieve a list of agent packages.",
@@ -1198,53 +1154,6 @@ const docTemplate = `{
                             "type": "object",
                             "additionalProperties": true
                         }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/namespaces/{namespace}/agentremoteconfigs/{name}/reconcile": {
-            "post": {
-                "description": "Re-detect endpoints from the config's exporters and re-propagate it to referencing agent groups.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "agentremoteconfig"
-                ],
-                "summary": "Reconcile Agent Remote Config",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Namespace",
-                        "name": "namespace",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Agent Remote Config Name",
-                        "name": "name",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
                     },
                     "404": {
                         "description": "Not Found",
@@ -1685,57 +1594,6 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/ListResponse-Endpoint"
                         }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/ErrorModel"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/ErrorModel"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/ErrorModel"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/namespaces/{namespace}/agents/{id}/reconcile": {
-            "post": {
-                "description": "Re-apply the matching agent groups' remote configs and connection settings to the agent.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "agent"
-                ],
-                "summary": "Reconcile Agent",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Namespace",
-                        "name": "namespace",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Instance UID of the agent",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
                     },
                     "400": {
                         "description": "Bad Request",
@@ -2496,6 +2354,67 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/namespaces/{namespace}/reconcile/{kind}/{name}": {
+            "post": {
+                "description": "Re-run the side effects that normally fire on create/update for the resource.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "reconcile"
+                ],
+                "summary": "Reconcile a resource",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Namespace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Resource kind (e.g. agentremoteconfig, agentgroup, agent)",
+                        "name": "kind",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Resource name, or instance UID for kind=agent",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/namespaces/{namespace}/rolebindings": {
             "get": {
                 "description": "Retrieves a list of role bindings with pagination options.",
@@ -2807,6 +2726,29 @@ const docTemplate = `{
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/reconcile/kinds": {
+            "get": {
+                "description": "List the resource kinds that support reconcile.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "reconcile"
+                ],
+                "summary": "List reconcilable kinds",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
                         }
                     }
                 }

--- a/pkg/apiserver/docs/swagger.json
+++ b/pkg/apiserver/docs/swagger.json
@@ -877,50 +877,6 @@
                 }
             }
         },
-        "/api/v1/namespaces/{namespace}/agentgroups/{name}/reconcile": {
-            "post": {
-                "description": "Re-apply the agent group's remote configs and connection settings to its matching agents.",
-                "tags": [
-                    "agentgroup"
-                ],
-                "summary": "Reconcile Agent Group",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Namespace",
-                        "name": "namespace",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Agent Group Name",
-                        "name": "name",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    }
-                }
-            }
-        },
         "/api/v1/namespaces/{namespace}/agentpackages": {
             "get": {
                 "description": "Retrieve a list of agent packages.",
@@ -1190,53 +1146,6 @@
                             "type": "object",
                             "additionalProperties": true
                         }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "type": "object",
-                            "additionalProperties": true
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/namespaces/{namespace}/agentremoteconfigs/{name}/reconcile": {
-            "post": {
-                "description": "Re-detect endpoints from the config's exporters and re-propagate it to referencing agent groups.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "agentremoteconfig"
-                ],
-                "summary": "Reconcile Agent Remote Config",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Namespace",
-                        "name": "namespace",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Agent Remote Config Name",
-                        "name": "name",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
                     },
                     "404": {
                         "description": "Not Found",
@@ -1677,57 +1586,6 @@
                         "schema": {
                             "$ref": "#/definitions/ListResponse-Endpoint"
                         }
-                    },
-                    "400": {
-                        "description": "Bad Request",
-                        "schema": {
-                            "$ref": "#/definitions/ErrorModel"
-                        }
-                    },
-                    "404": {
-                        "description": "Not Found",
-                        "schema": {
-                            "$ref": "#/definitions/ErrorModel"
-                        }
-                    },
-                    "500": {
-                        "description": "Internal Server Error",
-                        "schema": {
-                            "$ref": "#/definitions/ErrorModel"
-                        }
-                    }
-                }
-            }
-        },
-        "/api/v1/namespaces/{namespace}/agents/{id}/reconcile": {
-            "post": {
-                "description": "Re-apply the matching agent groups' remote configs and connection settings to the agent.",
-                "produces": [
-                    "application/json"
-                ],
-                "tags": [
-                    "agent"
-                ],
-                "summary": "Reconcile Agent",
-                "parameters": [
-                    {
-                        "type": "string",
-                        "description": "Namespace",
-                        "name": "namespace",
-                        "in": "path",
-                        "required": true
-                    },
-                    {
-                        "type": "string",
-                        "description": "Instance UID of the agent",
-                        "name": "id",
-                        "in": "path",
-                        "required": true
-                    }
-                ],
-                "responses": {
-                    "204": {
-                        "description": "No Content"
                     },
                     "400": {
                         "description": "Bad Request",
@@ -2488,6 +2346,67 @@
                 }
             }
         },
+        "/api/v1/namespaces/{namespace}/reconcile/{kind}/{name}": {
+            "post": {
+                "description": "Re-run the side effects that normally fire on create/update for the resource.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "reconcile"
+                ],
+                "summary": "Reconcile a resource",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Namespace",
+                        "name": "namespace",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Resource kind (e.g. agentremoteconfig, agentgroup, agent)",
+                        "name": "kind",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Resource name, or instance UID for kind=agent",
+                        "name": "name",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "204": {
+                        "description": "No Content"
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/namespaces/{namespace}/rolebindings": {
             "get": {
                 "description": "Retrieves a list of role bindings with pagination options.",
@@ -2799,6 +2718,29 @@
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/reconcile/kinds": {
+            "get": {
+                "description": "List the resource kinds that support reconcile.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "reconcile"
+                ],
+                "summary": "List reconcilable kinds",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
                         }
                     }
                 }

--- a/pkg/apiserver/docs/swagger.yaml
+++ b/pkg/apiserver/docs/swagger.yaml
@@ -2073,37 +2073,6 @@ paths:
       summary: Update Agent Group
       tags:
       - agentgroup
-  /api/v1/namespaces/{namespace}/agentgroups/{name}/reconcile:
-    post:
-      description: Re-apply the agent group's remote configs and connection settings
-        to its matching agents.
-      parameters:
-      - description: Namespace
-        in: path
-        name: namespace
-        required: true
-        type: string
-      - description: Agent Group Name
-        in: path
-        name: name
-        required: true
-        type: string
-      responses:
-        "204":
-          description: No Content
-        "404":
-          description: Not Found
-          schema:
-            additionalProperties: true
-            type: object
-        "500":
-          description: Internal Server Error
-          schema:
-            additionalProperties: true
-            type: object
-      summary: Reconcile Agent Group
-      tags:
-      - agentgroup
   /api/v1/namespaces/{namespace}/agentpackages:
     get:
       description: Retrieve a list of agent packages.
@@ -2300,39 +2269,6 @@ paths:
       summary: Update Agent Package
       tags:
       - agentpackage
-  /api/v1/namespaces/{namespace}/agentremoteconfigs/{name}/reconcile:
-    post:
-      description: Re-detect endpoints from the config's exporters and re-propagate
-        it to referencing agent groups.
-      parameters:
-      - description: Namespace
-        in: path
-        name: namespace
-        required: true
-        type: string
-      - description: Agent Remote Config Name
-        in: path
-        name: name
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "204":
-          description: No Content
-        "404":
-          description: Not Found
-          schema:
-            additionalProperties: true
-            type: object
-        "500":
-          description: Internal Server Error
-          schema:
-            additionalProperties: true
-            type: object
-      summary: Reconcile Agent Remote Config
-      tags:
-      - agentremoteconfig
   /api/v1/namespaces/{namespace}/agents:
     get:
       consumes:
@@ -2586,41 +2522,6 @@ paths:
           schema:
             $ref: '#/definitions/ErrorModel'
       summary: List Agent Endpoints
-      tags:
-      - agent
-  /api/v1/namespaces/{namespace}/agents/{id}/reconcile:
-    post:
-      description: Re-apply the matching agent groups' remote configs and connection
-        settings to the agent.
-      parameters:
-      - description: Namespace
-        in: path
-        name: namespace
-        required: true
-        type: string
-      - description: Instance UID of the agent
-        in: path
-        name: id
-        required: true
-        type: string
-      produces:
-      - application/json
-      responses:
-        "204":
-          description: No Content
-        "400":
-          description: Bad Request
-          schema:
-            $ref: '#/definitions/ErrorModel'
-        "404":
-          description: Not Found
-          schema:
-            $ref: '#/definitions/ErrorModel'
-        "500":
-          description: Internal Server Error
-          schema:
-            $ref: '#/definitions/ErrorModel'
-      summary: Reconcile Agent
       tags:
       - agent
   /api/v1/namespaces/{namespace}/agents/search:
@@ -3175,6 +3076,49 @@ paths:
       summary: Get Endpoint Throughput
       tags:
       - endpoint
+  /api/v1/namespaces/{namespace}/reconcile/{kind}/{name}:
+    post:
+      description: Re-run the side effects that normally fire on create/update for
+        the resource.
+      parameters:
+      - description: Namespace
+        in: path
+        name: namespace
+        required: true
+        type: string
+      - description: Resource kind (e.g. agentremoteconfig, agentgroup, agent)
+        in: path
+        name: kind
+        required: true
+        type: string
+      - description: Resource name, or instance UID for kind=agent
+        in: path
+        name: name
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "204":
+          description: No Content
+        "400":
+          description: Bad Request
+          schema:
+            additionalProperties: true
+            type: object
+        "404":
+          description: Not Found
+          schema:
+            additionalProperties: true
+            type: object
+        "500":
+          description: Internal Server Error
+          schema:
+            additionalProperties: true
+            type: object
+      summary: Reconcile a resource
+      tags:
+      - reconcile
   /api/v1/namespaces/{namespace}/rolebindings:
     get:
       description: Retrieves a list of role bindings with pagination options.
@@ -3390,6 +3334,21 @@ paths:
       summary: Ping
       tags:
       - ping
+  /api/v1/reconcile/kinds:
+    get:
+      description: List the resource kinds that support reconcile.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              type: string
+            type: array
+      summary: List reconcilable kinds
+      tags:
+      - reconcile
   /api/v1/roles:
     get:
       consumes:

--- a/pkg/apiserver/domain/agent/service/reconcilers.go
+++ b/pkg/apiserver/domain/agent/service/reconcilers.go
@@ -1,0 +1,121 @@
+package agentservice
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/uuid"
+
+	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/port"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/reconcile"
+)
+
+// Reconcile kind selectors. These are the stable, public identifiers used by the API and
+// CLI to address a reconciler; keep them lowercase to match opampctl resource names.
+const (
+	agentRemoteConfigKind = "agentremoteconfig"
+	agentGroupKind        = "agentgroup"
+	agentKind             = "agent"
+)
+
+// Compile-time checks that the adapters satisfy the generic reconcile contract.
+var (
+	_ reconcile.Reconciler = (*AgentRemoteConfigReconciler)(nil)
+	_ reconcile.Reconciler = (*AgentGroupReconciler)(nil)
+	_ reconcile.Reconciler = (*AgentReconciler)(nil)
+)
+
+// AgentRemoteConfigReconciler adapts AgentRemoteConfigUsecase to the generic reconcile
+// registry: reconciling re-detects endpoints from the config and re-propagates it to groups.
+type AgentRemoteConfigReconciler struct {
+	usecase agentport.AgentRemoteConfigUsecase
+}
+
+// NewAgentRemoteConfigReconciler creates an AgentRemoteConfigReconciler.
+func NewAgentRemoteConfigReconciler(usecase agentport.AgentRemoteConfigUsecase) *AgentRemoteConfigReconciler {
+	return &AgentRemoteConfigReconciler{usecase: usecase}
+}
+
+// Kind implements reconcile.Reconciler.
+func (*AgentRemoteConfigReconciler) Kind() string { return agentRemoteConfigKind }
+
+// Reconcile implements reconcile.Reconciler.
+func (r *AgentRemoteConfigReconciler) Reconcile(ctx context.Context, namespace, name string) error {
+	err := r.usecase.ReconcileAgentRemoteConfig(ctx, namespace, name)
+	if err != nil {
+		return fmt.Errorf("reconcile agent remote config: %w", err)
+	}
+
+	return nil
+}
+
+// AgentGroupReconciler adapts AgentGroupUsecase to the generic reconcile registry:
+// reconciling re-applies the group to its matching agents.
+type AgentGroupReconciler struct {
+	usecase agentport.AgentGroupUsecase
+}
+
+// NewAgentGroupReconciler creates an AgentGroupReconciler.
+func NewAgentGroupReconciler(usecase agentport.AgentGroupUsecase) *AgentGroupReconciler {
+	return &AgentGroupReconciler{usecase: usecase}
+}
+
+// Kind implements reconcile.Reconciler.
+func (*AgentGroupReconciler) Kind() string { return agentGroupKind }
+
+// Reconcile implements reconcile.Reconciler.
+func (r *AgentGroupReconciler) Reconcile(ctx context.Context, namespace, name string) error {
+	err := r.usecase.ReconcileAgentGroup(ctx, namespace, name)
+	if err != nil {
+		return fmt.Errorf("reconcile agent group: %w", err)
+	}
+
+	return nil
+}
+
+// AgentReconciler adapts the agent reconcile flow to the generic registry. The name is the
+// agent's instance UID; reconciling re-applies the matching agent groups to the agent and
+// persists the result. It enforces the namespace so an agent in another namespace is not
+// reachable through a mismatched path.
+type AgentReconciler struct {
+	agentUsecase agentport.AgentUsecase
+	groupUsecase agentport.AgentGroupUsecase
+}
+
+// NewAgentReconciler creates an AgentReconciler.
+func NewAgentReconciler(
+	agentUsecase agentport.AgentUsecase,
+	groupUsecase agentport.AgentGroupUsecase,
+) *AgentReconciler {
+	return &AgentReconciler{agentUsecase: agentUsecase, groupUsecase: groupUsecase}
+}
+
+// Kind implements reconcile.Reconciler.
+func (*AgentReconciler) Kind() string { return agentKind }
+
+// Reconcile implements reconcile.Reconciler. name is the agent's instance UID.
+func (r *AgentReconciler) Reconcile(ctx context.Context, namespace, name string) error {
+	instanceUID, err := uuid.Parse(name)
+	if err != nil {
+		return fmt.Errorf("invalid agent instance uid %q: %w: %w", name, port.ErrInvalidArgument, err)
+	}
+
+	agent, err := r.agentUsecase.GetAgent(ctx, instanceUID)
+	if err != nil {
+		return fmt.Errorf("get agent: %w", err)
+	}
+
+	// Scope the agent to the requested namespace: an agent in another namespace must not be
+	// reachable here. Treat a mismatch as not-found so it maps to 404 like a missing agent.
+	if agent.Metadata.Namespace != namespace {
+		return fmt.Errorf("agent %s not in namespace %q: %w", instanceUID, namespace, port.ErrResourceNotExist)
+	}
+
+	err = r.groupUsecase.ReconcileAgent(ctx, agent)
+	if err != nil {
+		return fmt.Errorf("reconcile agent: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/apiserver/domain/agent/service/reconcilers_test.go
+++ b/pkg/apiserver/domain/agent/service/reconcilers_test.go
@@ -1,0 +1,91 @@
+package agentservice_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
+	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
+	agentservice "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/service"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/port"
+)
+
+// fakeAgentLoader returns a fixed agent by UID; the embedded interface covers unused methods.
+type fakeAgentLoader struct {
+	agentport.AgentUsecase
+
+	agent *agentmodel.Agent
+}
+
+func (f *fakeAgentLoader) GetAgent(_ context.Context, _ uuid.UUID) (*agentmodel.Agent, error) {
+	if f.agent == nil {
+		return nil, port.ErrResourceNotExist
+	}
+
+	return f.agent, nil
+}
+
+// recordingGroupReconciler records whether ReconcileAgent ran.
+type recordingGroupReconciler struct {
+	agentport.AgentGroupUsecase
+
+	called bool
+}
+
+func (r *recordingGroupReconciler) ReconcileAgent(_ context.Context, _ *agentmodel.Agent) error {
+	r.called = true
+
+	return nil
+}
+
+func TestAgentReconciler_Reconcile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reconciles an agent in the requested namespace", func(t *testing.T) {
+		t.Parallel()
+
+		uid := uuid.New()
+		agent := agentmodel.NewAgent(uid)
+		agent.Metadata.Namespace = "team-a"
+
+		group := &recordingGroupReconciler{}
+		reconciler := agentservice.NewAgentReconciler(&fakeAgentLoader{agent: agent}, group)
+
+		err := reconciler.Reconcile(context.Background(), "team-a", uid.String())
+
+		require.NoError(t, err)
+		assert.True(t, group.called, "the agent should have been reconciled")
+	})
+
+	t.Run("treats a namespace mismatch as not found and does not reconcile", func(t *testing.T) {
+		t.Parallel()
+
+		uid := uuid.New()
+		agent := agentmodel.NewAgent(uid)
+		agent.Metadata.Namespace = "team-a"
+
+		group := &recordingGroupReconciler{}
+		reconciler := agentservice.NewAgentReconciler(&fakeAgentLoader{agent: agent}, group)
+
+		err := reconciler.Reconcile(context.Background(), "team-b", uid.String())
+
+		require.ErrorIs(t, err, port.ErrResourceNotExist)
+		assert.False(t, group.called, "an agent in another namespace must not be reconciled")
+	})
+
+	t.Run("rejects a non-uuid name as an invalid argument", func(t *testing.T) {
+		t.Parallel()
+
+		group := &recordingGroupReconciler{}
+		reconciler := agentservice.NewAgentReconciler(&fakeAgentLoader{agent: nil}, group)
+
+		err := reconciler.Reconcile(context.Background(), "team-a", "not-a-uuid")
+
+		require.ErrorIs(t, err, port.ErrInvalidArgument)
+		assert.False(t, group.called)
+	})
+}

--- a/pkg/apiserver/domain/reconcile/reconcile.go
+++ b/pkg/apiserver/domain/reconcile/reconcile.go
@@ -1,0 +1,85 @@
+// Package reconcile provides a generic, registry-based mechanism for re-enforcing a
+// domain object's invariants on demand. Each reconcilable resource kind registers a
+// [Reconciler]; the [Service] dispatches a (kind, namespace, name) request to the
+// matching one. New reconcilable objects plug in by implementing [Reconciler] and being
+// added to the registry — no new transport/CLI code is required.
+package reconcile
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+)
+
+// ErrUnknownKind is returned when a reconcile is requested for a kind that has no
+// registered [Reconciler].
+var ErrUnknownKind = errors.New("unknown reconcile kind")
+
+// ErrDuplicateKind is returned when two reconcilers register the same kind.
+var ErrDuplicateKind = errors.New("duplicate reconcile kind")
+
+// Reconciler re-enforces the domain invariants for a single resource kind, re-running the
+// side effects that normally fire when the resource is created or updated. Implementations
+// are thin adapters over the resource's domain use case.
+type Reconciler interface {
+	// Kind returns the resource kind this reconciler handles (e.g. "agentremoteconfig").
+	// It must be unique across the registry and stable, since it is the public selector
+	// used by the API and CLI.
+	Kind() string
+	// Reconcile re-enforces the named resource's invariants. For namespace-scoped kinds
+	// name is the resource name; for the agent kind it is the instance UID. A missing
+	// resource should surface as port.ErrResourceNotExist so the transport maps it to 404.
+	Reconcile(ctx context.Context, namespace, name string) error
+}
+
+// Service is the reconcile registry and dispatcher. It indexes the provided reconcilers by
+// kind and routes each request to the matching one.
+type Service struct {
+	byKind map[string]Reconciler
+}
+
+// NewService indexes the given reconcilers by kind. It returns an error if two reconcilers
+// claim the same kind, since that would make dispatch ambiguous.
+func NewService(reconcilers []Reconciler) (*Service, error) {
+	byKind := make(map[string]Reconciler, len(reconcilers))
+
+	for _, reconciler := range reconcilers {
+		kind := reconciler.Kind()
+		if _, exists := byKind[kind]; exists {
+			return nil, fmt.Errorf("%w: %q", ErrDuplicateKind, kind)
+		}
+
+		byKind[kind] = reconciler
+	}
+
+	return &Service{byKind: byKind}, nil
+}
+
+// Reconcile dispatches to the reconciler registered for kind. It returns ErrUnknownKind
+// when no reconciler is registered for the kind.
+func (s *Service) Reconcile(ctx context.Context, kind, namespace, name string) error {
+	reconciler, ok := s.byKind[kind]
+	if !ok {
+		return fmt.Errorf("%w: %q", ErrUnknownKind, kind)
+	}
+
+	err := reconciler.Reconcile(ctx, namespace, name)
+	if err != nil {
+		return fmt.Errorf("reconcile %s %q: %w", kind, name, err)
+	}
+
+	return nil
+}
+
+// Kinds returns the registered reconcile kinds in sorted order.
+func (s *Service) Kinds() []string {
+	kinds := make([]string, 0, len(s.byKind))
+	for kind := range s.byKind {
+		kinds = append(kinds, kind)
+	}
+
+	slices.Sort(kinds)
+
+	return kinds
+}

--- a/pkg/apiserver/domain/reconcile/reconcile_test.go
+++ b/pkg/apiserver/domain/reconcile/reconcile_test.go
@@ -1,0 +1,104 @@
+package reconcile_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/reconcile"
+)
+
+var errBoom = errors.New("boom")
+
+// fakeReconciler records the last reconcile call for assertions.
+type fakeReconciler struct {
+	kind      string
+	err       error
+	gotNS     string
+	gotName   string
+	callCount int
+}
+
+func (f *fakeReconciler) Kind() string { return f.kind }
+
+func (f *fakeReconciler) Reconcile(_ context.Context, namespace, name string) error {
+	f.callCount++
+	f.gotNS = namespace
+	f.gotName = name
+
+	return f.err
+}
+
+func TestService_Reconcile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("dispatches to the reconciler registered for the kind", func(t *testing.T) {
+		t.Parallel()
+
+		target := &fakeReconciler{kind: "agentgroup"}
+		other := &fakeReconciler{kind: "agent"}
+
+		svc, err := reconcile.NewService([]reconcile.Reconciler{target, other})
+		require.NoError(t, err)
+
+		err = svc.Reconcile(context.Background(), "agentgroup", "default", "obs")
+
+		require.NoError(t, err)
+		assert.Equal(t, 1, target.callCount)
+		assert.Equal(t, 0, other.callCount)
+		assert.Equal(t, "default", target.gotNS)
+		assert.Equal(t, "obs", target.gotName)
+	})
+
+	t.Run("returns ErrUnknownKind for an unregistered kind", func(t *testing.T) {
+		t.Parallel()
+
+		svc, err := reconcile.NewService([]reconcile.Reconciler{&fakeReconciler{kind: "agent"}})
+		require.NoError(t, err)
+
+		err = svc.Reconcile(context.Background(), "doesnotexist", "default", "x")
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, reconcile.ErrUnknownKind)
+	})
+
+	t.Run("propagates the reconciler's error", func(t *testing.T) {
+		t.Parallel()
+
+		svc, err := reconcile.NewService([]reconcile.Reconciler{&fakeReconciler{kind: "agent", err: errBoom}})
+		require.NoError(t, err)
+
+		err = svc.Reconcile(context.Background(), "agent", "default", "id")
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errBoom)
+	})
+
+	t.Run("rejects duplicate kinds", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := reconcile.NewService([]reconcile.Reconciler{
+			&fakeReconciler{kind: "agent"},
+			&fakeReconciler{kind: "agent"},
+		})
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, reconcile.ErrDuplicateKind)
+	})
+}
+
+func TestService_Kinds(t *testing.T) {
+	t.Parallel()
+
+	svc, err := reconcile.NewService([]reconcile.Reconciler{
+		&fakeReconciler{kind: "agentremoteconfig"},
+		&fakeReconciler{kind: "agent"},
+		&fakeReconciler{kind: "agentgroup"},
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, []string{"agent", "agentgroup", "agentremoteconfig"}, svc.Kinds())
+}

--- a/pkg/apiserver/internal/app/app.go
+++ b/pkg/apiserver/internal/app/app.go
@@ -40,20 +40,7 @@ type Server struct {
 
 // New creates a new instance of the Server struct.
 func New(settings config.ServerSettings) *Server {
-	app := fx.New(
-		// Hexagonal architecture layers
-		adaptermodule.NewAdapterModules(settings.DatabaseSettings.Type), // Adapters: HTTP, DB, messaging, scheduler
-		infrastructuremodule.New(settings.DatabaseSettings.Type),        // Bootstrap: Casbin RBAC + default seed hooks
-		applicationmodule.New(),    // Application services
-		domainmodule.New(),         // Domain services
-		NewConfigModule(&settings), // Configuration
-
-		// Base utilities
-		helper.NewModule(),
-		management.NewModule(),
-		// Initialize HTTP server
-		fx.Invoke(func(*http.Server) {}),
-	)
+	app := fx.New(appOptions(&settings)...)
 
 	server := &Server{
 		App:      app,
@@ -61,6 +48,34 @@ func New(settings config.ServerSettings) *Server {
 	}
 
 	return server
+}
+
+// appOptions returns the full FX option set for the apiserver. It is the single source of
+// truth for the composition root so New and ValidateWiring stay in sync.
+func appOptions(settings *config.ServerSettings) []fx.Option {
+	return []fx.Option{
+		// Hexagonal architecture layers
+		adaptermodule.NewAdapterModules(settings.DatabaseSettings.Type), // Adapters: HTTP, DB, messaging, scheduler
+		infrastructuremodule.New(settings.DatabaseSettings.Type),        // Bootstrap: Casbin RBAC + default seed hooks
+		applicationmodule.New(),   // Application services
+		domainmodule.New(),        // Domain services
+		NewConfigModule(settings), // Configuration
+
+		// Base utilities
+		helper.NewModule(),
+		management.NewModule(),
+		// Initialize HTTP server
+		fx.Invoke(func(*http.Server) {}),
+	}
+}
+
+// ValidateWiring checks that the apiserver's FX dependency graph resolves (no missing
+// dependencies or cycles) without constructing the application or running any lifecycle
+// hooks. It is exposed so a fast wiring test can guard against regressions without
+// importing FX directly.
+func ValidateWiring(settings config.ServerSettings) error {
+	//nolint:wrapcheck // thin pass-through to fx.ValidateApp for tests
+	return fx.ValidateApp(appOptions(&settings)...)
 }
 
 // Run starts the server and blocks until the context is done.

--- a/pkg/apiserver/internal/app/wiring_validate_test.go
+++ b/pkg/apiserver/internal/app/wiring_validate_test.go
@@ -1,0 +1,25 @@
+package app_test
+
+import (
+	"testing"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/config"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/internal/app"
+)
+
+// TestWiringValidates checks the full FX dependency graph resolves without missing
+// dependencies or cycles — a fast guard (in-memory DB, no lifecycle/network) against
+// wiring regressions such as the generic reconcile registry pulling in a cycle.
+func TestWiringValidates(t *testing.T) {
+	t.Parallel()
+
+	//exhaustruct:ignore
+	settings := config.ServerSettings{
+		DatabaseSettings: config.DatabaseSettings{Type: config.DatabaseTypeInMemory},
+	}
+
+	err := app.ValidateWiring(settings)
+	if err != nil {
+		t.Fatalf("fx app graph failed to validate: %v", err)
+	}
+}

--- a/pkg/apiserver/internal/module/adapter/primary/http.go
+++ b/pkg/apiserver/internal/module/adapter/primary/http.go
@@ -31,6 +31,7 @@ import (
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/primary/http/v1/namespace"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/primary/http/v1/opamp"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/primary/http/v1/ping"
+	reconcilecontroller "github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/primary/http/v1/reconcile"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/primary/http/v1/role"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/primary/http/v1/rolebinding"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/primary/http/v1/server"
@@ -78,6 +79,7 @@ func NewHTTP() fx.Option {
 			AsController(agentgroup.NewController),
 			AsController(agentpackage.NewController),
 			AsController(agentremoteconfigcontroller.NewController),
+			AsController(reconcilecontroller.NewController),
 			AsController(endpoint.NewController),
 			AsController(endpointmetrics.NewController),
 			AsController(namespace.NewController),

--- a/pkg/apiserver/internal/module/application/application.go
+++ b/pkg/apiserver/internal/module/application/application.go
@@ -20,6 +20,7 @@ import (
 	hostApplicationService "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/host"
 	namespaceApplicationService "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/namespace"
 	opampApplicationService "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/opamp"
+	reconcileApplicationService "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/reconcile"
 	roleApplicationService "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/role"
 	rolebindingApplicationService "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/rolebinding"
 	serverApplicationService "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/server"
@@ -48,6 +49,9 @@ func New() fx.Option {
 
 			agentApplicationService.New,
 			fx.Annotate(Identity[*agentApplicationService.Service], fx.As(new(port.AgentManageUsecase))),
+
+			reconcileApplicationService.New,
+			fx.Annotate(Identity[*reconcileApplicationService.Service], fx.As(new(port.ReconcileManageUsecase))),
 
 			agentgroupApplicationService.NewManageService,
 			fx.Annotate(Identity[*agentgroupApplicationService.ManageService], fx.As(new(port.AgentGroupManageUsecase))),

--- a/pkg/apiserver/internal/module/domain/domain.go
+++ b/pkg/apiserver/internal/module/domain/domain.go
@@ -11,12 +11,15 @@ import (
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/config"
 	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
 	agentservice "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/service"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/reconcile"
 	userport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/port"
 	userservice "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/service"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/internal/module/helper"
 )
 
 // New creates a new module for domain services.
+//
+//nolint:funlen // DI wiring: a flat list of service providers/annotations.
 func New() fx.Option {
 	components := []any{
 		fx.Annotate(agentservice.NewConnectionService, fx.As(new(agentport.ConnectionUsecase))),
@@ -71,6 +74,17 @@ func New() fx.Option {
 		helper.AsRunner(Identity[*agentservice.ServerService]),
 		helper.AsRunner(Identity[*agentservice.ServerIdentityService]),
 		helper.AsRunner(Identity[*agentservice.AgentNotificationService]),
+
+		// Generic reconcile registry: each Reconciler is collected into the "reconcilers"
+		// group and indexed by reconcile.NewService. A new reconcilable kind plugs in by
+		// adding one AsReconciler line here.
+		helper.AsReconciler(agentservice.NewAgentRemoteConfigReconciler),
+		helper.AsReconciler(agentservice.NewAgentGroupReconciler),
+		helper.AsReconciler(agentservice.NewAgentReconciler),
+		fx.Annotate(
+			reconcile.NewService,
+			fx.ParamTags(`group:"reconcilers"`),
+		),
 	}
 
 	return fx.Module(

--- a/pkg/apiserver/internal/module/helper/fx.go
+++ b/pkg/apiserver/internal/module/helper/fx.go
@@ -6,6 +6,7 @@ import (
 	"go.uber.org/fx"
 
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/primary/scheduler"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/reconcile"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/management/healthcheck"
 )
 
@@ -26,6 +27,17 @@ func AsRunner(f any) any {
 		f,
 		fx.As(new(scheduler.Scheduler)),
 		fx.ResultTags(`group:"runners"`),
+	)
+}
+
+// AsReconciler annotates a constructor as a reconcile.Reconciler. The annotated value is
+// collected into the "reconcilers" group and indexed by the reconcile registry, so a new
+// reconcilable kind plugs in with just this one wiring line.
+func AsReconciler(f any) any {
+	return fx.Annotate(
+		f,
+		fx.As(new(reconcile.Reconciler)),
+		fx.ResultTags(`group:"reconcilers"`),
 	)
 }
 

--- a/pkg/client/agent.go
+++ b/pkg/client/agent.go
@@ -26,8 +26,6 @@ const (
 	UpdateAgentURL = agentByIDURL
 	// DeleteAgentURL is the path to delete an agent by ID in a namespace.
 	DeleteAgentURL = agentByIDURL
-	// ReconcileAgentURL is the path to reconcile an agent by ID in a namespace.
-	ReconcileAgentURL = agentByIDURL + "/reconcile"
 )
 
 // AgentService provides methods to interact with agents.
@@ -155,35 +153,6 @@ func (s *AgentService) DeleteAgent(
 
 	if res.IsError() {
 		return fmt.Errorf("failed to delete agent: %w", &ResponseError{
-			StatusCode:   res.StatusCode(),
-			ErrorMessage: res.String(),
-		})
-	}
-
-	return nil
-}
-
-// ReconcileAgent re-applies the matching agent groups to an agent so it picks up its
-// assigned remote configs and connection settings on demand.
-func (s *AgentService) ReconcileAgent(
-	ctx context.Context,
-	namespace string,
-	id uuid.UUID,
-) error {
-	// Reconcile runs synchronously on the server (re-applying matching groups and persisting
-	// the agent), which can outlast the shared client's 15s timeout in a large namespace.
-	// Clone the client and clear the timeout; the context deadline is the only limit.
-	res, err := s.service.Resty.Clone().SetTimeout(0).R().
-		SetContext(ctx).
-		SetPathParam("namespace", namespace).
-		SetPathParam("id", id.String()).
-		Post(ReconcileAgentURL)
-	if err != nil {
-		return fmt.Errorf("failed to reconcile agent: %w", err)
-	}
-
-	if res.IsError() {
-		return fmt.Errorf("failed to reconcile agent: %w", &ResponseError{
 			StatusCode:   res.StatusCode(),
 			ErrorMessage: res.String(),
 		})

--- a/pkg/client/agentgroup.go
+++ b/pkg/client/agentgroup.go
@@ -22,8 +22,6 @@ const (
 	UpdateAgentGroupURL = "/api/v1/namespaces/{namespace}/agentgroups/{id}"
 	// DeleteAgentGroupURL is the path to delete an agent group.
 	DeleteAgentGroupURL = "/api/v1/namespaces/{namespace}/agentgroups/{id}"
-	// ReconcileAgentGroupURL is the path to reconcile an agent group by name in a namespace.
-	ReconcileAgentGroupURL = "/api/v1/namespaces/{namespace}/agentgroups/{id}/reconcile"
 )
 
 // AgentGroupService provides methods to interact with agent groups.
@@ -240,30 +238,6 @@ func (s *AgentGroupService) DeleteAgentGroup(ctx context.Context, namespace stri
 
 	if res.IsError() {
 		return fmt.Errorf("failed to delete agent group(responseError): %w", &ResponseError{
-			StatusCode:   res.StatusCode(),
-			ErrorMessage: res.String(),
-		})
-	}
-
-	return nil
-}
-
-// ReconcileAgentGroup re-applies the named agent group to its matching agents on demand.
-func (s *AgentGroupService) ReconcileAgentGroup(ctx context.Context, namespace string, name string) error {
-	// Reconcile runs synchronously on the server (re-applying the group to all its agents),
-	// which can outlast the shared client's 15s timeout in a large namespace. Clone the client
-	// and clear the timeout; the context deadline is the only limit.
-	res, err := s.service.Resty.Clone().SetTimeout(0).R().
-		SetContext(ctx).
-		SetPathParam("namespace", namespace).
-		SetPathParam("id", name).
-		Post(ReconcileAgentGroupURL)
-	if err != nil {
-		return fmt.Errorf("failed to reconcile agent group(restyError): %w", err)
-	}
-
-	if res.IsError() {
-		return fmt.Errorf("failed to reconcile agent group(responseError): %w", &ResponseError{
 			StatusCode:   res.StatusCode(),
 			ErrorMessage: res.String(),
 		})

--- a/pkg/client/agentremoteconfig.go
+++ b/pkg/client/agentremoteconfig.go
@@ -1,3 +1,4 @@
+//nolint:dupl // Similar structure to other resource services is intentional
 package client
 
 import (
@@ -18,8 +19,6 @@ const (
 	UpdateAgentRemoteConfigURL = "/api/v1/namespaces/{namespace}/agentremoteconfigs/{id}"
 	// DeleteAgentRemoteConfigURL is the path to delete an agent remote config.
 	DeleteAgentRemoteConfigURL = "/api/v1/namespaces/{namespace}/agentremoteconfigs/{id}"
-	// ReconcileAgentRemoteConfigURL is the path to reconcile an agent remote config by name.
-	ReconcileAgentRemoteConfigURL = "/api/v1/namespaces/{namespace}/agentremoteconfigs/{id}/reconcile"
 )
 
 // AgentRemoteConfigService provides methods to interact with agent remote configs.
@@ -197,40 +196,6 @@ func (s *AgentRemoteConfigService) DeleteAgentRemoteConfig(
 	if res.IsError() {
 		return fmt.Errorf(
 			"failed to delete agent remote config(responseError): %w",
-			&ResponseError{
-				StatusCode:   res.StatusCode(),
-				ErrorMessage: res.String(),
-			},
-		)
-	}
-
-	return nil
-}
-
-// ReconcileAgentRemoteConfig re-detects telemetry endpoints from the config's collector
-// exporters and re-propagates it to the agent groups that reference it.
-func (s *AgentRemoteConfigService) ReconcileAgentRemoteConfig(
-	ctx context.Context,
-	namespace string,
-	name string,
-) error {
-	// Reconcile runs synchronously on the server (endpoint detection plus re-propagation to
-	// referencing groups), which can outlast the shared client's 15s timeout in a large
-	// namespace. Clone the client and clear the timeout; the context deadline is the only limit.
-	res, err := s.service.Resty.Clone().SetTimeout(0).R().
-		SetContext(ctx).
-		SetPathParam("namespace", namespace).
-		SetPathParam("id", name).
-		Post(ReconcileAgentRemoteConfigURL)
-	if err != nil {
-		return fmt.Errorf(
-			"failed to reconcile agent remote config(restyError): %w", err,
-		)
-	}
-
-	if res.IsError() {
-		return fmt.Errorf(
-			"failed to reconcile agent remote config(responseError): %w",
 			&ResponseError{
 				StatusCode:   res.StatusCode(),
 				ErrorMessage: res.String(),

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -34,6 +34,7 @@ type Client struct {
 	UserService              *UserService
 	RoleService              *RoleService
 	RoleBindingService       *RoleBindingService
+	ReconcileService         *ReconcileService
 }
 
 type service struct {
@@ -64,6 +65,7 @@ func New(endpoint string, opt ...Option) *Client {
 		UserService:              nil,
 		RoleService:              nil,
 		RoleBindingService:       nil,
+		ReconcileService:         nil,
 	}
 
 	for _, o := range opt {
@@ -84,6 +86,7 @@ func New(endpoint string, opt ...Option) *Client {
 	client.UserService = NewUserService(&service)
 	client.RoleService = NewRoleService(&service)
 	client.RoleBindingService = NewRoleBindingService(&service)
+	client.ReconcileService = NewReconcileService(&service)
 
 	return client
 }

--- a/pkg/client/reconcile.go
+++ b/pkg/client/reconcile.go
@@ -1,0 +1,72 @@
+package client
+
+import (
+	"context"
+	"fmt"
+)
+
+const (
+	// ReconcileURL is the path to reconcile a resource of a given kind in a namespace.
+	ReconcileURL = "/api/v1/namespaces/{namespace}/reconcile/{kind}/{name}"
+	// ReconcileKindsURL is the path to list the reconcilable kinds.
+	ReconcileKindsURL = "/api/v1/reconcile/kinds"
+)
+
+// ReconcileService re-enforces a domain object's invariants on demand via the generic
+// reconcile endpoint.
+type ReconcileService struct {
+	service *service
+}
+
+// NewReconcileService creates a new ReconcileService.
+func NewReconcileService(service *service) *ReconcileService {
+	return &ReconcileService{service: service}
+}
+
+// Reconcile re-runs the side effects that normally fire on create/update for the named
+// resource of the given kind. For kind "agent", name is the instance UID.
+func (s *ReconcileService) Reconcile(ctx context.Context, kind, namespace, name string) error {
+	// Reconcile runs synchronously on the server and can outlast the shared client's 15s
+	// timeout in a large namespace. Clone the client and clear the timeout; the context
+	// deadline is the only limit.
+	res, err := s.service.Resty.Clone().SetTimeout(0).R().
+		SetContext(ctx).
+		SetPathParam("namespace", namespace).
+		SetPathParam("kind", kind).
+		SetPathParam("name", name).
+		Post(ReconcileURL)
+	if err != nil {
+		return fmt.Errorf("failed to reconcile %s %q: %w", kind, name, err)
+	}
+
+	if res.IsError() {
+		return fmt.Errorf("failed to reconcile %s %q: %w", kind, name, &ResponseError{
+			StatusCode:   res.StatusCode(),
+			ErrorMessage: res.String(),
+		})
+	}
+
+	return nil
+}
+
+// ListKinds returns the reconcilable kinds advertised by the server.
+func (s *ReconcileService) ListKinds(ctx context.Context) ([]string, error) {
+	var kinds []string
+
+	res, err := s.service.Resty.R().
+		SetContext(ctx).
+		SetResult(&kinds).
+		Get(ReconcileKindsURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list reconcile kinds: %w", err)
+	}
+
+	if res.IsError() {
+		return nil, fmt.Errorf("failed to list reconcile kinds: %w", &ResponseError{
+			StatusCode:   res.StatusCode(),
+			ErrorMessage: res.String(),
+		})
+	}
+
+	return kinds, nil
+}

--- a/pkg/cmd/opampctl/reconcile/reconcile.go
+++ b/pkg/cmd/opampctl/reconcile/reconcile.go
@@ -1,24 +1,20 @@
-// Package reconcile provides the reconcile command for opampctl. It re-runs, on demand, the
-// side effects that normally fire when a resource is created or updated — useful for repairing
-// drift on resources that predate a feature or whose triggers were missed.
+// Package reconcile provides the generic `opampctl reconcile` command. It re-enforces a
+// domain object's invariants on demand by dispatching to the server's reconcile registry,
+// so any reconcilable kind is reachable through a single command without per-kind code.
 package reconcile
 
 import (
 	"context"
 	"fmt"
 
-	"github.com/google/uuid"
-	"github.com/samber/lo"
 	"github.com/spf13/cobra"
 
-	v1 "github.com/minuk-dev/opampcommander/api/v1"
-	"github.com/minuk-dev/opampcommander/pkg/client"
 	"github.com/minuk-dev/opampcommander/pkg/clientutil"
 	"github.com/minuk-dev/opampcommander/pkg/opampctl/config"
 )
 
-// MaxCompletionResults is the maximum number of completion results to return.
-const MaxCompletionResults = 20
+// reconcileArgs is the number of positional arguments: <kind> <name>.
+const reconcileArgs = 2
 
 // CommandOptions contains the options for the reconcile command.
 type CommandOptions struct {
@@ -27,133 +23,43 @@ type CommandOptions struct {
 
 // NewCommand creates a new reconcile command.
 func NewCommand(options CommandOptions) *cobra.Command {
-	//exhaustruct:ignore
-	cmd := &cobra.Command{
-		Use:   "reconcile",
-		Short: "reconcile resources",
-		Long: "Re-run a resource's automatic side effects on demand (the same work performed when it is " +
-			"created/updated or by the background reconcile loop).",
-	}
-
-	cmd.AddCommand(newReconcileRemoteConfigCommand(options))
-	cmd.AddCommand(newReconcileAgentGroupCommand(options))
-	cmd.AddCommand(newReconcileAgentCommand(options))
-
-	return cmd
-}
-
-// newReconcileRemoteConfigCommand reconciles an agent remote config: it re-detects telemetry
-// endpoints from the config's collector exporters and re-propagates it to referencing groups.
-func newReconcileRemoteConfigCommand(options CommandOptions) *cobra.Command {
 	var namespace string
 
 	//exhaustruct:ignore
 	cmd := &cobra.Command{
-		Use:     "remoteconfig <name>",
-		Aliases: []string{"agentremoteconfig"},
-		Short:   "reconcile an agent remote config",
-		Args:    cobra.ExactArgs(1),
+		Use:   "reconcile <kind> <name>",
+		Short: "reconcile a resource",
+		Long: "Re-run the side effects that normally fire when a resource is created/updated, " +
+			"to re-enforce its domain rules on demand. For kind \"agent\", <name> is the instance UID.",
+		Args: cobra.ExactArgs(reconcileArgs),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			cli, err := clientutil.NewClient(options.GlobalConfig)
 			if err != nil {
 				return fmt.Errorf("failed to create API client: %w", err)
 			}
 
-			name := args[0]
+			kind, name := args[0], args[1]
 
-			err = cli.AgentRemoteConfigService.ReconcileAgentRemoteConfig(context.Background(), namespace, name)
+			err = cli.ReconcileService.Reconcile(context.Background(), kind, namespace, name)
 			if err != nil {
-				return fmt.Errorf("failed to reconcile agent remote config: %w", err)
+				return fmt.Errorf("failed to reconcile %s %q: %w", kind, name, err)
 			}
 
-			cmd.Printf("AgentRemoteConfig %s/%s reconciled successfully\n", namespace, name)
+			cmd.Printf("%s %s/%s reconciled successfully\n", kind, namespace, name)
 
 			return nil
 		},
-		ValidArgsFunction: remoteConfigNameCompletion(options, &namespace),
+		ValidArgsFunction: kindCompletion(options),
 	}
 
-	cmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "Namespace of the agent remote config")
+	cmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "Namespace of the resource")
 
 	return cmd
 }
 
-// newReconcileAgentGroupCommand reconciles an agent group: it re-applies the group's remote
-// configs and connection settings to its matching agents.
-func newReconcileAgentGroupCommand(options CommandOptions) *cobra.Command {
-	var namespace string
-
-	//exhaustruct:ignore
-	cmd := &cobra.Command{
-		Use:   "agentgroup <name>",
-		Short: "reconcile an agent group",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			cli, err := clientutil.NewClient(options.GlobalConfig)
-			if err != nil {
-				return fmt.Errorf("failed to create API client: %w", err)
-			}
-
-			name := args[0]
-
-			err = cli.AgentGroupService.ReconcileAgentGroup(context.Background(), namespace, name)
-			if err != nil {
-				return fmt.Errorf("failed to reconcile agent group: %w", err)
-			}
-
-			cmd.Printf("AgentGroup %s/%s reconciled successfully\n", namespace, name)
-
-			return nil
-		},
-		ValidArgsFunction: agentGroupNameCompletion(options, &namespace),
-	}
-
-	cmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "Namespace of the agent group")
-
-	return cmd
-}
-
-// newReconcileAgentCommand reconciles an agent: it re-applies the agent groups that match the
-// agent so it picks up its assigned remote configs and connection settings.
-func newReconcileAgentCommand(options CommandOptions) *cobra.Command {
-	var namespace string
-
-	//exhaustruct:ignore
-	cmd := &cobra.Command{
-		Use:   "agent <id>",
-		Short: "reconcile an agent",
-		Args:  cobra.ExactArgs(1),
-		RunE: func(cmd *cobra.Command, args []string) error {
-			cli, err := clientutil.NewClient(options.GlobalConfig)
-			if err != nil {
-				return fmt.Errorf("failed to create API client: %w", err)
-			}
-
-			agentUUID, err := uuid.Parse(args[0])
-			if err != nil {
-				return fmt.Errorf("invalid agent ID format: %w", err)
-			}
-
-			err = cli.AgentService.ReconcileAgent(context.Background(), namespace, agentUUID)
-			if err != nil {
-				return fmt.Errorf("failed to reconcile agent: %w", err)
-			}
-
-			cmd.Printf("Agent %s/%s reconciled successfully\n", namespace, agentUUID)
-
-			return nil
-		},
-		ValidArgsFunction: agentIDCompletion(options, &namespace),
-	}
-
-	cmd.Flags().StringVarP(&namespace, "namespace", "n", "default", "Namespace of the agent")
-
-	return cmd
-}
-
-func remoteConfigNameCompletion(
+// kindCompletion completes the first argument (kind) from the server's reconcile registry.
+func kindCompletion(
 	options CommandOptions,
-	namespace *string,
 ) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
 	return func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
 		if len(args) != 0 {
@@ -165,74 +71,11 @@ func remoteConfigNameCompletion(
 			return nil, cobra.ShellCompDirectiveError
 		}
 
-		items, err := clientutil.ListAgentRemoteConfigFully(cmd.Context(), cli, *namespace)
+		kinds, err := cli.ReconcileService.ListKinds(cmd.Context())
 		if err != nil {
 			return nil, cobra.ShellCompDirectiveError
 		}
 
-		names := lo.Map(items, func(item v1.AgentRemoteConfig, _ int) string {
-			return item.Metadata.Name
-		})
-
-		return names, cobra.ShellCompDirectiveNoFileComp
-	}
-}
-
-func agentGroupNameCompletion(
-	options CommandOptions,
-	namespace *string,
-) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
-	return func(cmd *cobra.Command, args []string, _ string) ([]string, cobra.ShellCompDirective) {
-		if len(args) != 0 {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		cli, err := clientutil.NewClient(options.GlobalConfig)
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		items, err := clientutil.ListAgentGroupFully(cmd.Context(), cli, *namespace)
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		names := lo.Map(items, func(item v1.AgentGroup, _ int) string {
-			return item.Metadata.Name
-		})
-
-		return names, cobra.ShellCompDirectiveNoFileComp
-	}
-}
-
-func agentIDCompletion(
-	options CommandOptions,
-	namespace *string,
-) func(*cobra.Command, []string, string) ([]string, cobra.ShellCompDirective) {
-	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
-		if len(args) != 0 {
-			return nil, cobra.ShellCompDirectiveNoFileComp
-		}
-
-		cli, err := clientutil.NewClient(options.GlobalConfig)
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		resp, err := cli.AgentService.SearchAgents(
-			cmd.Context(),
-			*namespace,
-			toComplete,
-			client.WithLimit(MaxCompletionResults),
-		)
-		if err != nil {
-			return nil, cobra.ShellCompDirectiveError
-		}
-
-		instanceUIDs := lo.Map(resp.Items, func(agent v1.Agent, _ int) string {
-			return agent.Metadata.InstanceUID.String()
-		})
-
-		return instanceUIDs, cobra.ShellCompDirectiveNoFileComp
+		return kinds, cobra.ShellCompDirectiveNoFileComp
 	}
 }

--- a/test/integration/restart_test.go
+++ b/test/integration/restart_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/agent"
 	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
 	modelagent "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model/agent"
-	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/port"
 )
@@ -40,7 +39,6 @@ func TestRestartAgentIntegration(t *testing.T) {
 			agentUsecase,
 			agentNotificationUsecase,
 			mockEndpointDetectionUsecase{},
-			stubAgentGroupUsecase{},
 			slog.Default(),
 		)
 
@@ -99,7 +97,6 @@ func TestRestartAgentIntegration(t *testing.T) {
 			agentUsecase,
 			agentNotificationUsecase,
 			mockEndpointDetectionUsecase{},
-			stubAgentGroupUsecase{},
 			slog.Default(),
 		)
 
@@ -215,7 +212,3 @@ func (mockEndpointDetectionUsecase) ExtractEndpointsFromAgent(
 ) ([]*agentmodel.Endpoint, error) {
 	return nil, nil
 }
-
-// stubAgentGroupUsecase is a no-op; these restart tests do not exercise agent-group
-// reconciliation. The embedded interface satisfies the contract.
-type stubAgentGroupUsecase struct{ agentport.AgentGroupUsecase }


### PR DESCRIPTION
## Why

The previous PR (#459) added reconcile for `agent`/`agentgroup`/`agentremoteconfig` as **per-type** usecase methods, HTTP routes, client methods, and CLI subcommands. The ask: make this a **reusable mechanism** so any domain object can re-enforce its invariants on demand ("무언가 꼬였을 때 도메인 규칙을 다시 강제") — future kinds plug in without new transport/CLI code.

## What

A domain **Reconciler registry** with a single generic dispatch surface.

- **`domain/reconcile`** — `Reconciler` interface (`Kind()` + `Reconcile(ctx, ns, name)`) and a `Service` registry that dispatches by kind, returning `ErrUnknownKind` for an unregistered kind (rejects duplicate kinds at construction).
- **`domain/agent/service/reconcilers.go`** — thin adapters wrapping the existing domain reconcile usecases (`agentremoteconfig`, `agentgroup`, `agent`). The agent adapter resolves the instance UID and enforces the namespace (mismatch → `ErrResourceNotExist` → 404; bad UID → `ErrInvalidArgument` → 400).
- **fx group wiring** — `helper.AsReconciler` mirrors `AsRunner`/`AsHealthIndicator`; the registry consumes `group:"reconcilers"`. **Adding a new reconcilable kind = implement `Reconciler` + one `AsReconciler` line.**
- **Single generic surface** (replaces the typed ones):
  - application `ReconcileManageUsecase`
  - `POST /api/v1/namespaces/{ns}/reconcile/{kind}/{name}` and `GET /api/v1/reconcile/kinds`
  - client `ReconcileService`
  - `opampctl reconcile <kind> <name>` (kind shell-completion from the server)

Removes the per-type reconcile methods/routes/CLI/client from #459 and reverts the agent application service's agent-group dependency (no longer needed). The domain reconcile *logic* (`ReconcileAgentRemoteConfig`/`ReconcileAgentGroup`/`ReconcileAgent`) is unchanged — only the dispatch is generalized. Net **−49 lines** despite the new abstraction.

No dependency cycles: the agent-service reconcilers depend on usecases that never depend back on the reconcile registry; verified by a new fast **fx wiring-validation test** (in-memory DB, no lifecycle/network).

## Verification

- `make generate` (swagger + mocks), `go build ./...`, `make lint` (0 issues), `make unittest` (pass)
- New unit tests: registry dispatch / `ErrUnknownKind` / duplicate-kind / sorted `Kinds()`; agent reconciler namespace-mismatch (404) and bad-UID (400); fx wiring validation
- `opampctl reconcile --help` shows the generic command; kinds complete from `GET /reconcile/kinds`

🤖 Generated with [Claude Code](https://claude.com/claude-code)