### PR TITLE
feat(agent): add optimistic concurrency to agent writes (#465)

### DIFF
--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/agent.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/agent.go
@@ -43,8 +43,26 @@ func (r *AgentRepository) GetAgent(_ context.Context, instanceUID uuid.UUID) (*a
 }
 
 // PutAgent implements agentport.AgentPersistencePort.
+//
+// Like the MongoDB adapter, this is an optimistic-concurrency write: it succeeds
+// only if the stored agent's ResourceVersion still equals the version the passed
+// agent was loaded with, otherwise it returns [port.ErrConflict]. On success the
+// version is incremented and written back onto the passed agent.
 func (r *AgentRepository) PutAgent(_ context.Context, agent *agentmodel.Agent) error {
-	r.store.put(agent.Metadata.InstanceUID, agent)
+	expected := agent.Metadata.ResourceVersion
+	next := expected + 1
+
+	toStore := agent.Clone()
+	toStore.Metadata.ResourceVersion = next
+
+	err := r.store.casPut(agent.Metadata.InstanceUID, toStore, expected, func(a *agentmodel.Agent) int64 {
+		return a.Metadata.ResourceVersion
+	})
+	if err != nil {
+		return err
+	}
+
+	agent.Metadata.ResourceVersion = next
 
 	return nil
 }

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/common.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/common.go
@@ -19,6 +19,12 @@ func errResourceNotExist() error {
 	return port.ErrResourceNotExist
 }
 
+// errConflict returns the shared optimistic-concurrency error so the in-memory
+// store rejects stale writes exactly like the MongoDB adapter's version check.
+func errConflict() error {
+	return port.ErrConflict
+}
+
 // matchesSelector reports whether the agent satisfies every identifying and
 // non-identifying attribute in the selector. An empty selector matches all
 // agents, mirroring the MongoDB selector-to-filter behaviour.

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/inmemory_test.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/inmemory_test.go
@@ -417,3 +417,72 @@ func TestTransactionRunner_RunsCallback(t *testing.T) {
 	})
 	require.ErrorIs(t, err, errSentinel)
 }
+
+func TestAgentRepository_PutAgentBumpsResourceVersion(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo := inmemory.NewAgentRepository()
+	uid := uuid.New()
+	agent := agentmodel.NewAgent(uid)
+
+	// A freshly created agent starts at version 0; the first write inserts it as v1.
+	assert.Equal(t, int64(0), agent.Metadata.ResourceVersion)
+	require.NoError(t, repo.PutAgent(ctx, agent))
+	assert.Equal(t, int64(1), agent.Metadata.ResourceVersion, "PutAgent must bump the caller's version")
+
+	got, err := repo.GetAgent(ctx, uid)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), got.Metadata.ResourceVersion)
+
+	// A read-modify-write cycle advances the version again.
+	got.Metadata.Namespace = "ns-x"
+	require.NoError(t, repo.PutAgent(ctx, got))
+	assert.Equal(t, int64(2), got.Metadata.ResourceVersion)
+}
+
+func TestAgentRepository_PutAgentConflictOnStaleVersion(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo := inmemory.NewAgentRepository()
+	uid := uuid.New()
+
+	first := agentmodel.NewAgent(uid)
+	require.NoError(t, repo.PutAgent(ctx, first)) // stored at v1
+
+	// Two writers load the same v1 snapshot.
+	loadA, err := repo.GetAgent(ctx, uid)
+	require.NoError(t, err)
+	loadB, err := repo.GetAgent(ctx, uid)
+	require.NoError(t, err)
+
+	// Writer A wins, advancing the stored version to v2.
+	loadA.Metadata.Namespace = "from-a"
+	require.NoError(t, repo.PutAgent(ctx, loadA))
+
+	// Writer B still holds v1, so its write is rejected instead of clobbering A.
+	loadB.Metadata.Namespace = "from-b"
+	require.ErrorIs(t, repo.PutAgent(ctx, loadB), port.ErrConflict)
+
+	stored, err := repo.GetAgent(ctx, uid)
+	require.NoError(t, err)
+	assert.Equal(t, "from-a", stored.Metadata.Namespace, "the losing writer must not overwrite the winner")
+	assert.Equal(t, int64(2), stored.Metadata.ResourceVersion)
+}
+
+func TestAgentRepository_PutAgentConflictOnConcurrentCreate(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo := inmemory.NewAgentRepository()
+	uid := uuid.New()
+
+	// Two nodes independently GetOrCreate the same not-yet-persisted agent (both v0).
+	createA := agentmodel.NewAgent(uid)
+	createB := agentmodel.NewAgent(uid)
+
+	require.NoError(t, repo.PutAgent(ctx, createA))
+	// The second create-as-v0 must conflict rather than insert a duplicate.
+	require.ErrorIs(t, repo.PutAgent(ctx, createB), port.ErrConflict)
+}

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/store.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/store.go
@@ -117,6 +117,38 @@ func (s *store[K, V]) put(key K, value V) {
 	s.nextSeq++
 }
 
