### PR TITLE
feat(connection): cluster-wide connection listing via periodic snapshots

### DIFF
--- a/api/v1/connection.go
+++ b/api/v1/connection.go
@@ -22,6 +22,10 @@ type Connection struct {
 	// Type is the type of connection (e.g., "http", "websocket").
 	Type string `json:"type"`
 
+	// ServerID is the server instance holding the connection. It is populated for
+	// cluster-wide listings (scope=cluster) and empty for the node-local listing.
+	ServerID string `json:"serverId,omitempty"`
+
 	// LastCommunicatedAt is the timestamp of the last communication with the agent.
 	LastCommunicatedAt Time `json:"lastCommunicatedAt"`
 

--- a/pkg/apiserver/adapter/primary/http/v1/connection/controller.go
+++ b/pkg/apiserver/adapter/primary/http/v1/connection/controller.go
@@ -13,6 +13,10 @@ import (
 	"github.com/minuk-dev/opampcommander/pkg/utils/clock"
 )
 
+// scopeCluster is the value of the "scope" query parameter that requests a cluster-wide
+// connection listing instead of the default node-local one.
+const scopeCluster = "cluster"
+
 // Controller is a struct that handles HTTP requests related to connections.
 type Controller struct {
 	logger *slog.Logger
@@ -52,15 +56,17 @@ func (c *Controller) RoutesInfo() gin.RoutesInfo {
 //
 // @Summary List Connections
 // @Tags connection
-// @Description Retrieve the live connections in a namespace. NOTE: connections are
-// @Description WebSockets bound to a single server, so this returns only the connections
-// @Description held by the server instance handling the request — in a multi-server (HA)
-// @Description deployment it is a node-local view, not a cluster-wide list. For a global
-// @Description view of which agents are connected (and to which server), use the agents
-// @Description API (each agent reports its Connected status and last-reported server).
+// @Description Retrieve connections in a namespace. By default (scope=local) this returns
+// @Description only the connections held by the server instance handling the request —
+// @Description connections are WebSockets bound to a single node, so in a multi-server (HA)
+// @Description deployment the default is a node-local view. Pass scope=cluster to get a
+// @Description cluster-wide view aggregated from each server's periodic snapshot; those
+// @Description items include the owning serverId. For an always-current view of agent
+// @Description connectivity, the agents API remains authoritative.
 // @Accept  json
 // @Produce json
 // @Param namespace path string true "Namespace"
+// @Param scope query string false "Scope of the listing: 'local' (default) or 'cluster'"
 // @Param limit query int false "Maximum number of connections to return"
 // @Param continue query string false "Token to continue listing connections"
 // @Success 200 {object} v1.ListResponse[v1.Connection]
@@ -76,16 +82,20 @@ func (c *Controller) List(ctx *gin.Context) {
 		return
 	}
 
-	continueToken := ctx.Query("continue")
+	options := &applicationport.ListOptions{
+		Limit:          limit,
+		Continue:       ctx.Query("continue"),
+		IncludeDeleted: false,
+	}
 
 	var connectionResponse *v1.ListResponse[v1.Connection]
 
-	connectionResponse, err = c.adminUsecase.ListConnections(
-		ctx.Request.Context(), namespace, &applicationport.ListOptions{
-			Limit:          limit,
-			Continue:       continueToken,
-			IncludeDeleted: false,
-		})
+	if ctx.Query("scope") == scopeCluster {
+		connectionResponse, err = c.adminUsecase.ListClusterConnections(ctx.Request.Context(), namespace, options)
+	} else {
+		connectionResponse, err = c.adminUsecase.ListConnections(ctx.Request.Context(), namespace, options)
+	}
+
 	if err != nil {
 		c.logger.Error("failed to list connections", "error", err.Error())
 		ginutil.InternalServerError(ctx, err, "An error occurred while listing connections.")

--- a/pkg/apiserver/adapter/primary/http/v1/connection/controller_test.go
+++ b/pkg/apiserver/adapter/primary/http/v1/connection/controller_test.go
@@ -160,3 +160,14 @@ func (m *mockAdminUsecase) ListConnections(
 
 	return args.Get(0).(*v1.ListResponse[v1.Connection]), args.Error(1)
 }
+
+func (m *mockAdminUsecase) ListClusterConnections(
+	ctx context.Context,
+	namespace string,
+	options *applicationport.ListOptions,
+) (*v1.ListResponse[v1.Connection], error) {
+	args := m.Called(ctx, namespace, options)
+	resp, _ := args.Get(0).(*v1.ListResponse[v1.Connection])
+
+	return resp, args.Error(1) //nolint:wrapcheck // mock error
+}

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/inmemory_test.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/inmemory_test.go
@@ -485,3 +485,88 @@ func TestAgentRepository_PutAgentConflictOnConcurrentCreate(t *testing.T) {
 	// The second create-as-v0 must conflict rather than insert a duplicate.
 	require.ErrorIs(t, repo.PutAgent(ctx, createB), model.ErrConflict)
 }
+
+func TestServerConnectionRepository_ReplaceAndList(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo := inmemory.NewServerConnectionRepository()
+	now := time.Now()
+
+	sc := func(server, ns string, uid uuid.UUID) *agentmodel.ServerConnection {
+		return &agentmodel.ServerConnection{
+			ServerID:           server,
+			UID:                uid,
+			InstanceUID:        uuid.New(),
+			Type:               agentmodel.ConnectionTypeWebSocket,
+			Namespace:          ns,
+			LastCommunicatedAt: now,
+			SnapshotAt:         now,
+		}
+	}
+
+	a1, a2, b1 := uuid.New(), uuid.New(), uuid.New()
+	require.NoError(t, repo.ReplaceServerConnections(ctx, "server-a", []*agentmodel.ServerConnection{
+		sc("server-a", "default", a1), sc("server-a", "default", a2),
+	}))
+	require.NoError(t, repo.ReplaceServerConnections(ctx, "server-b", []*agentmodel.ServerConnection{
+		sc("server-b", "default", b1),
+	}))
+
+	// Cluster view spans both servers.
+	resp, err := repo.ListServerConnections(ctx, "default", time.Time{}, nil)
+	require.NoError(t, err)
+	assert.Len(t, resp.Items, 3)
+
+	// Replacing one server's set only affects that server.
+	require.NoError(t, repo.ReplaceServerConnections(ctx, "server-a", []*agentmodel.ServerConnection{
+		sc("server-a", "default", a1),
+	}))
+
+	resp, err = repo.ListServerConnections(ctx, "default", time.Time{}, nil)
+	require.NoError(t, err)
+	assert.Len(t, resp.Items, 2) // a1 + b1
+
+	// Clearing a server removes its records.
+	require.NoError(t, repo.ReplaceServerConnections(ctx, "server-b", nil))
+
+	resp, err = repo.ListServerConnections(ctx, "default", time.Time{}, nil)
+	require.NoError(t, err)
+	assert.Len(t, resp.Items, 1)
+	assert.Equal(t, "server-a", resp.Items[0].ServerID)
+}
+
+func TestServerConnectionRepository_ListFiltersNamespaceAndStaleness(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo := inmemory.NewServerConnectionRepository()
+	now := time.Now()
+
+	fresh := &agentmodel.ServerConnection{
+		ServerID: "server-a", UID: uuid.New(), InstanceUID: uuid.New(),
+		Type: agentmodel.ConnectionTypeHTTP, Namespace: "ns-a",
+		LastCommunicatedAt: now, SnapshotAt: now,
+	}
+	otherNS := &agentmodel.ServerConnection{
+		ServerID: "server-a", UID: uuid.New(), InstanceUID: uuid.New(),
+		Type: agentmodel.ConnectionTypeHTTP, Namespace: "ns-b",
+		LastCommunicatedAt: now, SnapshotAt: now,
+	}
+	stale := &agentmodel.ServerConnection{
+		ServerID: "server-c", UID: uuid.New(), InstanceUID: uuid.New(),
+		Type: agentmodel.ConnectionTypeHTTP, Namespace: "ns-a",
+		LastCommunicatedAt: now, SnapshotAt: now.Add(-10 * time.Minute),
+	}
+
+	require.NoError(t, repo.ReplaceServerConnections(ctx, "server-a",
+		[]*agentmodel.ServerConnection{fresh, otherNS}))
+	require.NoError(t, repo.ReplaceServerConnections(ctx, "server-c",
+		[]*agentmodel.ServerConnection{stale}))
+
+	// Namespace filter + staleness cutoff (notBefore) excludes other-namespace and stale records.
+	resp, err := repo.ListServerConnections(ctx, "ns-a", now.Add(-90*time.Second), nil)
+	require.NoError(t, err)
+	require.Len(t, resp.Items, 1)
+	assert.Equal(t, fresh.UID, resp.Items[0].UID)
+}

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/serverconnection.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/serverconnection.go
@@ -1,0 +1,80 @@
+package inmemory
+
+import (
+	"context"
+	"time"
+
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent"
+	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+)
+
+var _ agentport.ServerConnectionPersistencePort = (*ServerConnectionRepository)(nil)
+
+// ServerConnectionRepository is the in-memory implementation of
+// [agentport.ServerConnectionPersistencePort]. It backs standalone mode, where there is
+// only one server, so the cluster view is simply this process's own snapshot.
+type ServerConnectionRepository struct {
+	store *store[string, *agentmodel.ServerConnection]
+}
+
+// NewServerConnectionRepository creates a new in-memory ServerConnectionRepository.
+func NewServerConnectionRepository() *ServerConnectionRepository {
+	return &ServerConnectionRepository{
+		store: newStore[string](cloneServerConnection, nil),
+	}
+}
+
+// ReplaceServerConnections implements agentport.ServerConnectionPersistencePort.
+func (r *ServerConnectionRepository) ReplaceServerConnections(
+	_ context.Context,
+	serverID string,
+	conns []*agentmodel.ServerConnection,
+) error {
+	existing := r.store.snapshot(false, func(sc *agentmodel.ServerConnection) bool {
+		return sc.ServerID == serverID
+	})
+	for _, sc := range existing {
+		_ = r.store.delete(serverConnectionKey(sc))
+	}
+
+	for _, sc := range conns {
+		r.store.put(serverConnectionKey(sc), sc)
+	}
+
+	return nil
+}
+
+// ListServerConnections implements agentport.ServerConnectionPersistencePort.
+func (r *ServerConnectionRepository) ListServerConnections(
+	_ context.Context,
+	namespace string,
+	notBefore time.Time,
+	options *model.ListOptions,
+) (*model.ListResponse[*agentmodel.ServerConnection], error) {
+	return r.store.list(options, func(sc *agentmodel.ServerConnection) bool {
+		if sc.Namespace != namespace {
+			return false
+		}
+
+		if !notBefore.IsZero() && sc.SnapshotAt.Before(notBefore) {
+			return false
+		}
+
+		return true
+	})
+}
+
+func serverConnectionKey(sc *agentmodel.ServerConnection) string {
+	return sc.ServerID + "/" + sc.UID.String()
+}
+
+func cloneServerConnection(sc *agentmodel.ServerConnection) *agentmodel.ServerConnection {
+	if sc == nil {
+		return nil
+	}
+
+	clone := *sc
+
+	return &clone
+}

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/entity/serverconnection.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/entity/serverconnection.go
@@ -1,0 +1,70 @@
+package entity
+
+import (
+	"time"
+
+	"github.com/google/uuid"
+	"go.mongodb.org/mongo-driver/v2/bson"
+
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent"
+)
+
+// ServerConnection represents a per-server connection snapshot in MongoDB. Each alive
+// server periodically replaces its own set of records so the cluster-wide connection view
+// can be queried from any node.
+type ServerConnection struct {
+	// ID is the MongoDB ObjectID.
+	ID *bson.ObjectID `bson:"_id,omitempty"`
+	// ServerID is the server instance that owns this connection.
+	ServerID string `bson:"serverId"`
+	// UID is the connection's unique identifier (string form of the UUID).
+	UID string `bson:"uid"`
+	// InstanceUID is the agent instance UID (string form of the UUID).
+	InstanceUID string `bson:"instanceUid"`
+	// Type is the connection type string (e.g. "HTTP", "WebSocket").
+	Type string `bson:"type"`
+	// Namespace is the namespace the connection belongs to.
+	Namespace string `bson:"namespace"`
+	// LastCommunicatedAt is the last time the connection was communicated with.
+	LastCommunicatedAt time.Time `bson:"lastCommunicatedAt"`
+	// SnapshotAt is when the owning server last refreshed this record.
+	SnapshotAt time.Time `bson:"snapshotAt"`
+}
+
+// ToDomain converts the entity to a domain model. Unparseable UUIDs become uuid.Nil.
+func (e *ServerConnection) ToDomain() *agentmodel.ServerConnection {
+	if e == nil {
+		return nil
+	}
+
+	uid, _ := uuid.Parse(e.UID)
+	instanceUID, _ := uuid.Parse(e.InstanceUID)
+
+	return &agentmodel.ServerConnection{
+		ServerID:           e.ServerID,
+		UID:                uid,
+		InstanceUID:        instanceUID,
+		Type:               agentmodel.ConnectionTypeFromString(e.Type),
+		Namespace:          e.Namespace,
+		LastCommunicatedAt: e.LastCommunicatedAt,
+		SnapshotAt:         e.SnapshotAt,
+	}
+}
+
+// ServerConnectionFromDomain converts a domain model to an entity.
+func ServerConnectionFromDomain(conn *agentmodel.ServerConnection) *ServerConnection {
+	if conn == nil {
+		return nil
+	}
+
+	return &ServerConnection{
+		ID:                 nil,
+		ServerID:           conn.ServerID,
+		UID:                conn.UID.String(),
+		InstanceUID:        conn.InstanceUID.String(),
+		Type:               conn.Type.String(),
+		Namespace:          conn.Namespace,
+		LastCommunicatedAt: conn.LastCommunicatedAt,
+		SnapshotAt:         conn.SnapshotAt,
+	}
+}

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/mongodb.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/mongodb.go
@@ -49,6 +49,7 @@ var (
 		certificateCollectionName,
 		namespaceCollectionName,
 		serverCollectionName,
+		serverConnectionCollectionName,
 	}
 
 	indexes = []collectionAndIndexes{
@@ -191,6 +192,26 @@ var (
 				{
 					Keys: bson.D{
 						{Key: "serverId", Value: 1},
+					},
+					Options: nil,
+				},
+			},
+		},
+		{
+			collectionName: serverConnectionCollectionName,
+			indexes: []mongo.IndexModel{
+				// Backs ReplaceServerConnections' per-server delete and the cluster-list
+				// query's namespace + snapshot-staleness filter.
+				{
+					Keys: bson.D{
+						{Key: "serverId", Value: 1},
+					},
+					Options: nil,
+				},
+				{
+					Keys: bson.D{
+						{Key: "namespace", Value: 1},
+						{Key: "snapshotAt", Value: 1},
 					},
 					Options: nil,
 				},

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/serverconnection.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/serverconnection.go
@@ -1,0 +1,147 @@
+package mongodb
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/samber/lo"
+	"go.mongodb.org/mongo-driver/v2/bson"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/secondary/persistence/mongodb/entity"
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent"
+	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+)
+
+const serverConnectionCollectionName = "serverconnections"
+
+var _ agentport.ServerConnectionPersistencePort = (*ServerConnectionAdapter)(nil)
+
+// ServerConnectionAdapter persists per-server connection snapshots in MongoDB.
+type ServerConnectionAdapter struct {
+	collection *mongo.Collection
+	logger     *slog.Logger
+}
+
+// NewServerConnectionAdapter creates a new instance of ServerConnectionAdapter.
+func NewServerConnectionAdapter(database *mongo.Database, logger *slog.Logger) *ServerConnectionAdapter {
+	return &ServerConnectionAdapter{
+		collection: database.Collection(serverConnectionCollectionName),
+		logger:     logger,
+	}
+}
+
+// ReplaceServerConnections implements agentport.ServerConnectionPersistencePort.
+//
+// It deletes the owning server's existing records and inserts the new set. The two steps
+// are not transactional; a reader hitting the brief gap simply sees this server's
+// connections momentarily missing, which is acceptable for a periodic snapshot view.
+func (a *ServerConnectionAdapter) ReplaceServerConnections(
+	ctx context.Context,
+	serverID string,
+	conns []*agentmodel.ServerConnection,
+) error {
+	_, err := a.collection.DeleteMany(ctx, bson.M{"serverId": serverID})
+	if err != nil {
+		return fmt.Errorf("failed to delete server connections from mongodb: %w", err)
+	}
+
+	if len(conns) == 0 {
+		return nil
+	}
+
+	docs := lo.Map(conns, func(conn *agentmodel.ServerConnection, _ int) any {
+		return entity.ServerConnectionFromDomain(conn)
+	})
+
+	_, err = a.collection.InsertMany(ctx, docs)
+	if err != nil {
+		return fmt.Errorf("failed to insert server connections to mongodb: %w", err)
+	}
+
+	return nil
+}
+
+// ListServerConnections implements agentport.ServerConnectionPersistencePort.
+func (a *ServerConnectionAdapter) ListServerConnections(
+	ctx context.Context,
+	namespace string,
+	notBefore time.Time,
+	options *model.ListOptions,
+) (*model.ListResponse[*agentmodel.ServerConnection], error) {
+	if options == nil {
+		//exhaustruct:ignore
+		options = &model.ListOptions{}
+	}
+
+	conditions := []bson.M{{"namespace": sanitizeResourceName(namespace)}}
+	if !notBefore.IsZero() {
+		conditions = append(conditions, bson.M{"snapshotAt": bson.M{"$gte": notBefore}})
+	}
+
+	continueTokenObjectID, err := bson.ObjectIDFromHex(options.Continue)
+	if err != nil && options.Continue != "" {
+		return nil, fmt.Errorf("invalid continue token: %w", err)
+	}
+
+	if continueTokenFilter := withContinueToken(continueTokenObjectID); continueTokenFilter != nil {
+		conditions = append(conditions, continueTokenFilter)
+	}
+
+	filter := buildFilter(conditions)
+
+	count, err := a.collection.CountDocuments(ctx, filter)
+	if err != nil {
+		return nil, fmt.Errorf("failed to count server connections in mongodb: %w", err)
+	}
+
+	entities, continueToken, err := a.findServerConnections(ctx, filter, options.Limit)
+	if err != nil {
+		return nil, err
+	}
+
+	return &model.ListResponse[*agentmodel.ServerConnection]{
+		Items: lo.Map(entities, func(item *entity.ServerConnection, _ int) *agentmodel.ServerConnection {
+			return item.ToDomain()
+		}),
+		Continue:           continueToken,
+		RemainingItemCount: count - int64(len(entities)),
+	}, nil
+}
+
+// findServerConnections runs the paginated find and returns the decoded entities plus the
+// continue token for the next page.
+func (a *ServerConnectionAdapter) findServerConnections(
+	ctx context.Context,
+	filter bson.M,
+	limit int64,
+) ([]*entity.ServerConnection, string, error) {
+	cursor, err := a.collection.Find(ctx, filter, withPageOptions(limit))
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to find server connections in mongodb: %w", err)
+	}
+
+	defer func() {
+		closeErr := cursor.Close(ctx)
+		if closeErr != nil {
+			a.logger.Warn("failed to close mongodb cursor", slog.String("error", closeErr.Error()))
+		}
+	}()
+
+	var entities []*entity.ServerConnection
+
+	err = cursor.All(ctx, &entities)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to decode server connections from mongodb: %w", err)
+	}
+
+	continueToken, err := getContinueTokenFromEntities(entities)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to get continue token from entities: %w", err)
+	}
+
+	return entities, continueToken, nil
+}

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/serverconnection_test.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/serverconnection_test.go
@@ -1,0 +1,81 @@
+package mongodb_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	mongoTestContainer "github.com/testcontainers/testcontainers-go/modules/mongodb"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/secondary/persistence/mongodb"
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent"
+	"github.com/minuk-dev/opampcommander/pkg/testutil"
+)
+
+func TestServerConnectionMongoAdapter(t *testing.T) {
+	testcontainers.SkipIfProviderIsNotHealthy(t)
+	t.Parallel()
+	base := testutil.NewBase(t)
+	ctx := t.Context()
+	mongoDBContainer, err := mongoTestContainer.Run(ctx, testMongoDBImage)
+	require.NoError(t, err)
+
+	mongoDBURI, err := mongoDBContainer.ConnectionString(ctx)
+	require.NoError(t, err)
+
+	client, err := mongo.Connect(options.Client().ApplyURI(mongoDBURI))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, client.Disconnect(ctx))
+	})
+
+	database := client.Database("testdb")
+	adapter := mongodb.NewServerConnectionAdapter(database, base.Logger)
+
+	now := time.Now()
+	rec := func(server, ns string, uid uuid.UUID, snapshotAt time.Time) *agentmodel.ServerConnection {
+		return &agentmodel.ServerConnection{
+			ServerID: server, UID: uid, InstanceUID: uuid.New(),
+			Type: agentmodel.ConnectionTypeWebSocket, Namespace: ns,
+			LastCommunicatedAt: now, SnapshotAt: snapshotAt,
+		}
+	}
+
+	a1, b1 := uuid.New(), uuid.New()
+
+	t.Run("replace per server and list cluster-wide", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, adapter.ReplaceServerConnections(ctx, "server-a",
+			[]*agentmodel.ServerConnection{rec("server-a", "default", a1, now)}))
+		require.NoError(t, adapter.ReplaceServerConnections(ctx, "server-b",
+			[]*agentmodel.ServerConnection{rec("server-b", "default", b1, now)}))
+
+		resp, err := adapter.ListServerConnections(ctx, "default", time.Time{}, nil)
+		require.NoError(t, err)
+		assert.Len(t, resp.Items, 2)
+
+		// Replacing one server's set leaves the other untouched.
+		require.NoError(t, adapter.ReplaceServerConnections(ctx, "server-a", nil))
+
+		resp, err = adapter.ListServerConnections(ctx, "default", time.Time{}, nil)
+		require.NoError(t, err)
+		require.Len(t, resp.Items, 1)
+		assert.Equal(t, "server-b", resp.Items[0].ServerID)
+		assert.Equal(t, b1, resp.Items[0].UID)
+	})
+
+	t.Run("staleness cutoff excludes old snapshots", func(t *testing.T) {
+		t.Parallel()
+		require.NoError(t, adapter.ReplaceServerConnections(ctx, "server-stale",
+			[]*agentmodel.ServerConnection{rec("server-stale", "ns-stale", uuid.New(), now.Add(-10*time.Minute))}))
+
+		resp, err := adapter.ListServerConnections(ctx, "ns-stale", now.Add(-90*time.Second), nil)
+		require.NoError(t, err)
+		assert.Empty(t, resp.Items)
+	})
+}

