### PR TITLE
feat(web): add reconcile button to agent, agent group, and remote config

### DIFF
--- a/web/src/features/reconcile/api/reconcile.ts
+++ b/web/src/features/reconcile/api/reconcile.ts
@@ -1,0 +1,15 @@
+import { api } from '@shared/api';
+
+// Reconcilable resource kinds, matching the server's reconcile registry
+// (GET /api/v1/reconcile/kinds). For kind 'agent', `name` is the instance UID.
+export type ReconcileKind = 'agent' | 'agentgroup' | 'agentremoteconfig';
+
+// reconcileResource asks the server to re-run the side effects that normally fire when the
+// named resource is created/updated, re-enforcing its domain rules on demand.
+export function reconcileResource(
+  kind: ReconcileKind,
+  namespace: string,
+  name: string,
+): Promise<void> {
+  return api.post(`/api/v1/namespaces/${namespace}/reconcile/${kind}/${encodeURIComponent(name)}`);
+}

--- a/web/src/features/reconcile/index.ts
+++ b/web/src/features/reconcile/index.ts
@@ -1,0 +1,2 @@
+export { default as ReconcileButton } from './ui/ReconcileButton';
+export { reconcileResource, type ReconcileKind } from './api/reconcile';

--- a/web/src/features/reconcile/ui/ReconcileButton.tsx
+++ b/web/src/features/reconcile/ui/ReconcileButton.tsx
@@ -1,0 +1,70 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { Alert, Button, Snackbar, type ButtonProps } from '@mui/material';
+import { Sync as SyncIcon } from '@mui/icons-material';
+import { reconcileResource, type ReconcileKind } from '../api/reconcile';
+
+interface ReconcileButtonProps {
+  kind: ReconcileKind;
+  namespace: string;
+  /** Resource name, or instance UID when kind is 'agent'. */
+  name: string;
+  label?: string;
+  variant?: ButtonProps['variant'];
+  /** Called after a successful reconcile, e.g. to refresh the view. */
+  onReconciled?: () => void;
+}
+
+type Feedback = { severity: 'success' | 'error'; message: string };
+
+// ReconcileButton triggers an on-demand reconcile of a single resource and reports the
+// outcome via a self-contained snackbar, so it can be dropped into any detail page or list
+// without the host wiring up feedback.
+export default function ReconcileButton({
+  kind,
+  namespace,
+  name,
+  label = 'Reconcile',
+  variant = 'outlined',
+  onReconciled,
+}: ReconcileButtonProps) {
+  const [busy, setBusy] = useState(false);
+  const [feedback, setFeedback] = useState<Feedback | null>(null);
+
+  const run = useCallback(async () => {
+    setBusy(true);
+    try {
+      await reconcileResource(kind, namespace, name);
+      setFeedback({ severity: 'success', message: `Reconciled ${kind} "${name}".` });
+      onReconciled?.();
+    } catch (err) {
+      setFeedback({
+        severity: 'error',
+        message: err instanceof Error ? err.message : `Failed to reconcile ${kind}.`,
+      });
+    } finally {
+      setBusy(false);
+    }
+  }, [kind, namespace, name, onReconciled]);
+
+  return (
+    <>
+      <Button startIcon={<SyncIcon />} variant={variant} onClick={run} disabled={busy}>
+        {label}
+      </Button>
+      <Snackbar
+        open={feedback !== null}
+        autoHideDuration={4000}
+        onClose={() => setFeedback(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      >
+        {feedback === null ? undefined : (
+          <Alert severity={feedback.severity} onClose={() => setFeedback(null)} variant="filled">
+            {feedback.message}
+          </Alert>
+        )}
+      </Snackbar>
+    </>
+  );
+}

--- a/web/src/views/agent-detail/ui/AgentDetailPage.tsx
+++ b/web/src/views/agent-detail/ui/AgentDetailPage.tsx
@@ -26,6 +26,7 @@ import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { Suspense, useCallback, useEffect, useMemo, useState } from 'react';
 import { PageHeader, ConfirmDialog, JsonBlock } from '@shared/ui';
 import { TimeDisplay } from '@shared/preferences';
+import { ReconcileButton } from '@features/reconcile';
 import { useNamespace } from '@entities/namespace';
 import { api, useApi } from '@shared/api';
 import {
@@ -153,6 +154,12 @@ function AgentDetailInner() {
             <Button startIcon={<RestartIcon />} onClick={requestRestart} disabled={restartBusy}>
               Request restart
             </Button>
+            <ReconcileButton
+              kind="agent"
+              namespace={namespace}
+              name={agent.metadata.instanceUid}
+              onReconciled={fetchAgent}
+            />
             {!agent.status.connected && (
               <Button startIcon={<DeleteIcon />} color="error" onClick={() => setDeleteOpen(true)}>
                 Delete

--- a/web/src/views/agent-group-detail/ui/AgentGroupDetailPage.tsx
+++ b/web/src/views/agent-group-detail/ui/AgentGroupDetailPage.tsx
@@ -29,6 +29,7 @@ import { useParams, useRouter, useSearchParams } from 'next/navigation';
 import { Suspense, useEffect, useState } from 'react';
 import { PageHeader, JsonBlock, ConfirmDialog } from '@shared/ui';
 import { TimeDisplay } from '@shared/preferences';
+import { ReconcileButton } from '@features/reconcile';
 import { useNamespace } from '@entities/namespace';
 import { api, useApi } from '@shared/api';
 import type { AgentGroup } from '@entities/agent-group';
@@ -151,6 +152,12 @@ function AgentGroupDetailInner() {
             >
               Apply remote configs
             </Button>
+            <ReconcileButton
+              kind="agentgroup"
+              namespace={namespace}
+              name={group.metadata.name}
+              onReconciled={fetchGroup}
+            />
             <Button startIcon={<EditIcon />} variant="contained" onClick={() => setEditing(true)}>
               Edit
             </Button>

--- a/web/src/views/agent-remote-configs/ui/AgentRemoteConfigsPage.tsx
+++ b/web/src/views/agent-remote-configs/ui/AgentRemoteConfigsPage.tsx
@@ -1,13 +1,14 @@
 'use client';
 
-import { Box } from '@mui/material';
-import { PlaylistAddCheck as ApplyIcon } from '@mui/icons-material';
+import { Alert, Box, Snackbar } from '@mui/material';
+import { PlaylistAddCheck as ApplyIcon, Sync as SyncIcon } from '@mui/icons-material';
 import { useState } from 'react';
 import { useNamespace } from '@entities/namespace';
 import dynamic from 'next/dynamic';
 import { ResourceListPage } from '@widgets/resource-list-page';
 import { TimeDisplay } from '@shared/preferences';
 import { api } from '@shared/api';
+import { reconcileResource } from '@features/reconcile';
 import type { AgentRemoteConfig } from '@entities/agent-remote-config';
 
 // Lazy-loaded: heavy dialogs (JSON editor pulls in js-yaml, ApplyToGroup pulls
@@ -29,9 +30,28 @@ function emptyConfig(namespace: string): AgentRemoteConfig {
   };
 }
 
+type ReconcileFeedback = { severity: 'success' | 'error'; message: string };
+
 export default function AgentRemoteConfigsPage() {
   const { namespace } = useNamespace();
   const [applyTarget, setApplyTarget] = useState<AgentRemoteConfig | null>(null);
+  const [reconcileFeedback, setReconcileFeedback] = useState<ReconcileFeedback | null>(null);
+
+  const reconcileConfig = async (c: AgentRemoteConfig) => {
+    try {
+      await reconcileResource('agentremoteconfig', namespace, c.metadata.name);
+      setReconcileFeedback({
+        severity: 'success',
+        message: `Reconciled "${c.metadata.name}": detected endpoints and re-propagated to groups.`,
+      });
+    } catch (err) {
+      setReconcileFeedback({
+        severity: 'error',
+        message: err instanceof Error ? err.message : `Failed to reconcile "${c.metadata.name}".`,
+      });
+    }
+  };
+
   return (
     <Box>
       <ResourceListPage<AgentRemoteConfig>
@@ -48,6 +68,11 @@ export default function AgentRemoteConfigsPage() {
             label: 'Apply to agent group',
             icon: <ApplyIcon fontSize="small" />,
             onClick: () => setApplyTarget(c),
+          },
+          {
+            label: 'Reconcile',
+            icon: <SyncIcon fontSize="small" />,
+            onClick: () => void reconcileConfig(c),
           },
         ]}
         columns={[
@@ -109,6 +134,22 @@ export default function AgentRemoteConfigsPage() {
           onApplied={() => setApplyTarget(null)}
         />
       )}
+      <Snackbar
+        open={reconcileFeedback !== null}
+        autoHideDuration={4000}
+        onClose={() => setReconcileFeedback(null)}
+        anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+      >
+        {reconcileFeedback === null ? undefined : (
+          <Alert
+            severity={reconcileFeedback.severity}
+            onClose={() => setReconcileFeedback(null)}
+            variant="filled"
+          >
+            {reconcileFeedback.message}
+          </Alert>
+        )}
+      </Snackbar>
     </Box>
   );
 }


### PR DESCRIPTION
## Why

The generic reconcile mechanism (#461) is now in the API/CLI but not the dashboard. Surface it so operators can re-enforce a resource's domain rules from the UI when something drifts — no `opampctl` needed.

## What

A reusable **`features/reconcile`** slice (FSD):

- **`ReconcileButton`** — a self-contained button that `POST`s to `/api/v1/namespaces/{ns}/reconcile/{kind}/{name}` and reports the outcome via its own snackbar, so it drops into any page without the host wiring up feedback. Calls `onReconciled` on success to refresh the view.
- **`reconcileResource(kind, namespace, name)`** — the data-access helper (also usable from list row actions).

Placed on:
- **Agent detail** — `kind=agent` (name = instance UID), next to *Request restart*.
- **Agent group detail** — `kind=agentgroup`, next to *Apply remote configs*.
- **Agent remote configs list** — a *Reconcile* row action (`kind=agentremoteconfig`) with a page-level snackbar.

## Verification

Per `web/`'s required checks:
- `npx tsc --noEmit` ✅
- `npm run lint` ✅ (FSD downward deps: views → features → shared)
- `npm test` ✅ (64 tests)
- `npm run build` ✅ (compiled successfully)

Depends on the reconcile endpoints from #461 (already merged to main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)