### PR TITLE
docs(connection): clarify ListConnections is a node-local view (#468)

### DIFF
--- a/pkg/apiserver/adapter/primary/http/v1/connection/controller.go
+++ b/pkg/apiserver/adapter/primary/http/v1/connection/controller.go
@@ -52,7 +52,12 @@ func (c *Controller) RoutesInfo() gin.RoutesInfo {
 //
 // @Summary List Connections
 // @Tags connection
-// @Description  Retrieve a list of connections in a namespace.
+// @Description Retrieve the live connections in a namespace. NOTE: connections are
+// @Description WebSockets bound to a single server, so this returns only the connections
+// @Description held by the server instance handling the request — in a multi-server (HA)
+// @Description deployment it is a node-local view, not a cluster-wide list. For a global
+// @Description view of which agents are connected (and to which server), use the agents
+// @Description API (each agent reports its Connected status and last-reported server).
 // @Accept  json
 // @Produce json
 // @Param namespace path string true "Namespace"

--- a/pkg/apiserver/application/service/admin/admin.go
+++ b/pkg/apiserver/application/service/admin/admin.go
@@ -42,7 +42,9 @@ func New(
 	}
 }
 
-// ListConnections lists connections filtered by namespace.
+// ListConnections lists connections filtered by namespace. The result is scoped to the
+// server instance handling the request (connections are node-local live WebSockets); in
+// HA use the agents API for a cluster-wide view of connectivity.
 func (s *Service) ListConnections(
 	ctx context.Context,
 	namespace string,

--- a/pkg/apiserver/docs/docs.go
+++ b/pkg/apiserver/docs/docs.go
@@ -1905,7 +1905,7 @@ const docTemplate = `{
         },
         "/api/v1/namespaces/{namespace}/connections": {
             "get": {
-                "description": "Retrieve a list of connections in a namespace.",
+                "description": "Retrieve the live connections in a namespace. NOTE: connections are\nWebSockets bound to a single server, so this returns only the connections\nheld by the server instance handling the request — in a multi-server (HA)\ndeployment it is a node-local view, not a cluster-wide list. For a global\nview of which agents are connected (and to which server), use the agents\nAPI (each agent reports its Connected status and last-reported server).",
                 "consumes": [
                     "application/json"
                 ],

--- a/pkg/apiserver/docs/swagger.json
+++ b/pkg/apiserver/docs/swagger.json
@@ -1897,7 +1897,7 @@
         },
         "/api/v1/namespaces/{namespace}/connections": {
             "get": {
-                "description": "Retrieve a list of connections in a namespace.",
+                "description": "Retrieve the live connections in a namespace. NOTE: connections are\nWebSockets bound to a single server, so this returns only the connections\nheld by the server instance handling the request — in a multi-server (HA)\ndeployment it is a node-local view, not a cluster-wide list. For a global\nview of which agents are connected (and to which server), use the agents\nAPI (each agent reports its Connected status and last-reported server).",
                 "consumes": [
                     "application/json"
                 ],

--- a/pkg/apiserver/docs/swagger.yaml
+++ b/pkg/apiserver/docs/swagger.yaml
@@ -2770,7 +2770,13 @@ paths:
     get:
       consumes:
       - application/json
-      description: Retrieve a list of connections in a namespace.
+      description: |-
+        Retrieve the live connections in a namespace. NOTE: connections are
+        WebSockets bound to a single server, so this returns only the connections
+        held by the server instance handling the request — in a multi-server (HA)
+        deployment it is a node-local view, not a cluster-wide list. For a global
+        view of which agents are connected (and to which server), use the agents
+        API (each agent reports its Connected status and last-reported server).
       parameters:
       - description: Namespace
         in: path

--- a/pkg/apiserver/domain/agent/port/in.go
+++ b/pkg/apiserver/domain/agent/port/in.go
@@ -377,7 +377,9 @@ type ConnectionUsecase interface {
 	GetOrCreateConnectionByID(ctx context.Context, id any) (*agentmodel.Connection, error)
 	// GetConnectionByID returns the connection for the given ID.
 	GetConnectionByID(ctx context.Context, id any) (*agentmodel.Connection, error)
-	// ListConnections returns the list of connections filtered by namespace.
+	// ListConnections returns the list of connections filtered by namespace. The result is
+	// scoped to the current server instance (connections are live WebSockets that live on a
+	// single node); in HA, query the agents API for a cluster-wide view of connectivity.
 	ListConnections(ctx context.Context, namespace string,
 		options *model.ListOptions) (*model.ListResponse[*agentmodel.Connection], error)
 	// SaveConnection saves the connection.

--- a/pkg/apiserver/domain/agent/service/connection.go
+++ b/pkg/apiserver/domain/agent/service/connection.go
@@ -24,6 +24,14 @@ const (
 )
 
 // Service is a struct that implements the ConnectionUsecase interface.
+//
+// connectionMap holds only the live connections owned by THIS server instance: an
+// OpAMP WebSocket is a stateful socket that lives on exactly one node, so it cannot be
+// shared or reconstructed elsewhere. Consequently every read here (GetConnectionByID,
+// ListConnections, ...) is node-scoped by design. In an HA deployment, the cluster-wide
+// view of which agents are connected and to which server is the agent record itself
+// (Status.Connected / Status.ConnectionType / Status.LastReportedTo), which is persisted
+// and queryable through the agents API — not this transport-level map.
 type Service struct {
 	agentUsecase  agentport.AgentUsecase
 	logger        *slog.Logger
@@ -94,6 +102,10 @@ func (s *Service) GetConnectionByInstanceUID(_ context.Context, instanceUID uuid
 }
 
 // ListConnections implements agentport.ConnectionUsecase.
+//
+// It returns only the connections held by this server instance (see the Service doc):
+// in HA the result is the local node's live connections, not a cluster-wide list. Use
+// the agents API for a global view of agent connectivity.
 func (s *Service) ListConnections(
 	_ context.Context,
 	namespace string,

--- a/pkg/client/connection.go
+++ b/pkg/client/connection.go
@@ -61,7 +61,10 @@ func (s *ConnectionService) GetConnection(
 	return &result, nil
 }
 
-// ListConnections lists connections in a namespace.
+// ListConnections lists connections in a namespace. The server returns only the live
+// connections held by the instance that handles the request, so against an HA deployment
+// this is a node-local view; for a cluster-wide picture of agent connectivity, list agents
+// instead (each carries its connected status and last-reported server).
 func (s *ConnectionService) ListConnections(
 	ctx context.Context,
 	namespace string,


### PR DESCRIPTION
Closes #468.

## Context
`ListConnections` is backed by an in-process map of live OpAMP WebSockets. A WebSocket is a stateful socket bound to exactly one server, so the connection-list API returns only the connections held by the node serving the request. In an HA deployment this is a **node-local view**, not a cluster-wide list — which was undocumented and surprising (the original concern in #468).

## Decision
Node-local is correct by design: connections cannot be shared or reconstructed across nodes. A cluster-wide view of agent connectivity is already available from the **agents API** — each agent persists `Status.Connected`, `Status.ConnectionType`, and `Status.LastReportedTo` (the server it last reported to). Building a cross-node connection aggregation would duplicate that and require an ephemeral fan-out mechanism the messaging layer doesn't have.

So this PR documents the scope rather than changing behaviour.

## Changes (docs only)
- Domain `Service` / `ListConnections` godoc: explain the node-local scope and where the global view lives.
- `ConnectionUsecase.ListConnections` port doc.
- Application `admin.ListConnections` doc.
- HTTP controller Swagger `@Description` (regenerated `docs.go` / `swagger.json` / `swagger.yaml`).
- Go client `ConnectionService.ListConnections` doc.

No behavioural change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)