### PR TITLE
refactor(role): move lifecycle logic into rich domain service

### DIFF
--- a/pkg/apiserver/application/service/role/service.go
+++ b/pkg/apiserver/application/service/role/service.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
-	"time"
 
 	"github.com/google/uuid"
 	"github.com/samber/lo"
@@ -71,38 +70,30 @@ func (s *Service) ListRoles(
 
 // CreateRole implements [applicationport.RoleManageUsecase].
 func (s *Service) CreateRole(ctx context.Context, apiRole *v1.Role) (*v1.Role, error) {
-	// User-created roles cannot be marked as built-in
 	domainRole := usermodel.NewRole(apiRole.Spec.DisplayName, false)
 	domainRole.Spec.Description = apiRole.Spec.Description
 	domainRole.Spec.Permissions = apiRole.Spec.Permissions
 
-	err := s.roleUsecase.SaveRole(ctx, domainRole)
+	created, err := s.roleUsecase.CreateRole(ctx, domainRole)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create role: %w", err)
 	}
 
-	return s.mapper.MapRoleToAPI(domainRole), nil
+	return s.mapper.MapRoleToAPI(created), nil
 }
 
 // UpdateRole implements [applicationport.RoleManageUsecase].
 func (s *Service) UpdateRole(ctx context.Context, uid uuid.UUID, apiRole *v1.Role) (*v1.Role, error) {
-	existing, err := s.roleUsecase.GetRole(ctx, uid, nil)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get role: %w", err)
-	}
+	domainRole := usermodel.NewRole(apiRole.Spec.DisplayName, false)
+	domainRole.Spec.Description = apiRole.Spec.Description
+	domainRole.Spec.Permissions = apiRole.Spec.Permissions
 
-	existing.Spec.DisplayName = apiRole.Spec.DisplayName
-	existing.Spec.Description = apiRole.Spec.Description
-	existing.Spec.Permissions = apiRole.Spec.Permissions
-	// IsBuiltIn is immutable — not updated from the request
-	existing.Metadata.UpdatedAt = time.Now()
-
-	err = s.roleUsecase.SaveRole(ctx, existing)
+	updated, err := s.roleUsecase.UpdateRole(ctx, uid, domainRole)
 	if err != nil {
 		return nil, fmt.Errorf("failed to update role: %w", err)
 	}
 
-	return s.mapper.MapRoleToAPI(existing), nil
+	return s.mapper.MapRoleToAPI(updated), nil
 }
 
 // DeleteRole implements [applicationport.RoleManageUsecase].

--- a/pkg/apiserver/application/service/rolebinding/service_test.go
+++ b/pkg/apiserver/application/service/rolebinding/service_test.go
@@ -195,6 +195,30 @@ func (m *mockRoleUsecase) SaveRole(ctx context.Context, role *usermodel.Role) er
 	return args.Error(0) //nolint:wrapcheck // mock error
 }
 