+// casPut is an optimistic-concurrency variant of put: it stores value only if the
+// currently stored value's version (as reported by versionOf) equals expected. An
+// expected of 0 means the key must not already exist (a create). On a version
+// mismatch — or an existing key when expected is 0 — it returns
+// [port.ErrConflict] without mutating the store, mirroring the MongoDB adapter's
+// versioned ReplaceOne. value is deep-copied on store, like put.
+func (s *store[K, V]) casPut(key K, value V, expected int64, versionOf func(V) int64) error {
+	stored := s.clone(value)
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if existing, ok := s.items[key]; ok {
+		if versionOf(existing.value) != expected {
+			return errConflict()
+		}
+
+		existing.value = stored
+
+		return nil
+	}
+
+	if expected != 0 {
+		return errConflict()
+	}
+
+	s.items[key] = &item[V]{seq: s.nextSeq, value: stored}
+	s.nextSeq++
+
+	return nil
+}
+
 // delete permanently removes key (hard delete). It returns
 // [port.ErrResourceNotExist] when the key is absent.
 func (s *store[K, V]) delete(key K) error {

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/agent.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/agent.go
@@ -510,22 +510,9 @@ func (a *AgentRepository) ensureIndexes(ctx context.Context) {
 		a.logger.Warn("failed to create index for instanceUidString", slog.String("error", err.Error()))
 	}
 
-	// Unique index on the logical key. Besides preventing duplicate agent documents,
-	// it is what makes PutAgent's optimistic-concurrency create path correct: a racing
-	// insert for an already-existing instanceUid is rejected as a duplicate key (mapped
-	// to port.ErrConflict) instead of silently producing a second document.
-	//exhaustruct:ignore
-	uniqueKeyIndex := mongo.IndexModel{
-		Keys: bson.D{
-			{Key: entity.AgentKeyFieldName, Value: 1},
-		},
-		Options: options.Index().SetUnique(true),
-	}
-
-	_, err = a.collection.Indexes().CreateOne(ctx, uniqueKeyIndex)
-	if err != nil {
-		a.logger.Warn("failed to create unique index for instanceUid", slog.String("error", err.Error()))
-	}
+	// The unique index on metadata.instanceUid — which PutAgent's optimistic-concurrency
+	// create path relies on — is owned by the centralized EnsureSchema (mongodb.go) so it
+	// is not declared twice with conflicting options.
 }
 
 // prefixUpperBound returns the exclusive upper bound for a prefix range scan: the

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/agent.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/agent.go
@@ -12,11 +12,17 @@ import (
 	"github.com/samber/lo"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/secondary/persistence/mongodb/entity"
 	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/model"
 	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/port"
+)
+
+const (
+	resourceVersionFieldName = "metadata.resourceVersion"
 )
 
 var (
@@ -119,13 +125,48 @@ func (a *AgentRepository) ListAgents(
 }
 
 // PutAgent implements agentport.AgentPersistencePort.
+//
+// PutAgent is an optimistic-concurrency write: it only succeeds when the stored
+// document's resourceVersion still equals the version the in-memory agent was
+// loaded with (agent.Metadata.ResourceVersion). On success the stored version is
+// incremented and the increment is written back onto the passed agent, so the
+// caller — and any cache that clones it afterwards — holds the new version. A
+// concurrent writer that already advanced the version (another HA node, the
+// reconcile loop, a racing API call) makes this return [port.ErrConflict] instead
+// of silently clobbering that writer's change.
+//
+// The create case (expected version 0) relies on the unique index on
+// metadata.instanceUid: if the agent already exists, the version filter misses and
+// the upsert attempts an insert that the unique index rejects as a duplicate key,
+// which is surfaced as a conflict rather than a duplicate document.
 func (a *AgentRepository) PutAgent(ctx context.Context, agent *agentmodel.Agent) error {
-	entity := entity.AgentFromDomain(agent)
+	expected := agent.Metadata.ResourceVersion
+	next := expected + 1
 
-	err := a.common.put(ctx, entity)
+	doc := entity.AgentFromDomain(agent)
+	doc.Metadata.ResourceVersion = next
+
+	filter := bson.M{
+		entity.AgentKeyFieldName: a.common.KeyQueryFunc(agent.Metadata.InstanceUID),
+		resourceVersionFieldName: expected,
+	}
+
+	result, err := a.collection.ReplaceOne(ctx, filter, doc, options.Replace().SetUpsert(expected == 0))
 	if err != nil {
+		if mongo.IsDuplicateKeyError(err) {
+			return fmt.Errorf("%w: agent %s was created concurrently", port.ErrConflict, agent.Metadata.InstanceUID)
+		}
+
 		return fmt.Errorf("failed to put agent to persistence: %w", err)
 	}
+
+	// No matched (and not freshly upserted) document means the version filter did not
+	// find the expected version — another writer advanced it (or deleted the agent).
+	if result.MatchedCount == 0 && result.UpsertedCount == 0 {
+		return fmt.Errorf("%w: agent %s was modified concurrently", port.ErrConflict, agent.Metadata.InstanceUID)
+	}
+
+	agent.Metadata.ResourceVersion = next
 
 	return nil
 }
@@ -458,15 +499,32 @@ func (a *AgentRepository) countAgents(ctx context.Context, filter bson.M) (int64
 // ensureIndexes creates necessary indexes for the agent collection.
 func (a *AgentRepository) ensureIndexes(ctx context.Context) {
 	//exhaustruct:ignore
-	indexModel := mongo.IndexModel{
+	searchIndex := mongo.IndexModel{
 		Keys: bson.D{
 			{Key: "metadata.instanceUidString", Value: 1},
 		},
 	}
 
-	_, err := a.collection.Indexes().CreateOne(ctx, indexModel)
+	_, err := a.collection.Indexes().CreateOne(ctx, searchIndex)
 	if err != nil {
 		a.logger.Warn("failed to create index for instanceUidString", slog.String("error", err.Error()))
+	}
+
+	// Unique index on the logical key. Besides preventing duplicate agent documents,
+	// it is what makes PutAgent's optimistic-concurrency create path correct: a racing
+	// insert for an already-existing instanceUid is rejected as a duplicate key (mapped
+	// to port.ErrConflict) instead of silently producing a second document.
+	//exhaustruct:ignore
+	uniqueKeyIndex := mongo.IndexModel{
+		Keys: bson.D{
+			{Key: entity.AgentKeyFieldName, Value: 1},
+		},
+		Options: options.Index().SetUnique(true),
+	}
+
+	_, err = a.collection.Indexes().CreateOne(ctx, uniqueKeyIndex)
+	if err != nil {
+		a.logger.Warn("failed to create unique index for instanceUid", slog.String("error", err.Error()))
 	}
 }
 

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/agent_test.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/agent_test.go
@@ -1455,3 +1455,75 @@ func TestAgentMongoAdapter_SearchAgents(t *testing.T) {
 		assert.Empty(t, listResponse.Items) // No agent has literal "1234.*" in UUID
 	})
 }
+
+func TestAgentMongoAdapter_OptimisticConcurrency(t *testing.T) {
+	testcontainers.SkipIfProviderIsNotHealthy(t)
+	t.Parallel()
+	base := testutil.NewBase(t)
+	ctx := t.Context()
+	mongoDBContainer, err := mongoTestContainer.Run(
+		ctx,
+		testMongoDBImage,
+	)
+	require.NoError(t, err)
+
+	mongoDBURI, err := mongoDBContainer.ConnectionString(ctx)
+	require.NoError(t, err)
+
+	client, err := mongo.Connect(options.Client().ApplyURI(mongoDBURI))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		err := client.Disconnect(ctx)
+		require.NoError(t, err)
+	})
+
+	database := client.Database("testdb")
+	agentRepository := mongodb.NewAgentRepository(database, base.Logger)
+
+	t.Run("first put inserts at version 1 and bumps the caller", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		newAgent := agentmodel.NewAgent(uuid.New())
+		require.Equal(t, int64(0), newAgent.Metadata.ResourceVersion)
+
+		require.NoError(t, agentRepository.PutAgent(ctx, newAgent))
+		assert.Equal(t, int64(1), newAgent.Metadata.ResourceVersion)
+
+		got, err := agentRepository.GetAgent(ctx, newAgent.Metadata.InstanceUID)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), got.Metadata.ResourceVersion)
+	})
+
+	t.Run("stale write loses to the concurrent winner", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		uid := uuid.New()
+		require.NoError(t, agentRepository.PutAgent(ctx, agentmodel.NewAgent(uid)))
+
+		loadA, err := agentRepository.GetAgent(ctx, uid)
+		require.NoError(t, err)
+		loadB, err := agentRepository.GetAgent(ctx, uid)
+		require.NoError(t, err)
+
+		loadA.Metadata.Namespace = "from-a"
+		require.NoError(t, agentRepository.PutAgent(ctx, loadA))
+
+		loadB.Metadata.Namespace = "from-b"
+		require.ErrorIs(t, agentRepository.PutAgent(ctx, loadB), port.ErrConflict)
+
+		stored, err := agentRepository.GetAgent(ctx, uid)
+		require.NoError(t, err)
+		assert.Equal(t, "from-a", stored.Metadata.Namespace)
+		assert.Equal(t, int64(2), stored.Metadata.ResourceVersion)
+	})
+
+	t.Run("concurrent create conflicts via the unique key", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		uid := uuid.New()
+
+		require.NoError(t, agentRepository.PutAgent(ctx, agentmodel.NewAgent(uid)))
+		// A second create-as-v0 for the same instanceUid must conflict, not duplicate.
+		require.ErrorIs(t, agentRepository.PutAgent(ctx, agentmodel.NewAgent(uid)), port.ErrConflict)
+	})
+}

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/agent_test.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/agent_test.go
@@ -1478,6 +1478,10 @@ func TestAgentMongoAdapter_OptimisticConcurrency(t *testing.T) {
 	})
 
 	database := client.Database("testdb")