--- a/pkg/apiserver/application/port/in.go
+++ b/pkg/apiserver/application/port/in.go
@@ -42,7 +42,13 @@ type OpAMPUsecase interface {
 
 // AdminUsecase is a use case that handles admin operations.
 type AdminUsecase interface {
+	// ListConnections lists the connections held by the server instance handling the
+	// request (node-local view).
 	ListConnections(ctx context.Context, namespace string,
+		options *ListOptions) (*v1.ListResponse[v1.Connection], error)
+	// ListClusterConnections lists connections across all alive servers, aggregated from
+	// the periodic per-server snapshots. Each item carries its owning ServerID.
+	ListClusterConnections(ctx context.Context, namespace string,
 		options *ListOptions) (*v1.ListResponse[v1.Connection], error)
 }
 

--- a/pkg/apiserver/application/service/admin/admin.go
+++ b/pkg/apiserver/application/service/admin/admin.go
@@ -23,6 +23,7 @@ type Service struct {
 	clock                    clock.Clock
 	agentUsecase             agentport.AgentUsecase
 	connectionUsecase        agentport.ConnectionUsecase
+	clusterConnectionUsecase agentport.ClusterConnectionUsecase
 	agentNotificationUsecase agentport.AgentNotificationUsecase
 }
 
@@ -30,6 +31,7 @@ type Service struct {
 func New(
 	agentUsecase agentport.AgentUsecase,
 	connectionUsecase agentport.ConnectionUsecase,
+	clusterConnectionUsecase agentport.ClusterConnectionUsecase,
 	agentNotificationUsecase agentport.AgentNotificationUsecase,
 	logger *slog.Logger,
 ) *Service {
@@ -38,6 +40,7 @@ func New(
 		clock:                    clock.RealClock{},
 		agentUsecase:             agentUsecase,
 		connectionUsecase:        connectionUsecase,
+		clusterConnectionUsecase: clusterConnectionUsecase,
 		agentNotificationUsecase: agentNotificationUsecase,
 	}
 }
@@ -64,6 +67,41 @@ func (s *Service) ListConnections(
 				InstanceUID:        connection.InstanceUID,
 				Namespace:          connection.Namespace,
 				Type:               connection.Type.String(),
+				ServerID:           "",
+				Alive:              connection.IsAlive(now),
+				LastCommunicatedAt: v1.NewTime(connection.LastCommunicatedAt),
+			}
+		}),
+		v1.ListMeta{
+			RemainingItemCount: response.RemainingItemCount,
+			Continue:           response.Continue,
+		},
+	), nil
+}
+
+// ListClusterConnections lists connections across all alive servers, aggregated from the
+// periodic per-server snapshots. Unlike ListConnections (node-local), this spans the whole
+// cluster; each item carries the ServerID of the node holding the connection.
+func (s *Service) ListClusterConnections(
+	ctx context.Context,
+	namespace string,
+	options *applicationport.ListOptions,
+) (*v1.ListResponse[v1.Connection], error) {
+	response, err := s.clusterConnectionUsecase.ListClusterConnections(ctx, namespace, options.ToDomain())
+	if err != nil {
+		return nil, fmt.Errorf("failed to list cluster connections: %w", err)
+	}
+
+	now := s.clock.Now()
+
+	return v1.NewConnectionListResponse(
+		lo.Map(response.Items, func(connection *agentmodel.ServerConnection, _ int) v1.Connection {
+			return v1.Connection{
+				ID:                 connection.UID,
+				InstanceUID:        connection.InstanceUID,
+				Namespace:          connection.Namespace,
+				Type:               connection.Type.String(),
+				ServerID:           connection.ServerID,
 				Alive:              connection.IsAlive(now),
 				LastCommunicatedAt: v1.NewTime(connection.LastCommunicatedAt),
 			}

--- a/pkg/apiserver/docs/docs.go
+++ b/pkg/apiserver/docs/docs.go
@@ -1905,7 +1905,7 @@ const docTemplate = `{
         },
         "/api/v1/namespaces/{namespace}/connections": {
             "get": {
-                "description": "Retrieve the live connections in a namespace. NOTE: connections are\nWebSockets bound to a single server, so this returns only the connections\nheld by the server instance handling the request — in a multi-server (HA)\ndeployment it is a node-local view, not a cluster-wide list. For a global\nview of which agents are connected (and to which server), use the agents\nAPI (each agent reports its Connected status and last-reported server).",
+                "description": "Retrieve connections in a namespace. By default (scope=local) this returns\nonly the connections held by the server instance handling the request —\nconnections are WebSockets bound to a single node, so in a multi-server (HA)\ndeployment the default is a node-local view. Pass scope=cluster to get a\ncluster-wide view aggregated from each server's periodic snapshot; those\nitems include the owning serverId. For an always-current view of agent\nconnectivity, the agents API remains authoritative.",
                 "consumes": [
                     "application/json"
                 ],
@@ -1923,6 +1923,12 @@ const docTemplate = `{
                         "name": "namespace",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Scope of the listing: 'local' (default) or 'cluster'",
+                        "name": "scope",
+                        "in": "query"
                     },
                     {
                         "type": "integer",
@@ -4105,6 +4111,10 @@ const docTemplate = `{
                 },
                 "namespace": {
                     "description": "Namespace is the namespace the connection belongs to.",
+                    "type": "string"
+                },
+                "serverId": {
+                    "description": "ServerID is the server instance holding the connection. It is populated for\ncluster-wide listings (scope=cluster) and empty for the node-local listing.",
                     "type": "string"
                 },
                 "type": {

--- a/pkg/apiserver/docs/swagger.json
+++ b/pkg/apiserver/docs/swagger.json
@@ -1897,7 +1897,7 @@
         },
         "/api/v1/namespaces/{namespace}/connections": {
             "get": {
-                "description": "Retrieve the live connections in a namespace. NOTE: connections are\nWebSockets bound to a single server, so this returns only the connections\nheld by the server instance handling the request — in a multi-server (HA)\ndeployment it is a node-local view, not a cluster-wide list. For a global\nview of which agents are connected (and to which server), use the agents\nAPI (each agent reports its Connected status and last-reported server).",
+                "description": "Retrieve connections in a namespace. By default (scope=local) this returns\nonly the connections held by the server instance handling the request —\nconnections are WebSockets bound to a single node, so in a multi-server (HA)\ndeployment the default is a node-local view. Pass scope=cluster to get a\ncluster-wide view aggregated from each server's periodic snapshot; those\nitems include the owning serverId. For an always-current view of agent\nconnectivity, the agents API remains authoritative.",
                 "consumes": [
                     "application/json"
                 ],
@@ -1915,6 +1915,12 @@
                         "name": "namespace",
                         "in": "path",
                         "required": true
+                    },
+                    {
+                        "type": "string",
+                        "description": "Scope of the listing: 'local' (default) or 'cluster'",
+                        "name": "scope",
+                        "in": "query"
                     },
                     {
                         "type": "integer",
@@ -4097,6 +4103,10 @@
                 },
                 "namespace": {
                     "description": "Namespace is the namespace the connection belongs to.",
+                    "type": "string"
+                },
+                "serverId": {
+                    "description": "ServerID is the server instance holding the connection. It is populated for\ncluster-wide listings (scope=cluster) and empty for the node-local listing.",
                     "type": "string"
                 },
                 "type": {

--- a/pkg/apiserver/docs/swagger.yaml
+++ b/pkg/apiserver/docs/swagger.yaml
@@ -466,6 +466,11 @@ definitions:
       namespace:
         description: Namespace is the namespace the connection belongs to.
         type: string
+      serverId:
+        description: |-
+          ServerID is the server instance holding the connection. It is populated for
+          cluster-wide listings (scope=cluster) and empty for the node-local listing.
+        type: string
       type:
         description: Type is the type of connection (e.g., "http", "websocket").
         type: string
@@ -2771,17 +2776,22 @@ paths:
       consumes:
       - application/json
       description: |-
-        Retrieve the live connections in a namespace. NOTE: connections are
-        WebSockets bound to a single server, so this returns only the connections
-        held by the server instance handling the request — in a multi-server (HA)
-        deployment it is a node-local view, not a cluster-wide list. For a global
-        view of which agents are connected (and to which server), use the agents
-        API (each agent reports its Connected status and last-reported server).
+        Retrieve connections in a namespace. By default (scope=local) this returns
+        only the connections held by the server instance handling the request —
+        connections are WebSockets bound to a single node, so in a multi-server (HA)
+        deployment the default is a node-local view. Pass scope=cluster to get a
+        cluster-wide view aggregated from each server's periodic snapshot; those
+        items include the owning serverId. For an always-current view of agent
+        connectivity, the agents API remains authoritative.
       parameters:
       - description: Namespace
         in: path
         name: namespace
         required: true
+        type: string
+      - description: 'Scope of the listing: ''local'' (default) or ''cluster'''
+        in: query
+        name: scope
         type: string
       - description: Maximum number of connections to return
         in: query

--- a/pkg/apiserver/domain/agent/connection.go
+++ b/pkg/apiserver/domain/agent/connection.go
@@ -118,6 +118,37 @@ func (conn *Connection) IsAnonymous() bool {
 	return conn.InstanceUID == uuid.Nil
 }
 
+// ServerConnection is a persisted, cluster-visible snapshot of a single live connection,
+// stamped with the server instance that owns it. Each server periodically writes the
+// snapshot of its local connections so other servers can query a cluster-wide view (the
+// in-memory connection map itself is node-local). It is not the live connection — the
+// transport object (Connection.ID) is intentionally absent.
+type ServerConnection struct {
+	// ServerID is the identifier of the server instance that owns this connection.
+	ServerID string
+	// UID is the unique identifier of the connection.
+	UID uuid.UUID
+	// InstanceUID is the id of the agent on the other end.
+	InstanceUID uuid.UUID
+	// Type is the type of the connection.
+	Type ConnectionType
+	// Namespace is the namespace the connection belongs to.
+	Namespace string
+	// LastCommunicatedAt is the last time the connection was communicated with.
+	LastCommunicatedAt time.Time
+	// SnapshotAt is when this record was last refreshed by its owning server. It bounds
+	// staleness: records from a crashed server stop refreshing and are filtered out of
+	// cluster reads once SnapshotAt falls outside the staleness window.
+	SnapshotAt time.Time
+}
+
+// IsAlive reports whether the connection is alive, using the same rule as Connection.IsAlive:
+// WebSocket connections are always considered alive; others are alive while their last
+// communication is within the polling window.
+func (sc *ServerConnection) IsAlive(now time.Time) bool {
+	return sc.Type == ConnectionTypeWebSocket || now.Sub(sc.LastCommunicatedAt) < 2*OpAMPPollingInterval
+}
+
 // IsManaged returns true if the connection is managed.
 func (conn *Connection) IsManaged() bool {
 	return !conn.IsAnonymous()

--- a/pkg/apiserver/domain/agent/port/in.go
+++ b/pkg/apiserver/domain/agent/port/in.go
@@ -389,3 +389,13 @@ type ConnectionUsecase interface {
 	// SendServerToAgent sends a ServerToAgent message to the agent via WebSocket connection.
 	SendServerToAgent(ctx context.Context, instanceUID uuid.UUID, message *protobufs.ServerToAgent) error
 }
+
+// ClusterConnectionUsecase exposes a cluster-wide view of connections, aggregated from the
+// per-server snapshots each node periodically persists. Unlike ConnectionUsecase.ListConnections
+// (which is node-local), this returns connections held by every alive server.
+type ClusterConnectionUsecase interface {
+	// ListClusterConnections returns connections across all servers, filtered by namespace.
+	// Records from servers whose last snapshot is stale (e.g. a crashed node) are excluded.
+	ListClusterConnections(ctx context.Context, namespace string,
+		options *model.ListOptions) (*model.ListResponse[*agentmodel.ServerConnection], error)
+}

--- a/pkg/apiserver/domain/agent/port/out.go
+++ b/pkg/apiserver/domain/agent/port/out.go
@@ -98,6 +98,20 @@ type ServerPersistencePort interface {
 	ListServers(ctx context.Context) ([]*agentmodel.Server, error)
 }
 
+// ServerConnectionPersistencePort persists per-server snapshots of live connections so the
+// cluster-wide connection view can be queried from any node.
+type ServerConnectionPersistencePort interface {
+	// ReplaceServerConnections atomically replaces all snapshot records owned by serverID
+	// with the provided set. An empty set clears the server's records (e.g. on shutdown or
+	// when it holds no connections).
+	ReplaceServerConnections(ctx context.Context, serverID string, conns []*agentmodel.ServerConnection) error
+	// ListServerConnections lists snapshot records across all servers, filtered by namespace.
+	// notBefore drops records whose SnapshotAt is older than it (stale/crashed servers); a
+	// zero notBefore returns all records.
+	ListServerConnections(ctx context.Context, namespace string, notBefore time.Time,
+		options *model.ListOptions) (*model.ListResponse[*agentmodel.ServerConnection], error)
+}
+
 // AgentPackagePersistencePort is an interface that defines the methods for agent package persistence.
 type AgentPackagePersistencePort interface {
 	// GetAgentPackage retrieves an agent package by its namespace and name.

--- a/pkg/apiserver/domain/agent/service/connection.go
+++ b/pkg/apiserver/domain/agent/service/connection.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"sort"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/open-telemetry/opamp-go/protobufs"
@@ -14,13 +15,28 @@ import (
 	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent"
 	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	"github.com/minuk-dev/opampcommander/pkg/utils/clock"
 	"github.com/minuk-dev/opampcommander/pkg/xsync"
 )
 
-var _ agentport.ConnectionUsecase = (*Service)(nil)
+var (
+	_ agentport.ConnectionUsecase        = (*Service)(nil)
+	_ agentport.ClusterConnectionUsecase = (*Service)(nil)
+)
 
 const (
 	idxInstanceUID = "instanceUID"
+
+	connectionServiceName = "ConnectionService"
+
+	// DefaultConnectionSnapshotInterval is how often this server persists a snapshot of its
+	// local connections so other servers can see them in the cluster-wide view.
+	DefaultConnectionSnapshotInterval = 30 * time.Second
+	// DefaultConnectionSnapshotStaleness is how long a server's snapshot is trusted after its
+	// last refresh. Records older than this (a crashed/stopped server) are excluded from
+	// cluster reads. Sized at 3x the snapshot interval so a single missed snapshot does not
+	// drop a live server's connections.
+	DefaultConnectionSnapshotStaleness = 3 * DefaultConnectionSnapshotInterval
 )
 
 // Service is a struct that implements the ConnectionUsecase interface.
@@ -28,26 +44,85 @@ const (
 // connectionMap holds only the live connections owned by THIS server instance: an
 // OpAMP WebSocket is a stateful socket that lives on exactly one node, so it cannot be
 // shared or reconstructed elsewhere. Consequently every read here (GetConnectionByID,
-// ListConnections, ...) is node-scoped by design. In an HA deployment, the cluster-wide
-// view of which agents are connected and to which server is the agent record itself
-// (Status.Connected / Status.ConnectionType / Status.LastReportedTo), which is persisted
-// and queryable through the agents API — not this transport-level map.
+// ListConnections, ...) is node-scoped by design.
+//
+// For a cluster-wide view, each server periodically snapshots its connectionMap into the
+// shared ServerConnectionPersistencePort (see Run/ListClusterConnections); reads there span
+// every alive server. The agent record (Status.Connected / ConnectionType / LastReportedTo)
+// remains the authoritative, always-current source of agent connectivity.
 type Service struct {
-	agentUsecase  agentport.AgentUsecase
-	logger        *slog.Logger
-	connectionMap *xsync.MultiMap[*agentmodel.Connection]
+	agentUsecase                    agentport.AgentUsecase
+	logger                          *slog.Logger
+	connectionMap                   *xsync.MultiMap[*agentmodel.Connection]
+	serverIdentityProvider          agentport.ServerIdentityProvider
+	serverConnectionPersistencePort agentport.ServerConnectionPersistencePort
+	clock                           clock.Clock
+
+	snapshotInterval  time.Duration
+	snapshotStaleness time.Duration
 }
 
 // NewConnectionService creates a new instance of the Service struct.
 func NewConnectionService(
 	agentUsecase agentport.AgentUsecase,
+	serverIdentityProvider agentport.ServerIdentityProvider,
+	serverConnectionPersistencePort agentport.ServerConnectionPersistencePort,
 	logger *slog.Logger,
 ) *Service {
 	return &Service{
-		agentUsecase:  agentUsecase,
-		logger:        logger,
-		connectionMap: xsync.NewMultiMap[*agentmodel.Connection](),
+		agentUsecase:                    agentUsecase,
+		logger:                          logger,
+		connectionMap:                   xsync.NewMultiMap[*agentmodel.Connection](),
+		serverIdentityProvider:          serverIdentityProvider,
+		serverConnectionPersistencePort: serverConnectionPersistencePort,
+		clock:                           clock.NewRealClock(),
+		snapshotInterval:                DefaultConnectionSnapshotInterval,
+		snapshotStaleness:               DefaultConnectionSnapshotStaleness,
 	}
+}
+
+// Name implements scheduler.Scheduler.
+func (s *Service) Name() string {
+	return connectionServiceName
+}
+
+// Run implements scheduler.Scheduler. It periodically snapshots this server's local
+// connections into the shared store so they appear in the cluster-wide view, and clears
+// the server's records on graceful shutdown so a stopped node drops out immediately rather
+// than lingering until its snapshot goes stale.
+func (s *Service) Run(ctx context.Context) error {
+	ticker := time.NewTicker(s.effectiveSnapshotInterval())
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			s.clearSnapshotOnShutdown(ctx)
+
+			return nil
+		case <-ticker.C:
+			s.snapshotConnections(ctx)
+		}
+	}
+}
+
+// ListClusterConnections implements agentport.ClusterConnectionUsecase. It returns the
+// connections of every alive server from the shared snapshot store, excluding records whose
+// last snapshot is older than the staleness window (so a crashed server's connections do
+// not linger in the view).
+func (s *Service) ListClusterConnections(
+	ctx context.Context,
+	namespace string,
+	options *model.ListOptions,
+) (*model.ListResponse[*agentmodel.ServerConnection], error) {
+	notBefore := s.clock.Now().Add(-s.effectiveSnapshotStaleness())
+
+	resp, err := s.serverConnectionPersistencePort.ListServerConnections(ctx, namespace, notBefore, options)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list cluster connections: %w", err)
+	}
+
+	return resp, nil
 }
 
 // DeleteConnection implements agentport.ConnectionUsecase.
@@ -236,6 +311,80 @@ func (s *Service) detectConnectionType(id any) agentmodel.ConnectionType {
 	// maintains the connection after OnConnected
 	// HTTP only has connection during request processing
 	return agentmodel.ConnectionTypeWebSocket
+}
+
+// snapshotConnections persists the current set of this server's local connections,
+// replacing any previously stored set for this server.
+func (s *Service) snapshotConnections(ctx context.Context) {
+	serverID := s.serverIdentityProvider.CurrentServerID()
+	if serverID == "" {
+		s.logger.Warn("skipping connection snapshot: current server has no identity")
+
+		return
+	}
+
+	now := s.clock.Now()
+	conns := s.connectionMap.Values()
+
+	records := make([]*agentmodel.ServerConnection, 0, len(conns))
+	for _, conn := range conns {
+		records = append(records, &agentmodel.ServerConnection{
+			ServerID:           serverID,
+			UID:                conn.UID,
+			InstanceUID:        conn.InstanceUID,
+			Type:               conn.Type,
+			Namespace:          conn.Namespace,
+			LastCommunicatedAt: conn.LastCommunicatedAt,
+			SnapshotAt:         now,
+		})
+	}
+
+	err := s.serverConnectionPersistencePort.ReplaceServerConnections(ctx, serverID, records)
+	if err != nil {
+		s.logger.Error("failed to snapshot connections", slog.String("error", err.Error()))
+
+		return
+	}
+
+	s.logger.Debug("snapshotted connections", slog.Int("count", len(records)))
+}
+
+// clearSnapshotOnShutdown removes this server's snapshot records so it drops out of the
+// cluster view promptly on graceful shutdown. The passed ctx is already cancelled (Run only
+// calls this after ctx.Done), so it derives a fresh, short-lived context via WithoutCancel —
+// keeping any request values while shedding the cancellation. Best-effort: failures are
+// logged, not retried.
+func (s *Service) clearSnapshotOnShutdown(ctx context.Context) {
+	serverID := s.serverIdentityProvider.CurrentServerID()
+	if serverID == "" {
+		return
+	}
+
+	const clearTimeout = 5 * time.Second
+
+	clearCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), clearTimeout)
+	defer cancel()
+
+	err := s.serverConnectionPersistencePort.ReplaceServerConnections(clearCtx, serverID, nil)
+	if err != nil {
+		s.logger.Warn("failed to clear connection snapshot on shutdown", slog.String("error", err.Error()))
+	}
+}
+
+func (s *Service) effectiveSnapshotInterval() time.Duration {
+	if s.snapshotInterval <= 0 {
+		return DefaultConnectionSnapshotInterval
+	}
+
+	return s.snapshotInterval
+}
+
+func (s *Service) effectiveSnapshotStaleness() time.Duration {
+	if s.snapshotStaleness <= 0 {
+		return DefaultConnectionSnapshotStaleness
+	}
+
+	return s.snapshotStaleness
 }
 
 // NotSupportedConnectionTypeError is returned when an operation is attempted.

--- a/pkg/apiserver/domain/agent/service/connection_internal_test.go
+++ b/pkg/apiserver/domain/agent/service/connection_internal_test.go
@@ -1,0 +1,110 @@
+package agentservice
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+)
+
+type stubServerIdentity struct {
+	id string
+}
+
+func (s stubServerIdentity) CurrentServerID() string { return s.id }
+func (s stubServerIdentity) CurrentServer(context.Context) (*agentmodel.Server, error) {
+	return &agentmodel.Server{ID: s.id}, nil
+}
+
+type fakeServerConnectionStore struct {
+	replacedServerID string
+	replaced         []*agentmodel.ServerConnection
+	listNotBefore    time.Time
+	listResult       []*agentmodel.ServerConnection
+}
+
+func (f *fakeServerConnectionStore) ReplaceServerConnections(
+	_ context.Context, serverID string, conns []*agentmodel.ServerConnection,
+) error {
+	f.replacedServerID = serverID
+	f.replaced = conns
+
+	return nil
+}
+
+func (f *fakeServerConnectionStore) ListServerConnections(
+	_ context.Context, _ string, notBefore time.Time, _ *model.ListOptions,
+) (*model.ListResponse[*agentmodel.ServerConnection], error) {
+	f.listNotBefore = notBefore
+
+	return &model.ListResponse[*agentmodel.ServerConnection]{
+		Items:              f.listResult,
+		Continue:           "",
+		RemainingItemCount: 0,
+	}, nil
+}
+
+func TestConnectionService_snapshotConnections(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := &fakeServerConnectionStore{}
+	svc := NewConnectionService(nil, stubServerIdentity{id: "server-1"}, store, slog.Default())
+
+	instanceUID := uuid.New()
+	conn := agentmodel.NewConnection("conn-key", agentmodel.ConnectionTypeWebSocket)
+	conn.SetInstanceUID(instanceUID)
+	conn.SetNamespace("default")
+	require.NoError(t, svc.SaveConnection(ctx, conn))
+
+	svc.snapshotConnections(ctx)
+
+	assert.Equal(t, "server-1", store.replacedServerID)
+	require.Len(t, store.replaced, 1)
+	assert.Equal(t, "server-1", store.replaced[0].ServerID)
+	assert.Equal(t, instanceUID, store.replaced[0].InstanceUID)
+	assert.Equal(t, conn.UID, store.replaced[0].UID)
+}
+
+func TestConnectionService_snapshotConnectionsSkipsWithoutIdentity(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeServerConnectionStore{}
+	svc := NewConnectionService(nil, stubServerIdentity{id: ""}, store, slog.Default())
+
+	svc.snapshotConnections(context.Background())
+
+	assert.Empty(t, store.replacedServerID)
+	assert.Nil(t, store.replaced)
+}
+
+func TestConnectionService_ListClusterConnectionsAppliesStalenessWindow(t *testing.T) {
+	t.Parallel()
+
+	store := &fakeServerConnectionStore{
+		listResult: []*agentmodel.ServerConnection{
+			{ServerID: "server-2", UID: uuid.New(), Namespace: "default"},
+		},
+	}
+	svc := NewConnectionService(nil, stubServerIdentity{id: "server-1"}, store, slog.Default())
+
+	before := time.Now()
+	resp, err := svc.ListClusterConnections(context.Background(), "default", nil)
+	after := time.Now()
+
+	require.NoError(t, err)
+	assert.Len(t, resp.Items, 1)
+
+	// The query must exclude records older than the staleness window: notBefore should be
+	// roughly now - staleness.
+	assert.WithinRange(t, store.listNotBefore,
+		before.Add(-DefaultConnectionSnapshotStaleness),
+		after.Add(-DefaultConnectionSnapshotStaleness))
+}

--- a/pkg/apiserver/internal/module/adapter/secondary/inmemory.go
+++ b/pkg/apiserver/internal/module/adapter/secondary/inmemory.go
@@ -47,6 +47,7 @@ func NewInMemory() fx.Option {
 			// Agent-domain repositories.
 			fx.Annotate(inmemory.NewAgentGroupRepository, fx.As(new(agentport.AgentGroupPersistencePort))),
 			fx.Annotate(inmemory.NewServerRepository, fx.As(new(agentport.ServerPersistencePort))),
+			fx.Annotate(inmemory.NewServerConnectionRepository, fx.As(new(agentport.ServerConnectionPersistencePort))),
 			fx.Annotate(inmemory.NewAgentPackageRepository, fx.As(new(agentport.AgentPackagePersistencePort))),
 			fx.Annotate(inmemory.NewNamespaceRepository, fx.As(new(agentport.NamespacePersistencePort))),
 			fx.Annotate(inmemory.NewAgentRemoteConfigRepository, fx.As(new(agentport.AgentRemoteConfigPersistencePort))),

--- a/pkg/apiserver/internal/module/adapter/secondary/mongodb.go
+++ b/pkg/apiserver/internal/module/adapter/secondary/mongodb.go
@@ -35,6 +35,7 @@ func NewMongoDB() fx.Option {
 			fx.Annotate(mongodb.NewAgentRepository, fx.As(new(agentport.AgentPersistencePort))),
 			fx.Annotate(mongodb.NewAgentGroupRepository, fx.As(new(agentport.AgentGroupPersistencePort))),
 			fx.Annotate(mongodb.NewServerAdapter, fx.As(new(agentport.ServerPersistencePort))),
+			fx.Annotate(mongodb.NewServerConnectionAdapter, fx.As(new(agentport.ServerConnectionPersistencePort))),
 			fx.Annotate(mongodb.NewAgentPackageRepository, fx.As(new(agentport.AgentPackagePersistencePort))),
 			fx.Annotate(mongodb.NewNamespaceRepository, fx.As(new(agentport.NamespacePersistencePort))),
 			fx.Annotate(mongodb.NewAgentRemoteConfigRepository, fx.As(new(agentport.AgentRemoteConfigPersistencePort))),

--- a/pkg/apiserver/internal/module/domain/domain.go
+++ b/pkg/apiserver/internal/module/domain/domain.go
@@ -22,7 +22,12 @@ import (
 //nolint:funlen // DI wiring: a flat list of service providers/annotations.
 func New() fx.Option {
 	components := []any{
-		fx.Annotate(agentservice.NewConnectionService, fx.As(new(agentport.ConnectionUsecase))),
+		agentservice.NewConnectionService,
+		fx.Annotate(
+			Identity[*agentservice.Service],
+			fx.As(new(agentport.ConnectionUsecase)),
+			fx.As(new(agentport.ClusterConnectionUsecase)),
+		),
 		provideAgentService,
 		fx.Annotate(
 			Identity[*agentservice.AgentService],
@@ -73,6 +78,7 @@ func New() fx.Option {
 			Identity[*userservice.RBACService],
 			fx.As(new(userport.RBACUsecase)),
 		),
+		helper.AsRunner(Identity[*agentservice.Service]),
 		helper.AsRunner(Identity[*agentservice.AgentGroupService]),
 		helper.AsRunner(Identity[*agentservice.ServerService]),
 		helper.AsRunner(Identity[*agentservice.ServerIdentityService]),


### PR DESCRIPTION
Adds a use case to query connections held by **other servers**, not just the node serving the request.

> Stacked on #478 (docs(connection): node-local clarification). The first commit here is that PR's commit; review/merge #478 first, or merge this (it includes those docs). The diff to focus on is the second commit.

## Approach
Per the requirement, connections are **not** stored in real time — each server periodically snapshots its local connections to MongoDB, and the new query reads that. No inter-server fan-out, no leader, no extra heartbeat, and no per-request write load.

- Each server (default every **30s**) replaces its own record set in a shared `serverconnections` collection, stamping `snapshotAt`. On graceful shutdown it clears its records so the node drops out immediately.
- `ListClusterConnections` reads the shared store and excludes records whose `snapshotAt` is older than the staleness window (**3× the snapshot interval**), so a crashed server's connections age out on their own.

## Changes
- **Domain:** `ServerConnection` model; `ClusterConnectionUsecase` (in) and `ServerConnectionPersistencePort` (out).
- **Persistence:** MongoDB + in-memory adapters; `EnsureSchema` collection + indexes (`serverId`, `namespace+snapshotAt`).
- **Service:** `ConnectionService` is now a scheduler runner — periodic snapshot + shutdown clear (uses `context.WithoutCancel` so the already-cancelled run ctx still drives the final write).
- **API:** `GET /api/v1/namespaces/{namespace}/connections?scope=cluster` returns the cluster-wide view; items carry the owning `serverId` (new optional field on `v1.Connection`). Default scope stays node-local. Swagger regenerated.
- Wired via the admin application service.

## Tests
- In-memory adapter: per-server replace, cluster list, namespace + staleness filtering.
- `ConnectionService`: snapshot writes correct records / skips without identity; `ListClusterConnections` applies the staleness cutoff.
- MongoDB adapter (testcontainers): replace-per-server, cluster list, staleness cutoff.
- FX `ValidateWiring` passes (no DI cycle from `ConnectionService`'s new `ServerIdentityProvider` + persistence deps).

## Notes
- Staleness window and snapshot interval are constants (30s / 90s) today; could be made configurable later.
- The agents API remains the always-current source of agent connectivity; this is a connection-transport view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)