### PR TITLE
feat(reconcile): run the agent-group reconcile loop on the leader only (#467)

### DIFF
--- a/pkg/apiserver/domain/agent/port/in.go
+++ b/pkg/apiserver/domain/agent/port/in.go
@@ -280,6 +280,16 @@ type ServerIdentityProvider interface {
 	CurrentServerID() string
 }
 
+// LeaderElector decides whether this server instance is the elected leader for
+// cluster-singleton background work (currently the periodic agent-group reconcile),
+// so that an N-node deployment runs such work once per interval instead of N times.
+type LeaderElector interface {
+	// IsLeader reports whether the current server is the leader. Callers should fail
+	// open (run the work) when this returns an error, so a transient inability to
+	// determine leadership never strands singleton work.
+	IsLeader(ctx context.Context) (bool, error)
+}
+
 // ServerMessageUsecase is an interface that defines the methods for server message use cases.
 type ServerMessageUsecase interface {
 	// SendMessageToServerByServerID sends a message to the specified server.

--- a/pkg/apiserver/domain/agent/service/agentgroup.go
+++ b/pkg/apiserver/domain/agent/service/agentgroup.go
@@ -59,6 +59,9 @@ type AgentGroupService struct {
 	// other domain usecases
 	agentUsecase agentport.AgentUsecase
 
+	// leaderElector gates the periodic reconcile loop so only one node runs it.
+	leaderElector agentport.LeaderElector
+
 	// internalStatus
 	changedAgentGroupCh chan *agentmodel.AgentGroup
 
@@ -73,6 +76,7 @@ func NewAgentGroupService(
 	agentRemoteConfigPersistencePort agentport.AgentRemoteConfigPersistencePort,
 	certificatePersistencePort agentport.CertificatePersistencePort,
 	agentUsecase agentport.AgentUsecase,
+	leaderElector agentport.LeaderElector,
 	logger *slog.Logger,
 ) *AgentGroupService {
 	return &AgentGroupService{
@@ -80,6 +84,7 @@ func NewAgentGroupService(
 		remoteConfigPersistencePort: agentRemoteConfigPersistencePort,
 		certificatePersistencePort:  certificatePersistencePort,
 		agentUsecase:                agentUsecase,
+		leaderElector:               leaderElector,
 		clock:                       clock.NewRealClock(),
 		logger:                      logger,
 		changedAgentGroupCh:         make(chan *agentmodel.AgentGroup, ChangedAgentGroupBufferSize),
@@ -472,7 +477,7 @@ func setAgentRemoteConfigs(agent *agentmodel.Agent, configs map[string]agentmode
 }
 
 func (s *AgentGroupService) runReconcileLoop(ctx context.Context) {
-	s.reconcileAll(ctx)
+	s.reconcileAllIfLeader(ctx)
 
 	ticker := time.NewTicker(DefaultReconcileInterval)
 	defer ticker.Stop()
@@ -482,9 +487,35 @@ func (s *AgentGroupService) runReconcileLoop(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
-			s.reconcileAll(ctx)
+			s.reconcileAllIfLeader(ctx)
 		}
 	}
+}
+
+// reconcileAllIfLeader runs the full reconcile pass only when this node is the elected
+// leader, so an N-node deployment performs one reconcile per interval instead of N
+// concurrent full scans (and the write contention they cause). The event-driven path
+// (changedAgentGroupCh) is deliberately not gated: it must run on whichever node served
+// the change so propagation stays immediate.
+//
+// Leader determination fails open: if the elector errors, this node reconciles anyway
+// so a transient server-registry read error cannot strand reconciliation cluster-wide.
+func (s *AgentGroupService) reconcileAllIfLeader(ctx context.Context) {
+	isLeader, err := s.leaderElector.IsLeader(ctx)
+	if err != nil {
+		s.logger.Warn("reconcile loop: leader election failed, reconciling anyway",
+			slog.String("error", err.Error()))
+
+		isLeader = true
+	}
+
+	if !isLeader {
+		s.logger.Debug("reconcile loop: not the leader, skipping periodic reconcile")
+
+		return
+	}
+
+	s.reconcileAll(ctx)
 }
 
 func (s *AgentGroupService) propagateAgentGroupChangesToAgents(

--- a/pkg/apiserver/domain/agent/service/agentgroup_internal_test.go
+++ b/pkg/apiserver/domain/agent/service/agentgroup_internal_test.go
@@ -310,7 +310,9 @@ func TestResolveRemoteConfig_RefMode(t *testing.T) {
 		logger := slog.Default()
 
 		mockCertPort := new(mockCertPersistence)
-		svc := NewAgentGroupService(mockPersistence, mockRemoteConfigPort, mockCertPort, mockAgentUC, logger)
+		svc := NewAgentGroupService(
+			mockPersistence, mockRemoteConfigPort, mockCertPort,
+			mockAgentUC, alwaysLeaderElector{}, logger)
 
 		refName := "shared-otel-config"
 		referencedConfig := &agentmodel.AgentRemoteConfig{
@@ -349,7 +351,9 @@ func TestResolveRemoteConfig_RefMode(t *testing.T) {
 		logger := slog.Default()
 
 		mockCertPort := new(mockCertPersistence)
-		svc := NewAgentGroupService(mockPersistence, mockRemoteConfigPort, mockCertPort, mockAgentUC, logger)
+		svc := NewAgentGroupService(
+			mockPersistence, mockRemoteConfigPort, mockCertPort,
+			mockAgentUC, alwaysLeaderElector{}, logger)
 
 		refName := "non-existent-config"
 		mockRemoteConfigPort.On("GetAgentRemoteConfig", ctx, "", refName, (*model.GetOptions)(nil)).
@@ -380,7 +384,9 @@ func TestResolveRemoteConfig_DirectMode(t *testing.T) {
 		logger := slog.Default()
 
 		mockCertPort := new(mockCertPersistence)
-		svc := NewAgentGroupService(mockPersistence, mockRemoteConfigPort, mockCertPort, mockAgentUC, logger)
+		svc := NewAgentGroupService(
+			mockPersistence, mockRemoteConfigPort, mockCertPort,
+			mockAgentUC, alwaysLeaderElector{}, logger)
 
 		configName := "collector-config"
 		configValue := []byte("exporters:\n  debug:\n    verbosity: detailed")
@@ -413,7 +419,9 @@ func TestResolveRemoteConfig_DirectMode(t *testing.T) {
 		logger := slog.Default()
 
 		mockCertPort := new(mockCertPersistence)
-		svc := NewAgentGroupService(mockPersistence, mockRemoteConfigPort, mockCertPort, mockAgentUC, logger)
+		svc := NewAgentGroupService(
+			mockPersistence, mockRemoteConfigPort, mockCertPort,
+			mockAgentUC, alwaysLeaderElector{}, logger)
 
 		configName := "missing-spec-config"
 		remoteConfig := agentmodel.AgentGroupAgentRemoteConfig{
@@ -437,7 +445,9 @@ func TestResolveRemoteConfig_DirectMode(t *testing.T) {
 		logger := slog.Default()
 
 		mockCertPort := new(mockCertPersistence)
-		svc := NewAgentGroupService(mockPersistence, mockRemoteConfigPort, mockCertPort, mockAgentUC, logger)
+		svc := NewAgentGroupService(
+			mockPersistence, mockRemoteConfigPort, mockCertPort,
+			mockAgentUC, alwaysLeaderElector{}, logger)
 
 		remoteConfig := agentmodel.AgentGroupAgentRemoteConfig{
 			AgentRemoteConfigName: nil, // Missing name
@@ -467,7 +477,9 @@ func TestApplyRemoteConfigs(t *testing.T) {
 		logger := slog.Default()
 
 		mockCertPort := new(mockCertPersistence)
-		svc := NewAgentGroupService(mockPersistence, mockRemoteConfigPort, mockCertPort, mockAgentUC, logger)
+		svc := NewAgentGroupService(
+			mockPersistence, mockRemoteConfigPort, mockCertPort,
+			mockAgentUC, alwaysLeaderElector{}, logger)
 
 		testAgent := agentmodel.NewAgent(uuid.New(), agentmodel.WithDescription(&agent.Description{
 			IdentifyingAttributes: map[string]string{"service.name": "test"},
@@ -516,7 +528,9 @@ func TestApplyRemoteConfigs(t *testing.T) {
 		logger := slog.Default()
 
 		mockCertPort := new(mockCertPersistence)
-		svc := NewAgentGroupService(mockPersistence, mockRemoteConfigPort, mockCertPort, mockAgentUC, logger)
+		svc := NewAgentGroupService(
+			mockPersistence, mockRemoteConfigPort, mockCertPort,
+			mockAgentUC, alwaysLeaderElector{}, logger)
 
 		testAgent := agentmodel.NewAgent(uuid.New(), agentmodel.WithDescription(&agent.Description{
 			IdentifyingAttributes: map[string]string{"service.name": "test"},
@@ -565,7 +579,9 @@ func TestNameCollisionPrevention(t *testing.T) {
 		logger := slog.Default()
 
 		mockCertPort := new(mockCertPersistence)
-		svc := NewAgentGroupService(mockPersistence, mockRemoteConfigPort, mockCertPort, mockAgentUC, logger)
+		svc := NewAgentGroupService(
+			mockPersistence, mockRemoteConfigPort, mockCertPort,
+			mockAgentUC, alwaysLeaderElector{}, logger)
 
 		// Create agent
 		testAgent := agentmodel.NewAgent(uuid.New(), agentmodel.WithDescription(&agent.Description{
@@ -640,6 +656,7 @@ func TestRecordRemoteConfigCondition(t *testing.T) {
 			new(mockRemoteConfigPersistence),
 			new(mockCertPersistence),
 			new(mockAgentUsecase),
+			alwaysLeaderElector{},
 			slog.Default(),
 		)
 
@@ -782,6 +799,7 @@ func TestRecordAgentRemoteConfigCondition(t *testing.T) {
 		new(mockRemoteConfigPersistence),
 		new(mockCertPersistence),
 		new(mockAgentUsecase),
+		alwaysLeaderElector{},
 		slog.Default(),
 	)
 
@@ -860,6 +878,7 @@ func TestDeleteAgentGroup_PropagatesDeletion(t *testing.T) {
 		new(mockRemoteConfigPersistence),
 		new(mockCertPersistence),
 		new(mockAgentUsecase),
+		alwaysLeaderElector{},
 		slog.Default(),
 	)
 
@@ -902,6 +921,7 @@ func TestShouldReconcileDeletedGroup(t *testing.T) {
 		new(mockRemoteConfigPersistence),
 		new(mockCertPersistence),
 		new(mockAgentUsecase),
+		alwaysLeaderElector{},
 		slog.Default(),
 	)
 
@@ -943,7 +963,9 @@ func TestUpdateAgentsByAgentGroup(t *testing.T) {
 		logger := slog.Default()
 
 		mockCertPort := new(mockCertPersistence)
-		svc := NewAgentGroupService(mockPersistence, mockRemoteConfigPort, mockCertPort, mockAgentUC, logger)
+		svc := NewAgentGroupService(
+			mockPersistence, mockRemoteConfigPort, mockCertPort,
+			mockAgentUC, alwaysLeaderElector{}, logger)
 
 		testAgent := agentmodel.NewAgent(uuid.New(), agentmodel.WithDescription(&agent.Description{
 			IdentifyingAttributes: map[string]string{"service.name": "my-service"},
@@ -1016,7 +1038,9 @@ func TestUpdateAgentsByAgentGroup(t *testing.T) {
 		logger := slog.Default()
 
 		mockCertPort := new(mockCertPersistence)
-		svc := NewAgentGroupService(mockPersistence, mockRemoteConfigPort, mockCertPort, mockAgentUC, logger)
+		svc := NewAgentGroupService(
+			mockPersistence, mockRemoteConfigPort, mockCertPort,
+			mockAgentUC, alwaysLeaderElector{}, logger)
 
 		testAgent := agentmodel.NewAgent(uuid.New(), agentmodel.WithDescription(&agent.Description{
 			IdentifyingAttributes: map[string]string{"service.name": "my-service"},
@@ -1072,5 +1096,70 @@ func TestUpdateAgentsByAgentGroup(t *testing.T) {
 
 		require.NoError(t, err)
 		mockAgentUC.AssertExpectations(t)
+	})
+}
+
+// alwaysLeaderElector is a test double that always reports leadership, so the
+// reconcile loop behaves as it did before leader election was introduced.
+type alwaysLeaderElector struct{}
+
+func (alwaysLeaderElector) IsLeader(context.Context) (bool, error) { return true, nil }
+
+// fakeLeaderElector returns a configurable leadership result for reconcile-loop tests.
+type fakeLeaderElector struct {
+	leader bool
+	err    error
+}
+
+func (f fakeLeaderElector) IsLeader(context.Context) (bool, error) { return f.leader, f.err }
+
+var errBoomLeader = errors.New("leader election boom")
+
+func TestAgentGroupService_reconcileAllIfLeader(t *testing.T) {
+	t.Parallel()
+
+	listOpts := (*model.ListOptions)(nil)
+
+	t.Run("skips the reconcile scan when not leader", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		mockPersistence := new(mockAgentGroupPersistence)
+		svc := NewAgentGroupService(
+			mockPersistence, new(mockRemoteConfigPersistence), new(mockCertPersistence),
+			new(mockAgentUsecase), fakeLeaderElector{leader: false, err: nil}, slog.Default())
+
+		svc.reconcileAllIfLeader(ctx)
+
+		mockPersistence.AssertNotCalled(t, "ListAgentGroups", mock.Anything, mock.Anything)
+	})
+
+	t.Run("runs the reconcile scan when leader", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		mockPersistence := new(mockAgentGroupPersistence)
+		mockPersistence.On("ListAgentGroups", mock.Anything, listOpts).
+			Return(&model.ListResponse[*agentmodel.AgentGroup]{Items: nil}, nil)
+		svc := NewAgentGroupService(
+			mockPersistence, new(mockRemoteConfigPersistence), new(mockCertPersistence),
+			new(mockAgentUsecase), fakeLeaderElector{leader: true, err: nil}, slog.Default())
+
+		svc.reconcileAllIfLeader(ctx)
+
+		mockPersistence.AssertCalled(t, "ListAgentGroups", mock.Anything, listOpts)
+	})
+
+	t.Run("fails open and reconciles when leader election errors", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		mockPersistence := new(mockAgentGroupPersistence)
+		mockPersistence.On("ListAgentGroups", mock.Anything, listOpts).
+			Return(&model.ListResponse[*agentmodel.AgentGroup]{Items: nil}, nil)
+		svc := NewAgentGroupService(
+			mockPersistence, new(mockRemoteConfigPersistence), new(mockCertPersistence),
+			new(mockAgentUsecase), fakeLeaderElector{leader: false, err: errBoomLeader}, slog.Default())
+
+		svc.reconcileAllIfLeader(ctx)
+
+		mockPersistence.AssertCalled(t, "ListAgentGroups", mock.Anything, listOpts)
 	})
 }

--- a/pkg/apiserver/domain/agent/service/agentgroup_test.go
+++ b/pkg/apiserver/domain/agent/service/agentgroup_test.go
@@ -318,7 +318,7 @@ func TestAgentGroupService_GetAgentGroup(t *testing.T) {
 
 		mockCertPersistence := new(MockCertificatePersistencePortForGroup)
 		svc := agentservice.NewAgentGroupService(
-			mockPersistence, mockRemoteConfigPort, mockCertPersistence, mockAgentUsecase, logger)
+			mockPersistence, mockRemoteConfigPort, mockCertPersistence, mockAgentUsecase, alwaysLeaderElector{}, logger)
 
 		expectedGroup := &agentmodel.AgentGroup{
 			Metadata: agentmodel.AgentGroupMetadata{
@@ -346,7 +346,7 @@ func TestAgentGroupService_GetAgentGroup(t *testing.T) {
 
 		mockCertPersistence := new(MockCertificatePersistencePortForGroup)
 		svc := agentservice.NewAgentGroupService(
-			mockPersistence, mockRemoteConfigPort, mockCertPersistence, mockAgentUsecase, logger)
+			mockPersistence, mockRemoteConfigPort, mockCertPersistence, mockAgentUsecase, alwaysLeaderElector{}, logger)
 
 		mockPersistence.On(
 			"GetAgentGroup", ctx, "default", "non-existent", (*model.GetOptions)(nil),
@@ -375,7 +375,7 @@ func TestAgentGroupService_ListAgentGroups(t *testing.T) {
 
 		mockCertPersistence := new(MockCertificatePersistencePortForGroup)
 		svc := agentservice.NewAgentGroupService(
-			mockPersistence, mockRemoteConfigPort, mockCertPersistence, mockAgentUsecase, logger)
+			mockPersistence, mockRemoteConfigPort, mockCertPersistence, mockAgentUsecase, alwaysLeaderElector{}, logger)
 
 		expectedResponse := &model.ListResponse[*agentmodel.AgentGroup]{
 			Items: []*agentmodel.AgentGroup{
@@ -411,7 +411,7 @@ func TestAgentGroupService_ListAgentsByAgentGroup(t *testing.T) {
 
 		mockCertPersistence := new(MockCertificatePersistencePortForGroup)
 		svc := agentservice.NewAgentGroupService(
-			mockPersistence, mockRemoteConfigPort, mockCertPersistence, mockAgentUsecase, logger)
+			mockPersistence, mockRemoteConfigPort, mockCertPersistence, mockAgentUsecase, alwaysLeaderElector{}, logger)
 
 		agentGroup := &agentmodel.AgentGroup{
 			Metadata: agentmodel.AgentGroupMetadata{
@@ -464,7 +464,7 @@ func TestAgentGroupService_GetAgentGroupsForAgent(t *testing.T) {
 
 		mockCertPersistence := new(MockCertificatePersistencePortForGroup)
 		svc := agentservice.NewAgentGroupService(
-			mockPersistence, mockRemoteConfigPort, mockCertPersistence, mockAgentUsecase, logger)
+			mockPersistence, mockRemoteConfigPort, mockCertPersistence, mockAgentUsecase, alwaysLeaderElector{}, logger)
 
 		testAgent := agentmodel.NewAgent(uuid.New(), agentmodel.WithDescription(&agent.Description{
 			IdentifyingAttributes: map[string]string{
@@ -546,7 +546,7 @@ func TestAgentGroupService_GetAgentGroupsForAgent(t *testing.T) {
 
 		mockCertPersistence := new(MockCertificatePersistencePortForGroup)
 		svc := agentservice.NewAgentGroupService(
-			mockPersistence, mockRemoteConfigPort, mockCertPersistence, mockAgentUsecase, logger)
+			mockPersistence, mockRemoteConfigPort, mockCertPersistence, mockAgentUsecase, alwaysLeaderElector{}, logger)
 
 		testAgent := agentmodel.NewAgent(uuid.New(), agentmodel.WithDescription(&agent.Description{
 			IdentifyingAttributes: map[string]string{
@@ -593,7 +593,7 @@ func TestAgentGroupService_Name(t *testing.T) {
 
 	mockCertPersistence := new(MockCertificatePersistencePortForGroup)
 	svc := agentservice.NewAgentGroupService(
-		mockPersistence, mockRemoteConfigPort, mockCertPersistence, mockAgentUsecase, logger)
+		mockPersistence, mockRemoteConfigPort, mockCertPersistence, mockAgentUsecase, alwaysLeaderElector{}, logger)
 
 	assert.Equal(t, "AgentGroupService", svc.Name())
 }
@@ -611,7 +611,7 @@ func TestAgentGroupService_ReconcileAgent(t *testing.T) {
 		mockCertPersistence := new(MockCertificatePersistencePortForGroup)
 
 		svc := agentservice.NewAgentGroupService(
-			mockPersistence, mockRemoteConfigPort, mockCertPersistence, mockAgentUsecase, slog.Default())
+			mockPersistence, mockRemoteConfigPort, mockCertPersistence, mockAgentUsecase, alwaysLeaderElector{}, slog.Default())
 
 		agent := agentmodel.NewAgent(uuid.New())
 
@@ -629,3 +629,8 @@ func TestAgentGroupService_ReconcileAgent(t *testing.T) {
 		mockAgentUsecase.AssertExpectations(t)
 	})
 }
+
+// alwaysLeaderElector is a test double that always reports leadership.
+type alwaysLeaderElector struct{}
+
+func (alwaysLeaderElector) IsLeader(context.Context) (bool, error) { return true, nil }

--- a/pkg/apiserver/domain/agent/service/server.go
+++ b/pkg/apiserver/domain/agent/service/server.go
@@ -20,6 +20,11 @@ import (
 
 var (
 	_ agentport.ServerUsecase = (*ServerService)(nil)
+	_ agentport.LeaderElector = (*ServerService)(nil)
+
+	// ErrNoCurrentServerID is returned by IsLeader when the current server has no
+	// identity, so leadership cannot be determined.
+	ErrNoCurrentServerID = errors.New("current server has no identity")
 )
 
 const (
@@ -147,6 +152,39 @@ func (s *ServerService) ListServers(ctx context.Context) ([]*agentmodel.Server, 
 	}
 
 	return aliveServers, nil
+}
+
+// IsLeader implements agentport.LeaderElector.
+//
+// Leadership is deterministic and requires no extra writes or lease document: the
+// leader is the alive server with the smallest ID. Each node already publishes a
+// heartbeat (ServerIdentityService), so ListServers' alive set is the single source
+// of truth. When no server is registered yet (cold start) the current node leads so
+// singleton work is not stranded. A brief dual-leader window during a heartbeat-timeout
+// transition is acceptable: the only leader-gated job (agent-group reconcile) is
+// idempotent.
+func (s *ServerService) IsLeader(ctx context.Context) (bool, error) {
+	currentID := s.serverIdentityProvider.CurrentServerID()
+	if currentID == "" {
+		return false, ErrNoCurrentServerID
+	}
+
+	servers, err := s.ListServers(ctx)
+	if err != nil {
+		return false, fmt.Errorf("failed to list servers for leader election: %w", err)
+	}
+
+	if len(servers) == 0 {
+		return true, nil
+	}
+
+	for _, server := range servers {
+		if server.ID < currentID {
+			return false, nil
+		}
+	}
+
+	return true, nil
 }
 
 // SendMessageToServerByServerID implements agentport.ServerUsecase.

--- a/pkg/apiserver/domain/agent/service/server_test.go
+++ b/pkg/apiserver/domain/agent/service/server_test.go
@@ -619,3 +619,102 @@ func TestServerService_SendMessageToServer_RemoteDispatch(t *testing.T) {
 	mockConnection.AssertNotCalled(t, "SendServerToAgent",
 		mock.Anything, mock.Anything, mock.Anything)
 }
+
+func newLeaderTestService(
+	mockPersistence *MockServerPersistencePort,
+	mockIdentity *MockServerIdentityProvider,
+	now time.Time,
+) *agentservice.ServerService {
+	svc := agentservice.NewServerService(
+		slog.Default(),
+		mockPersistence,
+		new(MockServerEventSenderPort),
+		new(MockServerEventReceiverPort),
+		mockIdentity,
+		new(MockConnectionUsecase),
+		new(MockAgentUsecase),
+	)
+	svc.SetClock(newTestFakeClock(now))
+
+	return svc
+}
+
+func TestServerService_IsLeader(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+
+	t.Run("leader when current server has the smallest alive ID", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		mockPersistence := new(MockServerPersistencePort)
+		mockIdentity := new(MockServerIdentityProvider)
+		mockIdentity.On("CurrentServerID").Return("server-1")
+		mockPersistence.On("ListServers", ctx).Return([]*agentmodel.Server{
+			{ID: "server-1", LastHeartbeatAt: now},
+			{ID: "server-2", LastHeartbeatAt: now},
+		}, nil)
+
+		isLeader, err := newLeaderTestService(mockPersistence, mockIdentity, now).IsLeader(ctx)
+		require.NoError(t, err)
+		assert.True(t, isLeader)
+	})
+
+	t.Run("not leader when a smaller alive ID exists", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		mockPersistence := new(MockServerPersistencePort)
+		mockIdentity := new(MockServerIdentityProvider)
+		mockIdentity.On("CurrentServerID").Return("server-1")
+		mockPersistence.On("ListServers", ctx).Return([]*agentmodel.Server{
+			{ID: "server-0", LastHeartbeatAt: now},
+			{ID: "server-1", LastHeartbeatAt: now},
+		}, nil)
+
+		isLeader, err := newLeaderTestService(mockPersistence, mockIdentity, now).IsLeader(ctx)
+		require.NoError(t, err)
+		assert.False(t, isLeader)
+	})
+
+	t.Run("a dead smaller server does not block leadership", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		mockPersistence := new(MockServerPersistencePort)
+		mockIdentity := new(MockServerIdentityProvider)
+		mockIdentity.On("CurrentServerID").Return("server-1")
+		// server-0 has a stale heartbeat (well past the timeout) so ListServers filters it out.
+		mockPersistence.On("ListServers", ctx).Return([]*agentmodel.Server{
+			{ID: "server-0", LastHeartbeatAt: now.Add(-10 * time.Minute)},
+			{ID: "server-1", LastHeartbeatAt: now},
+		}, nil)
+
+		isLeader, err := newLeaderTestService(mockPersistence, mockIdentity, now).IsLeader(ctx)
+		require.NoError(t, err)
+		assert.True(t, isLeader)
+	})
+
+	t.Run("leads on cold start when no server is registered", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		mockPersistence := new(MockServerPersistencePort)
+		mockIdentity := new(MockServerIdentityProvider)
+		mockIdentity.On("CurrentServerID").Return("server-1")
+		mockPersistence.On("ListServers", ctx).Return([]*agentmodel.Server{}, nil)
+
+		isLeader, err := newLeaderTestService(mockPersistence, mockIdentity, now).IsLeader(ctx)
+		require.NoError(t, err)
+		assert.True(t, isLeader)
+	})
+
+	t.Run("errors when the current server has no identity", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		mockPersistence := new(MockServerPersistencePort)
+		mockIdentity := new(MockServerIdentityProvider)
+		mockIdentity.On("CurrentServerID").Return("")
+
+		isLeader, err := newLeaderTestService(mockPersistence, mockIdentity, now).IsLeader(ctx)
+		require.ErrorIs(t, err, agentservice.ErrNoCurrentServerID)
+		assert.False(t, isLeader)
+	})
+}

--- a/pkg/apiserver/internal/module/domain/domain.go
+++ b/pkg/apiserver/internal/module/domain/domain.go
@@ -48,6 +48,7 @@ func New() fx.Option {
 			Identity[*agentservice.ServerService],
 			fx.As(new(agentport.ServerUsecase)),
 			fx.As(new(agentport.ServerMessageUsecase)),
+			fx.As(new(agentport.LeaderElector)),
 		),
 		agentservice.NewServerIdentityService,
 		fx.Annotate(


### PR DESCRIPTION
Closes #467.

## Problem
`AgentGroupService.runReconcileLoop` ran the full reconcile pass (`reconcileAll`) every 5 minutes — and once at startup — on **every** apiserver node. In an N-node deployment that means N redundant full scans of all agent groups + matching agents per interval, and N nodes doing concurrent read-modify-write over the same agents (write contention, plus lost-update amplification until optimistic concurrency lands in #465).

## Change
Gate the periodic reconcile behind a lightweight leader election.

- **`agentport.LeaderElector`** with `IsLeader(ctx) (bool, error)`. Leadership is deterministic and needs **no extra writes and no lease document**: the leader is the alive server with the smallest ID, derived from the server registry + heartbeats that `ServerIdentityService` already maintains. Cold start (no servers registered yet) leads so work isn't stranded; a brief dual-leader window during a heartbeat-timeout transition is harmless because reconcile is idempotent.
- **`ServerService.IsLeader`** implements it (alive set via the existing `ListServers`), wired as `LeaderElector` through FX.
- **`AgentGroupService.runReconcileLoop`** now calls `reconcileAllIfLeader`, which skips the scan on non-leaders and **fails open** (reconciles anyway) if the election errors, so a transient registry read can't strand reconciliation cluster-wide.

The event-driven propagation path (`changedAgentGroupCh`, fired by API group changes) is intentionally **not** gated — it must run on whichever node served the change so propagation stays immediate.

## Effect
- Reconcile load drops from N×/interval to 1×/interval.
- Non-leader nodes no longer contend on agent writes via the periodic loop.
- Pairs naturally with #465 (optimistic concurrency): the rare dual-leader window becomes fully safe once that lands.

## Tests
- `ServerService.IsLeader`: smallest-ID leads, smaller alive ID defers, dead smaller server ignored, cold-start leads, empty identity errors.
- `AgentGroupService.reconcileAllIfLeader`: skips scan when not leader, runs when leader, fails open on election error.
- FX `ValidateWiring` passes (no dependency cycle from the new `LeaderElector` edge).

## Follow-up
Other unconditional per-node startup work (bootstrap seeding) is idempotent and left as-is; making it leader-only too can be a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)