+func (m *mockRoleUsecase) CreateRole(ctx context.Context, role *usermodel.Role) (*usermodel.Role, error) {
+	args := m.Called(ctx, role)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	r, _ := args.Get(0).(*usermodel.Role)
+
+	return r, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockRoleUsecase) UpdateRole(
+	ctx context.Context, uid uuid.UUID, role *usermodel.Role,
+) (*usermodel.Role, error) {
+	args := m.Called(ctx, uid, role)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	r, _ := args.Get(0).(*usermodel.Role)
+
+	return r, args.Error(1) //nolint:wrapcheck // mock error
+}
+
 func (m *mockRoleUsecase) DeleteRole(ctx context.Context, uid uuid.UUID) error {
 	args := m.Called(ctx, uid)
 

--- a/pkg/apiserver/domain/user/port/in.go
+++ b/pkg/apiserver/domain/user/port/in.go
@@ -36,8 +36,17 @@ type RoleUsecase interface {
 	GetRoleByName(ctx context.Context, displayName string) (*usermodel.Role, error)
 	// ListRoles lists all roles.
 	ListRoles(ctx context.Context, options *model.ListOptions) (*model.ListResponse[*usermodel.Role], error)
-	// SaveRole saves the role.
+	// SaveRole persists the role as-is without applying lifecycle rules. It is the
+	// low-level write used by declarative bootstrap; application flows should prefer
+	// CreateRole/UpdateRole.
 	SaveRole(ctx context.Context, role *usermodel.Role) error
+	// CreateRole persists a user-created role. It forces the role to be non-built-in
+	// and stamps the creation/update timestamps.
+	CreateRole(ctx context.Context, role *usermodel.Role) (*usermodel.Role, error)
+	// UpdateRole applies the mutable spec fields (display name, description,
+	// permissions) from role onto the stored role identified by uid, keeping
+	// IsBuiltIn immutable, and stamps the update timestamp.
+	UpdateRole(ctx context.Context, uid uuid.UUID, role *usermodel.Role) (*usermodel.Role, error)
 	// DeleteRole deletes the role (only if it's not built-in).
 	DeleteRole(ctx context.Context, uid uuid.UUID) error
 }

--- a/pkg/apiserver/domain/user/service/role.go
+++ b/pkg/apiserver/domain/user/service/role.go
@@ -11,6 +11,7 @@ import (
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
 	usermodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/model"
 	userport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/port"
+	"github.com/minuk-dev/opampcommander/pkg/utils/clock"
 )
 
 // ErrBuiltInRoleCannotBeDeleted is returned when attempting to delete a built-in role.
@@ -18,9 +19,12 @@ var ErrBuiltInRoleCannotBeDeleted = errors.New("built-in role cannot be deleted"
 
 var _ userport.RoleUsecase = (*RoleService)(nil)
 
-// RoleService implements the RoleUsecase interface.
+// RoleService implements the RoleUsecase interface, owning the role lifecycle
+// rules (user-created roles are never built-in, IsBuiltIn is immutable on update,
+// and update timestamps are stamped).
 type RoleService struct {
 	rolePersistencePort userport.RolePersistencePort
+	clock               clock.Clock
 	logger              *slog.Logger
 }
 
@@ -31,8 +35,14 @@ func NewRoleService(
 ) *RoleService {
 	return &RoleService{
 		rolePersistencePort: rolePersistencePort,
+		clock:               clock.NewRealClock(),
 		logger:              logger,
 	}
+}
+
+// SetClock overrides the clock used for lifecycle timestamps. Intended for tests.
+func (s *RoleService) SetClock(c clock.Clock) {
+	s.clock = c
 }
 
 // GetRole implements [userport.RoleUsecase].
@@ -86,6 +96,56 @@ func (s *RoleService) SaveRole(
 	}
 
 	return nil
+}
+
+// CreateRole implements [userport.RoleUsecase]. User-created roles are forced to be
+// non-built-in, and their creation/update timestamps are stamped from the clock.
+func (s *RoleService) CreateRole(
+	ctx context.Context,
+	role *usermodel.Role,
+) (*usermodel.Role, error) {
+	role.Spec.IsBuiltIn = false
+
+	now := s.clock.Now()
+	role.Metadata.CreatedAt = now
+	role.Metadata.UpdatedAt = now
+
+	if role.Metadata.UID == uuid.Nil {
+		role.Metadata.UID = uuid.New()
+	}
+
+	_, err := s.rolePersistencePort.PutRole(ctx, role)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create role in persistence: %w", err)
+	}
+
+	return role, nil
+}
+
+// UpdateRole implements [userport.RoleUsecase]. It applies the mutable spec fields
+// onto the stored role, keeping IsBuiltIn immutable, and stamps the update time.
+func (s *RoleService) UpdateRole(
+	ctx context.Context,
+	uid uuid.UUID,
+	role *usermodel.Role,
+) (*usermodel.Role, error) {
+	existing, err := s.rolePersistencePort.GetRole(ctx, uid, nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get role for update: %w", err)
+	}
+
+	existing.Spec.DisplayName = role.Spec.DisplayName
+	existing.Spec.Description = role.Spec.Description
+	existing.Spec.Permissions = role.Spec.Permissions
+	// IsBuiltIn is immutable — not updated from the request.
+	existing.Metadata.UpdatedAt = s.clock.Now()
+
+	_, err = s.rolePersistencePort.PutRole(ctx, existing)
+	if err != nil {
+		return nil, fmt.Errorf("failed to update role in persistence: %w", err)
+	}
+
+	return existing, nil
 }
 
 // DeleteRole implements [userport.RoleUsecase].