+	// The concurrent-create conflict relies on the unique index on metadata.instanceUid,
+	// which is owned by EnsureSchema rather than the repository constructor.
+	require.NoError(t, mongodb.EnsureSchema(ctx, database))
+
 	agentRepository := mongodb.NewAgentRepository(database, base.Logger)
 
 	t.Run("first put inserts at version 1 and bumps the caller", func(t *testing.T) {

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/entity/agent.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/entity/agent.go
@@ -38,6 +38,7 @@ type AgentMetadata struct {
 	InstanceUID        bson.Binary              `bson:"instanceUid"`
 	InstanceUIDString  string                   `bson:"instanceUidString"` // String representation for searching
 	Namespace          string                   `bson:"namespace"`
+	ResourceVersion    int64                    `bson:"resourceVersion"` // Optimistic-concurrency token
 	Capabilities       *AgentCapabilities       `bson:"capabilities,omitempty"`
 	Description        *AgentDescription        `bson:"description,omitempty"`
 	CustomCapabilities *AgentCustomCapabilities `bson:"customCapabilities,omitempty"`
@@ -238,8 +239,9 @@ func (a *Agent) ToDomain() *agentmodel.Agent {
 // ToDmain converts the AgentMetadata to domain model.
 func (metadata *AgentMetadata) ToDmain() agentmodel.AgentMetadata {
 	return agentmodel.AgentMetadata{
-		InstanceUID: uuid.UUID(metadata.InstanceUID.Data),
-		Namespace:   metadata.Namespace,
+		InstanceUID:     uuid.UUID(metadata.InstanceUID.Data),
+		Namespace:       metadata.Namespace,
+		ResourceVersion: metadata.ResourceVersion,
 		//exhaustruct:ignore
 		Description:  mo.PointerToOption(metadata.Description.ToDomain()).OrElse(agent.Description{}),
 		Capabilities: mo.PointerToOption(metadata.Capabilities.ToDomain()).OrElse(agent.Capabilities(0)),
@@ -532,6 +534,7 @@ func AgentFromDomain(agent *agentmodel.Agent) *Agent {
 			},
 			InstanceUIDString:  agent.Metadata.InstanceUID.String(),
 			Namespace:          agent.Metadata.Namespace,
+			ResourceVersion:    agent.Metadata.ResourceVersion,
 			Capabilities:       AgentCapabilitiesFromDomain(&agent.Metadata.Capabilities),
 			Description:        AgentDescriptionFromDomain(&agent.Metadata.Description),
 			CustomCapabilities: AgentCustomCapabilitiesFromDomain(&agent.Metadata.CustomCapabilities),

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/mongodb.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/mongodb.go
@@ -55,11 +55,16 @@ var (
 		{
 			collectionName: agentCollectionName,
 			indexes: []mongo.IndexModel{
+				// Unique on the logical key. Besides preventing duplicate agent
+				// documents, this is what makes PutAgent's optimistic-concurrency
+				// create path correct: a racing insert for an existing instanceUid is
+				// rejected as a duplicate key (mapped to port.ErrConflict) instead of
+				// producing a second document.
 				{
 					Keys: bson.D{
 						{Key: "metadata.instanceUid", Value: 1},
 					},
-					Options: nil,
+					Options: options.Index().SetUnique(true),
 				},
 				{
 					Keys: bson.D{

--- a/pkg/apiserver/domain/agent/model/agent.go
+++ b/pkg/apiserver/domain/agent/model/agent.go
@@ -307,6 +307,15 @@ type AgentMetadata struct {
 	// Defaults to "default" if not specified.
 	Namespace string
 
+	// ResourceVersion is an optimistic-concurrency token. It is 0 for an agent that
+	// has never been persisted and is incremented by the persistence layer on every
+	// successful write. A write only succeeds if the stored version still equals the
+	// version this in-memory copy was loaded with; otherwise the persistence layer
+	// returns port.ErrConflict so a concurrent writer (another HA node, the reconcile
+	// loop, an API call) cannot be silently clobbered. Callers must not set this by
+	// hand — load via GetAgent, mutate, then SaveAgent.
+	ResourceVersion int64
+
 	// Description is a agent description defined in the opamp protocol.
 	// It is set by the agent and should not change between restarts of the agent.
 	// It can be changed by the agent at any time.
@@ -1273,10 +1282,11 @@ func (a *Agent) Clone() *Agent {
 
 func (a *Agent) cloneMetadata() AgentMetadata {
 	metadata := AgentMetadata{
-		InstanceUID:  a.Metadata.InstanceUID,
-		Namespace:    a.Metadata.Namespace,
-		Description:  a.cloneDescription(),
-		Capabilities: a.Metadata.Capabilities,
+		InstanceUID:     a.Metadata.InstanceUID,
+		Namespace:       a.Metadata.Namespace,
+		ResourceVersion: a.Metadata.ResourceVersion,
+		Description:     a.cloneDescription(),
+		Capabilities:    a.Metadata.Capabilities,
 		CustomCapabilities: AgentCustomCapabilities{
 			Capabilities: cloneStringSlice(a.Metadata.CustomCapabilities.Capabilities),
 		},

--- a/pkg/apiserver/domain/agent/service/agent.go
+++ b/pkg/apiserver/domain/agent/service/agent.go
@@ -175,14 +175,29 @@ func (s *AgentService) GetOrCreateAgent(ctx context.Context, instanceUID uuid.UU
 	return agent, nil
 }
 
-// SaveAgent saves the agent to the persistence layer.
+// SaveAgent saves the agent to the persistence layer with optimistic concurrency:
+// the write is rejected with [port.ErrConflict] when another writer (another HA
+// node, the reconcile loop, a racing API call) modified the agent since it was
+// loaded, rather than silently clobbering that change.
+//
+// On conflict the cached copy is invalidated so the next read goes to persistence
+// and observes the winning writer's version. Without this the owning server would
+// keep re-reading its own stale cached version and conflict on every retry until
+// the cache entry expired. The caller is expected to re-read and retry (or, for the
+// heartbeat path, simply let the next message re-report the state).
 func (s *AgentService) SaveAgent(ctx context.Context, agent *agentmodel.Agent) error {
 	err := s.agentPersistencePort.PutAgent(ctx, agent)
 	if err != nil {
+		if errors.Is(err, port.ErrConflict) {
+			s.InvalidateCache(agent.Metadata.InstanceUID)
+		}
+
 		return fmt.Errorf("failed to save agent to persistence: %w", err)
 	}
 
-	// Cache a clone to prevent external mutations from affecting cache
+	// Cache a clone to prevent external mutations from affecting cache. PutAgent has
+	// bumped agent.Metadata.ResourceVersion on success, so the cached clone carries
+	// the new version and the next SaveAgent from this process uses the right token.
 	if s.cacheEnabled {
 		s.agentCache.Set(agent.Metadata.InstanceUID, agent.Clone(), ttlcache.DefaultTTL)
 	}

--- a/pkg/apiserver/domain/port/port.go
+++ b/pkg/apiserver/domain/port/port.go
@@ -13,4 +13,9 @@ var (
 	// ErrResourceAlreadyExist indicates a create was attempted for a resource that
 	// already exists; it maps to HTTP 409.
 	ErrResourceAlreadyExist = errors.New("resource already exists")
+	// ErrConflict indicates an optimistic-concurrency conflict: the resource was
+	// modified by another writer since it was loaded, so the write was rejected to
+	// avoid clobbering that change. The caller should re-read and retry. It maps to
+	// HTTP 409.
+	ErrConflict = errors.New("resource version conflict")
 )

--- a/pkg/apiserver/ginutil/errormiddleware.go
+++ b/pkg/apiserver/ginutil/errormiddleware.go
@@ -94,6 +94,12 @@ func HandleDomainError(ctx *gin.Context, err error, fallbackMessage string) {
 		return
 	}
 
+	if errors.Is(err, port.ErrConflict) {
+		ConflictError(ctx, err, "The resource was modified concurrently; reload and retry.")
+
+		return
+	}
+
 	if errors.Is(err, port.ErrInvalidArgument) {
 		ctx.JSON(http.StatusBadRequest, &api.ErrorModel{
 			Type:     baseURL,


### PR DESCRIPTION
Closes #465.

## Problem
Agent persistence used a full-document `ReplaceOne(upsert)` with **no version guard**, so every write was last-writer-wins. In HA, concurrent writers — another apiserver node, the 5-minute reconcile loop, or a racing API call — silently clobbered each other's changes (e.g. a heartbeat write overwriting a just-applied remote-config command).

## Change
Introduce a `resourceVersion` compare-and-swap on the agent write path.

- **Domain/entity:** `AgentMetadata.ResourceVersion` (0 = never persisted), incremented by the persistence layer on each successful write and written back onto the caller's copy so the cache clone carries the new token.
- **MongoDB `PutAgent`:** versioned `ReplaceOne` filtered on the loaded version; a mismatch returns `port.ErrConflict` instead of overwriting. A new **unique index on `metadata.instanceUid`** makes the create path correct — a racing insert for an existing agent is rejected as a duplicate key (mapped to conflict) rather than producing a second document.
- **In-memory store:** atomic `casPut` mirrors the same semantics for standalone mode and tests.
- **`AgentService.SaveAgent`:** invalidates the cache on conflict so the owning server re-reads the winner's version instead of looping on its own stale cached copy until the 30s TTL.
- **HTTP:** `ErrConflict` → 409.

## Behavior change
Writes that previously lost silently now either:
- return **409** (API callers retry), or
- **log-and-skip** (heartbeat path — self-heals because the next message re-reports state, and the cache was invalidated).

## Out of scope (follow-up)
Automatic retry for internal read-modify-write paths (reconcile / agent-group propagation) is intentionally deferred; today those converge on the next reconcile cycle. Best handled together with leader-only reconcile (#467). Other low-write admin resources (user/role/namespace) are not versioned here.

## Tests
- In-memory: version bump, stale-write conflict (winner preserved), concurrent-create conflict — passing.
- MongoDB: same scenarios via testcontainers (skipped locally without Docker; runs in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)