### PR TITLE
feat(cache): broadcast agent cache invalidation on API writes (#466)

### DIFF
--- a/pkg/apiserver/adapter/common/kafka/kafka.go
+++ b/pkg/apiserver/adapter/common/kafka/kafka.go
@@ -13,6 +13,8 @@ const (
 const (
 	// SendToAgentEventType is the CloudEvent type for sending messages to agents.
 	SendToAgentEventType = "io.opampcommander.server.sendtosagent.v1"
+	// InvalidateAgentCacheEventType is the CloudEvent type for invalidating cached agents.
+	InvalidateAgentCacheEventType = "io.opampcommander.server.invalidateagentcache.v1"
 	// UnknownEventType is the CloudEvent type for unknown messages.
 	UnknownEventType = "io.opampcommander.server.unknown.v1"
 )
@@ -22,6 +24,8 @@ func EventTypeFromMessageType(messageType serverevent.MessageType) string {
 	switch messageType {
 	case serverevent.MessageTypeSendServerToAgent:
 		return SendToAgentEventType
+	case serverevent.MessageTypeInvalidateAgentCache:
+		return InvalidateAgentCacheEventType
 	default:
 		return UnknownEventType
 	}
@@ -32,6 +36,8 @@ func MessageTypeFromEventType(eventType string) (serverevent.MessageType, error)
 	switch eventType {
 	case SendToAgentEventType:
 		return serverevent.MessageTypeSendServerToAgent, nil
+	case InvalidateAgentCacheEventType:
+		return serverevent.MessageTypeInvalidateAgentCache, nil
 	default:
 		return "", &UnknownMessageTypeError{MessageType: eventType}
 	}

--- a/pkg/apiserver/application/service/agent/agent.go
+++ b/pkg/apiserver/application/service/agent/agent.go
@@ -32,9 +32,10 @@ var _ applicationport.AgentManageUsecase = (*Service)(nil)
 // Service is a struct that implements the AgentManageUsecase interface.
 type Service struct {
 	// domain usecases
-	agentUsecase             agentport.AgentUsecase
-	agentNotificationUsecase agentport.AgentNotificationUsecase
-	endpointDetectionUsecase agentport.EndpointDetectionUsecase
+	agentUsecase               agentport.AgentUsecase
+	agentNotificationUsecase   agentport.AgentNotificationUsecase
+	endpointDetectionUsecase   agentport.EndpointDetectionUsecase
+	cacheInvalidationPublisher agentport.AgentCacheInvalidationPublisher
 
 	// mapper
 	mapper *helper.Mapper
@@ -46,14 +47,16 @@ func New(
 	agentUsecase agentport.AgentUsecase,
 	agentNotificationUsecase agentport.AgentNotificationUsecase,
 	endpointDetectionUsecase agentport.EndpointDetectionUsecase,
+	cacheInvalidationPublisher agentport.AgentCacheInvalidationPublisher,
 	logger *slog.Logger,
 ) *Service {
 	realClock := clock.RealClock{}
 
 	return &Service{
-		agentUsecase:             agentUsecase,
-		agentNotificationUsecase: agentNotificationUsecase,
-		endpointDetectionUsecase: endpointDetectionUsecase,
+		agentUsecase:               agentUsecase,
+		agentNotificationUsecase:   agentNotificationUsecase,
+		endpointDetectionUsecase:   endpointDetectionUsecase,
+		cacheInvalidationPublisher: cacheInvalidationPublisher,
 
 		mapper: helper.NewMapper(realClock, agentmodel.DefaultConnectionStaleness),
 		logger: logger,
@@ -172,6 +175,8 @@ func (s *Service) DeleteAgent(
 		return fmt.Errorf("failed to delete agent: %w", err)
 	}
 
+	s.invalidatePeerCaches(ctx, instanceUID)
+
 	return nil
 }
 
@@ -217,7 +222,21 @@ func (s *Service) UpdateAgent(
 		s.logger.Error("failed to notify agent updated", "error", notifyErr.Error())
 	}
 
+	s.invalidatePeerCaches(ctx, instanceUID)
+
 	return s.mapper.MapAgentToAPI(existing), nil
+}
+
+// invalidatePeerCaches asks other nodes to drop their cached copy of the agent after a
+// local API mutation, so they don't serve it stale until their TTL expires. It is
+// best-effort: failures are logged, never surfaced to the API caller, since the entry
+// expires on its own and the local node's cache was already updated by the write.
+func (s *Service) invalidatePeerCaches(ctx context.Context, instanceUID uuid.UUID) {
+	err := s.cacheInvalidationPublisher.BroadcastAgentCacheInvalidation(ctx, instanceUID)
+	if err != nil {
+		s.logger.Error("failed to broadcast agent cache invalidation",
+			"instanceUID", instanceUID.String(), "error", err.Error())
+	}
 }
 
 // getAgentInNamespace fetches an agent by UID and verifies it belongs to the given

--- a/pkg/apiserver/application/service/agent/agent_test.go
+++ b/pkg/apiserver/application/service/agent/agent_test.go
@@ -146,7 +146,9 @@ func TestService_SearchAgents(t *testing.T) {
 		ctx := t.Context()
 		mockAgentUsecase := new(MockAgentUsecase)
 		mockNotificationUsecase := new(MockAgentNotificationUsecase)
-		service := agent.New(mockAgentUsecase, mockNotificationUsecase, stubEndpointDetectionUsecase{}, slog.Default())
+		service := agent.New(
+			mockAgentUsecase, mockNotificationUsecase, stubEndpointDetectionUsecase{},
+			noopCacheInvalidationPublisher{}, slog.Default())
 
 		instanceUID := uuid.New()
 		domainAgents := []*agentmodel.Agent{
@@ -178,7 +180,9 @@ func TestService_SearchAgents(t *testing.T) {
 		ctx := t.Context()
 		mockAgentUsecase := new(MockAgentUsecase)
 		mockNotificationUsecase := new(MockAgentNotificationUsecase)
-		service := agent.New(mockAgentUsecase, mockNotificationUsecase, stubEndpointDetectionUsecase{}, slog.Default())
+		service := agent.New(
+			mockAgentUsecase, mockNotificationUsecase, stubEndpointDetectionUsecase{},
+			noopCacheInvalidationPublisher{}, slog.Default())
 
 		mockAgentUsecase.On("SearchAgents", ctx, "default", "test", mock.Anything).Return(nil, errMockError)
 
@@ -199,7 +203,9 @@ func TestService_SearchAgents(t *testing.T) {
 		ctx := t.Context()
 		mockAgentUsecase := new(MockAgentUsecase)
 		mockNotificationUsecase := new(MockAgentNotificationUsecase)
-		service := agent.New(mockAgentUsecase, mockNotificationUsecase, stubEndpointDetectionUsecase{}, slog.Default())
+		service := agent.New(
+			mockAgentUsecase, mockNotificationUsecase, stubEndpointDetectionUsecase{},
+			noopCacheInvalidationPublisher{}, slog.Default())
 
 		domainAgents := []*agentmodel.Agent{
 			agentmodel.NewAgent(uuid.New()),
@@ -241,7 +247,9 @@ func TestService_DeleteAgent(t *testing.T) {
 		ctx := t.Context()
 		mockAgentUsecase := new(MockAgentUsecase)
 		mockNotificationUsecase := new(MockAgentNotificationUsecase)
-		service := agent.New(mockAgentUsecase, mockNotificationUsecase, stubEndpointDetectionUsecase{}, slog.Default())
+		service := agent.New(
+			mockAgentUsecase, mockNotificationUsecase, stubEndpointDetectionUsecase{},
+			noopCacheInvalidationPublisher{}, slog.Default())
 
 		instanceUID := uuid.New()
 		domainAgent := agentmodel.NewAgent(instanceUID) // Status.Connected defaults to false
@@ -265,7 +273,9 @@ func TestService_DeleteAgent(t *testing.T) {
 		ctx := t.Context()
 		mockAgentUsecase := new(MockAgentUsecase)
 		mockNotificationUsecase := new(MockAgentNotificationUsecase)
-		service := agent.New(mockAgentUsecase, mockNotificationUsecase, stubEndpointDetectionUsecase{}, slog.Default())
+		service := agent.New(
+			mockAgentUsecase, mockNotificationUsecase, stubEndpointDetectionUsecase{},
+			noopCacheInvalidationPublisher{}, slog.Default())
 
 		instanceUID := uuid.New()
 		domainAgent := agentmodel.NewAgent(instanceUID) // namespace "default"
@@ -288,7 +298,9 @@ func TestService_DeleteAgent(t *testing.T) {
 		ctx := t.Context()
 		mockAgentUsecase := new(MockAgentUsecase)
 		mockNotificationUsecase := new(MockAgentNotificationUsecase)
-		service := agent.New(mockAgentUsecase, mockNotificationUsecase, stubEndpointDetectionUsecase{}, slog.Default())
+		service := agent.New(
+			mockAgentUsecase, mockNotificationUsecase, stubEndpointDetectionUsecase{},
+			noopCacheInvalidationPublisher{}, slog.Default())
 
 		instanceUID := uuid.New()
 		domainAgent := agentmodel.NewAgent(instanceUID) // namespace defaults to "default"
@@ -311,7 +323,9 @@ func TestService_DeleteAgent(t *testing.T) {
 		ctx := t.Context()
 		mockAgentUsecase := new(MockAgentUsecase)
 		mockNotificationUsecase := new(MockAgentNotificationUsecase)
-		service := agent.New(mockAgentUsecase, mockNotificationUsecase, stubEndpointDetectionUsecase{}, slog.Default())
+		service := agent.New(
+			mockAgentUsecase, mockNotificationUsecase, stubEndpointDetectionUsecase{},
+			noopCacheInvalidationPublisher{}, slog.Default())
 
 		instanceUID := uuid.New()
 		domainAgent := agentmodel.NewAgent(instanceUID)
@@ -327,4 +341,48 @@ func TestService_DeleteAgent(t *testing.T) {
 		assert.Contains(t, err.Error(), "failed to delete agent")
 		mockAgentUsecase.AssertExpectations(t)
 	})
+}
+
+// noopCacheInvalidationPublisher satisfies agentport.AgentCacheInvalidationPublisher in
+// tests that do not assert on broadcasts.
+type noopCacheInvalidationPublisher struct{}
+
+func (noopCacheInvalidationPublisher) BroadcastAgentCacheInvalidation(
+	context.Context, ...uuid.UUID,
+) error {
+	return nil
+}
+
+// spyCacheInvalidationPublisher records the UIDs it was asked to broadcast.
+type spyCacheInvalidationPublisher struct {
+	broadcasted []uuid.UUID
+}
+
+func (s *spyCacheInvalidationPublisher) BroadcastAgentCacheInvalidation(
+	_ context.Context, instanceUIDs ...uuid.UUID,
+) error {
+	s.broadcasted = append(s.broadcasted, instanceUIDs...)
+
+	return nil
+}
+
+func TestService_DeleteAgent_BroadcastsCacheInvalidation(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	mockAgentUsecase := new(MockAgentUsecase)
+	mockNotificationUsecase := new(MockAgentNotificationUsecase)
+	spy := new(spyCacheInvalidationPublisher)
+	service := agent.New(mockAgentUsecase, mockNotificationUsecase, stubEndpointDetectionUsecase{}, spy, slog.Default())
+
+	instanceUID := uuid.New()
+	domainAgent := agentmodel.NewAgent(instanceUID)
+	mockAgentUsecase.On("GetAgent", ctx, instanceUID).Return(domainAgent, nil)
+	mockAgentUsecase.On("DeleteAgent", ctx, instanceUID).Return(nil)
+
+	err := service.DeleteAgent(ctx, "default", instanceUID)
+	require.NoError(t, err)
+
+	require.Len(t, spy.broadcasted, 1)
+	assert.Equal(t, instanceUID, spy.broadcasted[0])
 }

--- a/pkg/apiserver/domain/agent/model/serverevent/serverevent.go
+++ b/pkg/apiserver/domain/agent/model/serverevent/serverevent.go
@@ -14,6 +14,9 @@ func (s MessageType) String() string {
 const (
 	// MessageTypeSendServerToAgent is a message type for sending ServerToAgent messages for specific agents.
 	MessageTypeSendServerToAgent MessageType = "SendServerToAgent"
+	// MessageTypeInvalidateAgentCache asks the recipient server to drop its cached copy of
+	// the listed agents, so a write made on another node is not served stale from cache.
+	MessageTypeInvalidateAgentCache MessageType = "InvalidateAgentCache"
 )
 
 // Message represents a message sent between servers.
@@ -32,6 +35,8 @@ type Message struct {
 type MessagePayload struct {
 	// When Type is ServerMessageTypeSendServerToAgent, Payload is ServerToAgentMessage
 	*MessageForServerToAgent
+	// When Type is MessageTypeInvalidateAgentCache, Payload is MessageForInvalidateAgentCache.
+	*MessageForInvalidateAgentCache
 }
 
 // MessageForServerToAgent represents a message sent from the server to an agent.
@@ -42,4 +47,11 @@ type MessageForServerToAgent struct {
 	// because the message can be delayed or missed.
 	// All servers should check all agents status periodically to handle such cases.
 	TargetAgentInstanceUIDs []uuid.UUID `json:"targetAgentInstanceUids"`
+}
+
+// MessageForInvalidateAgentCache carries the agents whose cached copies the recipient
+// server should drop. It's encoded as json in the CloudEvent data field.
+type MessageForInvalidateAgentCache struct {
+	// AgentInstanceUIDs is the list of agent instance UIDs to invalidate from the cache.
+	AgentInstanceUIDs []uuid.UUID `json:"agentInstanceUids"`
 }

--- a/pkg/apiserver/domain/agent/port/in.go
+++ b/pkg/apiserver/domain/agent/port/in.go
@@ -62,6 +62,27 @@ type AgentNotificationUsecase interface {
 	NotifyAgentUpdated(ctx context.Context, agent *agentmodel.Agent) error
 }
 
+// AgentCacheInvalidationPublisher broadcasts agent cache invalidations to peer servers.
+//
+// It is used by external (API-driven) write paths so that a write made on one node is
+// not served stale from another node's read cache. The heartbeat-driven persistence path
+// deliberately does NOT use this — that volume would flood the cluster, and its cross-node
+// staleness is bounded by the cache TTL and harmless.
+type AgentCacheInvalidationPublisher interface {
+	// BroadcastAgentCacheInvalidation asks every other alive server to drop the listed
+	// agents from its cache. It is best-effort: delivery failures are logged, not returned
+	// as hard errors, since the cache entry expires on its own within the TTL regardless.
+	BroadcastAgentCacheInvalidation(ctx context.Context, instanceUIDs ...uuid.UUID) error
+}
+
+// AgentCacheInvalidator drops a single agent from the local in-process cache. It is the
+// receiving end of [AgentCacheInvalidationPublisher]: a peer's broadcast resolves to this.
+type AgentCacheInvalidator interface {
+	// InvalidateCache removes the agent from the local cache, forcing the next read to
+	// go to persistence.
+	InvalidateCache(instanceUID uuid.UUID)
+}
+
 // NamespaceUsecase is an interface that defines the methods for namespace use cases.
 type NamespaceUsecase interface {
 	// GetNamespace retrieves a namespace by its name.

--- a/pkg/apiserver/domain/agent/service/agent.go
+++ b/pkg/apiserver/domain/agent/service/agent.go
@@ -17,7 +17,10 @@ import (
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/port"
 )
 
-var _ agentport.AgentUsecase = (*AgentService)(nil)
+var (
+	_ agentport.AgentUsecase          = (*AgentService)(nil)
+	_ agentport.AgentCacheInvalidator = (*AgentService)(nil)
+)
 
 const (
 	// DefaultAgentCacheTTL is the default time-to-live for agent cache entries.

--- a/pkg/apiserver/domain/agent/service/agent_notification.go
+++ b/pkg/apiserver/domain/agent/service/agent_notification.go
@@ -356,6 +356,7 @@ func (s *AgentNotificationService) dispatchBatch(
 			MessageForServerToAgent: &serverevent.MessageForServerToAgent{
 				TargetAgentInstanceUIDs: uids,
 			},
+			MessageForInvalidateAgentCache: nil,
 		},
 	})
 	if err != nil {

--- a/pkg/apiserver/domain/agent/service/server.go
+++ b/pkg/apiserver/domain/agent/service/server.go
@@ -18,8 +18,9 @@ import (
 )
 
 var (
-	_ agentport.ServerUsecase = (*ServerService)(nil)
-	_ agentport.LeaderElector = (*ServerService)(nil)
+	_ agentport.ServerUsecase                   = (*ServerService)(nil)
+	_ agentport.LeaderElector                   = (*ServerService)(nil)
+	_ agentport.AgentCacheInvalidationPublisher = (*ServerService)(nil)
 
 	// ErrNoCurrentServerID is returned by IsLeader when the current server has no
 	// identity, so leadership cannot be determined.
@@ -47,6 +48,7 @@ type ServerService struct {
 	serverIdentityProvider  agentport.ServerIdentityProvider
 	connectionUsecase       agentport.ConnectionUsecase
 	agentUsecase            agentport.AgentUsecase
+	agentCacheInvalidator   agentport.AgentCacheInvalidator
 }
 
 // NewServerService creates a new instance of the ServerService.
@@ -58,6 +60,7 @@ func NewServerService(
 	serverIdentityProvider agentport.ServerIdentityProvider,
 	connectionUsecase agentport.ConnectionUsecase,
 	agentUsecase agentport.AgentUsecase,
+	agentCacheInvalidator agentport.AgentCacheInvalidator,
 ) *ServerService {
 	serverCache := ttlcache.New[string, *agentmodel.Server](
 		ttlcache.WithTTL[string, *agentmodel.Server](DefaultServerCacheTTL),
@@ -80,6 +83,7 @@ func NewServerService(
 		heartbeatTimeout:        DefaultHeartbeatTimeout,
 		connectionUsecase:       connectionUsecase,
 		agentUsecase:            agentUsecase,
+		agentCacheInvalidator:   agentCacheInvalidator,
 	}
 }
 
@@ -244,6 +248,59 @@ func (s *ServerService) SendMessageToServer(
 	return nil
 }
 
+// BroadcastAgentCacheInvalidation implements agentport.AgentCacheInvalidationPublisher.
+//
+// It asks every other alive server to drop the listed agents from its cache. The current
+// server is skipped (its cache was already refreshed by the write that triggered this).
+// Delivery is best-effort and per-peer: a failure to reach one peer is logged and does not
+// stop the others or fail the call, because the stale entry expires within the cache TTL
+// regardless.
+func (s *ServerService) BroadcastAgentCacheInvalidation(
+	ctx context.Context,
+	instanceUIDs ...uuid.UUID,
+) error {
+	if len(instanceUIDs) == 0 {
+		return nil
+	}
+
+	servers, err := s.ListServers(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to list servers for cache invalidation: %w", err)
+	}
+
+	currentID := ""
+	if s.serverIdentityProvider != nil {
+		currentID = s.serverIdentityProvider.CurrentServerID()
+	}
+
+	for _, server := range servers {
+		if server.ID == currentID {
+			continue
+		}
+
+		message := serverevent.Message{
+			Source: currentID,
+			Target: server.ID,
+			Type:   serverevent.MessageTypeInvalidateAgentCache,
+			Payload: serverevent.MessagePayload{
+				MessageForServerToAgent: nil,
+				MessageForInvalidateAgentCache: &serverevent.MessageForInvalidateAgentCache{
+					AgentInstanceUIDs: instanceUIDs,
+				},
+			},
+		}
+
+		sendErr := s.SendMessageToServer(ctx, server, message)
+		if sendErr != nil {
+			s.logger.Warn("failed to broadcast cache invalidation to peer",
+				slog.String("peerServerID", server.ID),
+				slog.String("error", sendErr.Error()))
+		}
+	}
+
+	return nil
+}
+
 func (s *ServerService) loopForReceivingMessages(ctx context.Context) error {
 	// StartReceiver is a blocking call.
 	// So, we don't need a loop here.
@@ -260,11 +317,38 @@ func (s *ServerService) handleServerEvent(ctx context.Context, event *servereven
 	switch event.Type {
 	case serverevent.MessageTypeSendServerToAgent:
 		return s.handleSendServerToAgentEvent(ctx, event)
+	case serverevent.MessageTypeInvalidateAgentCache:
+		return s.handleInvalidateAgentCacheEvent(event)
 	default:
 		s.logger.Warn("unknown server event type", slog.String("eventType", event.Type.String()))
 
 		return nil
 	}
+}
+
+// handleInvalidateAgentCacheEvent drops the listed agents from this server's local cache
+// so a write made on another node is not served stale from here. It never errors: a
+// missing/empty payload is logged and ignored, since a stale entry expires on its own.
+func (s *ServerService) handleInvalidateAgentCacheEvent(event *serverevent.Message) error {
+	if event.Payload.MessageForInvalidateAgentCache == nil {
+		s.logger.Warn("invalidate-agent-cache event has no payload")
+
+		return nil
+	}
+
+	uids := event.Payload.AgentInstanceUIDs
+	if len(uids) == 0 {
+		return nil
+	}
+
+	for _, instanceUID := range uids {
+		s.agentCacheInvalidator.InvalidateCache(instanceUID)
+	}
+
+	s.logger.Debug("invalidated agents from local cache on peer request",
+		slog.Int("agentCount", len(uids)))
+
+	return nil
 }
 
 var (

--- a/pkg/apiserver/domain/agent/service/server_test.go
+++ b/pkg/apiserver/domain/agent/service/server_test.go
@@ -366,6 +366,7 @@ func TestServerService_GetServer_CacheHit(t *testing.T) {
 		mockIdentity,
 		mockConnection,
 		mockAgent,
+		noopAgentCacheInvalidator{},
 	)
 
 	fakeClock := newTestFakeClock(now)
@@ -412,6 +413,7 @@ func TestServerService_GetServer_CacheMiss_Expired(t *testing.T) {
 		mockIdentity,
 		mockConnection,
 		mockAgent,
+		noopAgentCacheInvalidator{},
 	)
 
 	fakeClock := newTestFakeClock(now)
@@ -452,6 +454,7 @@ func TestServerService_GetServer_DatabaseError(t *testing.T) {
 		mockIdentity,
 		mockConnection,
 		mockAgent,
+		noopAgentCacheInvalidator{},
 	)
 
 	_, err := svc.GetServer(ctx, serverID)
@@ -496,6 +499,7 @@ func TestServerService_GetServer_CacheUpdate(t *testing.T) {
 		mockIdentity,
 		mockConnection,
 		mockAgent,
+		noopAgentCacheInvalidator{},
 	)
 
 	fakeClock := newTestFakeClock(now)
@@ -548,6 +552,7 @@ func TestServerService_SendMessageToServer_LocalShortCircuit(t *testing.T) {
 		mockIdentity,
 		mockConnection,
 		mockAgent,
+		noopAgentCacheInvalidator{},
 	)
 	svc.SetClock(newTestFakeClock(now))
 
@@ -597,6 +602,7 @@ func TestServerService_SendMessageToServer_RemoteDispatch(t *testing.T) {
 		mockIdentity,
 		mockConnection,
 		mockAgent,
+		noopAgentCacheInvalidator{},
 	)
 	svc.SetClock(newTestFakeClock(now))
 
@@ -620,6 +626,21 @@ func TestServerService_SendMessageToServer_RemoteDispatch(t *testing.T) {
 		mock.Anything, mock.Anything, mock.Anything)
 }
 
+// noopAgentCacheInvalidator satisfies agentport.AgentCacheInvalidator in tests that do
+// not exercise cache invalidation.
+type noopAgentCacheInvalidator struct{}
+
+func (noopAgentCacheInvalidator) InvalidateCache(uuid.UUID) {}
+
+// spyAgentCacheInvalidator records the agent UIDs it was asked to invalidate.
+type spyAgentCacheInvalidator struct {
+	invalidated []uuid.UUID
+}
+
+func (s *spyAgentCacheInvalidator) InvalidateCache(instanceUID uuid.UUID) {
+	s.invalidated = append(s.invalidated, instanceUID)
+}
+
 func newLeaderTestService(
 	mockPersistence *MockServerPersistencePort,
 	mockIdentity *MockServerIdentityProvider,
@@ -633,6 +654,29 @@ func newLeaderTestService(
 		mockIdentity,
 		new(MockConnectionUsecase),
 		new(MockAgentUsecase),
+		noopAgentCacheInvalidator{},
+	)
+	svc.SetClock(newTestFakeClock(now))
+
+	return svc
+}
+
+func newServerServiceForInvalidation(
+	mockPersistence *MockServerPersistencePort,
+	mockEventSender *MockServerEventSenderPort,
+	mockIdentity *MockServerIdentityProvider,
+	invalidator agentport.AgentCacheInvalidator,
+	now time.Time,
+) *agentservice.ServerService {
+	svc := agentservice.NewServerService(
+		slog.Default(),
+		mockPersistence,
+		mockEventSender,
+		new(MockServerEventReceiverPort),
+		mockIdentity,
+		new(MockConnectionUsecase),
+		new(MockAgentUsecase),
+		invalidator,
 	)
 	svc.SetClock(newTestFakeClock(now))
 
@@ -717,4 +761,78 @@ func TestServerService_IsLeader(t *testing.T) {
 		require.ErrorIs(t, err, agentservice.ErrNoCurrentServerID)
 		assert.False(t, isLeader)
 	})
+}
+
+func TestServerService_BroadcastAgentCacheInvalidation_SkipsSelfSendsPeers(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	now := time.Now()
+	uid := uuid.New()
+
+	mockPersistence := new(MockServerPersistencePort)
+	mockEventSender := new(MockServerEventSenderPort)
+	mockIdentity := new(MockServerIdentityProvider)
+
+	mockIdentity.On("CurrentServerID").Return("server-1")
+	mockPersistence.On("ListServers", ctx).Return([]*agentmodel.Server{
+		{ID: "server-1", LastHeartbeatAt: now}, // self
+		{ID: "server-2", LastHeartbeatAt: now}, // peer
+	}, nil)
+	mockEventSender.On("SendMessageToServer", ctx, "server-2", mock.MatchedBy(
+		func(m serverevent.Message) bool {
+			return m.Type == serverevent.MessageTypeInvalidateAgentCache &&
+				m.Payload.MessageForInvalidateAgentCache != nil &&
+				len(m.Payload.AgentInstanceUIDs) == 1 &&
+				m.Payload.AgentInstanceUIDs[0] == uid
+		},
+	)).Return(nil)
+
+	svc := newServerServiceForInvalidation(mockPersistence, mockEventSender, mockIdentity,
+		new(spyAgentCacheInvalidator), now)
+
+	err := svc.BroadcastAgentCacheInvalidation(ctx, uid)
+	require.NoError(t, err)
+
+	mockEventSender.AssertCalled(t, "SendMessageToServer", ctx, "server-2", mock.Anything)
+	mockEventSender.AssertNotCalled(t, "SendMessageToServer", ctx, "server-1", mock.Anything)
+}
+
+func TestServerService_HandleInvalidateAgentCacheEvent_InvalidatesLocally(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	now := time.Now()
+	uid := uuid.New()
+
+	mockPersistence := new(MockServerPersistencePort)
+	mockEventSender := new(MockServerEventSenderPort)
+	mockIdentity := new(MockServerIdentityProvider)
+	spy := new(spyAgentCacheInvalidator)
+
+	// Target the current server so SendMessageToServer dispatches the event locally,
+	// exercising the receive path (handleInvalidateAgentCacheEvent) without Kafka.
+	mockIdentity.On("CurrentServerID").Return("server-1")
+
+	svc := newServerServiceForInvalidation(mockPersistence, mockEventSender, mockIdentity, spy, now)
+
+	msg := serverevent.Message{
+		Source: "server-2",
+		Target: "server-1",
+		Type:   serverevent.MessageTypeInvalidateAgentCache,
+		Payload: serverevent.MessagePayload{
+			MessageForServerToAgent: nil,
+			MessageForInvalidateAgentCache: &serverevent.MessageForInvalidateAgentCache{
+				AgentInstanceUIDs: []uuid.UUID{uid},
+			},
+		},
+	}
+	self := &agentmodel.Server{ID: "server-1", LastHeartbeatAt: now}
+
+	err := svc.SendMessageToServer(ctx, self, msg)
+	require.NoError(t, err)
+
+	require.Len(t, spy.invalidated, 1)
+	assert.Equal(t, uid, spy.invalidated[0])
+	mockEventSender.AssertNotCalled(t, "SendMessageToServer", mock.Anything, mock.Anything, mock.Anything)
 }

--- a/pkg/apiserver/internal/module/domain/domain.go
+++ b/pkg/apiserver/internal/module/domain/domain.go
@@ -27,6 +27,7 @@ func New() fx.Option {
 		fx.Annotate(
 			Identity[*agentservice.AgentService],
 			fx.As(new(agentport.AgentUsecase)),
+			fx.As(new(agentport.AgentCacheInvalidator)),
 		),
 		agentservice.NewAgentGroupService,
 		fx.Annotate(
@@ -49,6 +50,7 @@ func New() fx.Option {
 			fx.As(new(agentport.ServerUsecase)),
 			fx.As(new(agentport.ServerMessageUsecase)),
 			fx.As(new(agentport.LeaderElector)),
+			fx.As(new(agentport.AgentCacheInvalidationPublisher)),
 		),
 		agentservice.NewServerIdentityService,
 		fx.Annotate(

--- a/test/integration/restart_test.go
+++ b/test/integration/restart_test.go
@@ -39,6 +39,7 @@ func TestRestartAgentIntegration(t *testing.T) {
 			agentUsecase,
 			agentNotificationUsecase,
 			mockEndpointDetectionUsecase{},
+			noopCacheInvalidationPublisher{},
 			slog.Default(),
 		)
 
@@ -97,6 +98,7 @@ func TestRestartAgentIntegration(t *testing.T) {
 			agentUsecase,
 			agentNotificationUsecase,
 			mockEndpointDetectionUsecase{},
+			noopCacheInvalidationPublisher{},
 			slog.Default(),
 		)
 
@@ -211,4 +213,14 @@ func (mockEndpointDetectionUsecase) ExtractEndpointsFromAgent(
 	_ *agentmodel.Agent,
 ) ([]*agentmodel.Endpoint, error) {
 	return nil, nil
+}
+
+// noopCacheInvalidationPublisher satisfies agentport.AgentCacheInvalidationPublisher in
+// integration tests that do not assert on cross-node cache invalidation.
+type noopCacheInvalidationPublisher struct{}
+
+func (noopCacheInvalidationPublisher) BroadcastAgentCacheInvalidation(
+	context.Context, ...uuid.UUID,
+) error {
+	return nil
 }


### PR DESCRIPTION
Closes #466.

## Problem
Each apiserver node keeps its own in-process agent cache (`ttlcache`, 30s TTL) with **no cross-node invalidation**. After an API write on node A, node B kept serving the agent stale from its cache until the TTL expired — there is no read-your-writes consistency across nodes.

## Change
Broadcast a cache-invalidation event to peer nodes when an agent is mutated **through the API**, over the existing inter-server messaging (Kafka, or in-memory in standalone mode).

- **`serverevent.MessageTypeInvalidateAgentCache`** (+ `MessageForInvalidateAgentCache` payload) and its CloudEvent type mapping. The two payload variants use distinct JSON field names, so they decode unambiguously.
- **`ServerService.BroadcastAgentCacheInvalidation`** sends the event to every *other* alive server (self is skipped — its cache was already refreshed by the write itself) and handles inbound events by dropping the listed agents from the local cache via the new `AgentCacheInvalidator`. Delivery is best-effort: a per-peer send failure is logged, never fatal, since the entry expires on its TTL regardless.
- The **application agent service** broadcasts after `UpdateAgent` and `DeleteAgent`.

## Scope decision (per discussion)
Heartbeat-driven persistence deliberately does **not** broadcast. That write volume would flood the cluster, and heartbeat-derived staleness (SequenceNum/LastReportedAt) on other nodes is bounded by the cache TTL and harmless. Only explicit API mutations broadcast. In single-node / in-memory mode there are no peers, so this is a no-op (one `ListServers` per API write).

Server-cache invalidation is intentionally out of scope (server records change rarely; staleness impact is minor).

## Tests
- `ServerService.BroadcastAgentCacheInvalidation`: sends to peers, skips self, carries the right message type + UIDs.
- Inbound invalidation event drops the agent from the local cache (exercised via the local-dispatch path).
- Application `DeleteAgent` triggers the broadcast.
- FX `ValidateWiring` passes (no dependency cycle from the new edges).

## Relationship to #465 / #467
Independent branch off `main`. Complements #465 (optimistic concurrency): once that lands, stale reads can no longer cause lost updates, and this PR closes the remaining read-your-writes gap for API mutations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)