--- a/pkg/apiserver/domain/user/service/role_test.go
+++ b/pkg/apiserver/domain/user/service/role_test.go
@@ -1,0 +1,95 @@
+package userservice_test
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	usermodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/model"
+	userport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/port"
+	userservice "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user/service"
+)
+
+// roleFakePersistence is a minimal in-memory RolePersistencePort for the role
+// lifecycle tests.
+type roleFakePersistence struct {
+	stored   *usermodel.Role
+	getErr   error
+	putCalls int
+	lastPut  *usermodel.Role
+}
+
+func (f *roleFakePersistence) GetRole(
+	_ context.Context, _ uuid.UUID, _ *model.GetOptions,
+) (*usermodel.Role, error) {
+	if f.getErr != nil {
+		return nil, f.getErr
+	}
+
+	return f.stored, nil
+}
+
+func (f *roleFakePersistence) GetRoleByName(_ context.Context, _ string) (*usermodel.Role, error) {
+	return f.stored, nil
+}
+
+func (f *roleFakePersistence) PutRole(_ context.Context, role *usermodel.Role) (*usermodel.Role, error) {
+	f.putCalls++
+	f.lastPut = role
+
+	return role, nil
+}
+
+func (f *roleFakePersistence) ListRoles(
+	_ context.Context, _ *model.ListOptions,
+) (*model.ListResponse[*usermodel.Role], error) {
+	return &model.ListResponse[*usermodel.Role]{}, nil
+}
+
+func (f *roleFakePersistence) DeleteRole(_ context.Context, _ uuid.UUID) error {
+	return nil
+}
+
+var _ userport.RolePersistencePort = (*roleFakePersistence)(nil)
+
+func TestRoleService_CreateRole_ForcesNotBuiltIn(t *testing.T) {
+	t.Parallel()
+
+	persistence := &roleFakePersistence{}
+	svc := userservice.NewRoleService(persistence, slog.Default())
+
+	// A caller trying to sneak in a built-in role must be overridden.
+	input := usermodel.NewRole("editor", true)
+
+	created, err := svc.CreateRole(t.Context(), input)
+
+	require.NoError(t, err)
+	assert.Equal(t, 1, persistence.putCalls)
+	assert.False(t, created.Spec.IsBuiltIn, "user-created roles must never be built-in")
+	assert.NotEqual(t, uuid.Nil, created.Metadata.UID, "a created role must have an identity")
+}
+
+func TestRoleService_UpdateRole_KeepsIsBuiltInImmutable(t *testing.T) {
+	t.Parallel()
+
+	stored := usermodel.NewRole("admin", true) // a built-in role
+	persistence := &roleFakePersistence{stored: stored}
+	svc := userservice.NewRoleService(persistence, slog.Default())
+
+	// The update body tries to flip IsBuiltIn off and change the spec.
+	incoming := usermodel.NewRole("admin-renamed", false)
+	incoming.Spec.Description = "changed"
+	incoming.Spec.Permissions = []string{"agent:GET"}
+
+	updated, err := svc.UpdateRole(t.Context(), stored.Metadata.UID, incoming)
+
+	require.NoError(t, err)
+	assert.True(t, updated.Spec.IsBuiltIn, "IsBuiltIn must be immutable on update")
+	assert.Equal(t, "admin-renamed", updated.Spec.DisplayName, "mutable spec fields must be applied")
+	assert.Equal(t, []string{"agent:GET"}, updated.Spec.Permissions)
+}


### PR DESCRIPTION
## Why

Phase 3 of the rich-domain refactor, for the RBAC aggregate. The `role` application service carried real domain logic:
- forcing user-created roles to be non-built-in,
- keeping `IsBuiltIn` immutable on update,
- stamping `UpdatedAt` with a **direct `time.Now()`** call (violating the injected-clock convention),

while the domain `RoleUsecase` exposed only `SaveRole` (a CRUD pass-through).

## What

- **`RoleUsecase.CreateRole` / `UpdateRole`** — new domain methods. Create forces non-built-in and stamps created/updated timestamps; Update applies the mutable spec (display name, description, permissions), keeps `IsBuiltIn` immutable, and stamps `UpdatedAt`. `RoleService` gets an injected clock (`SetClock` for tests), removing the `time.Now()` violation.
- Application role service is now thin (map DTO, delegate a single domain call).
- Added domain tests for the not-built-in and immutable-`IsBuiltIn` invariants.

**RoleBinding is intentionally untouched:** it already delegates to a rich domain (`CreateRoleBinding`/`UpdateRoleBinding`) and only does cross-aggregate orchestration (validate the referenced role exists, best-effort Casbin policy sync) — that's application-layer coordination, not entity lifecycle.

Behavior preserved.

## Test

- `make generate` → no diff
- `make lint` → 0 issues
- `make unittest` → pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)