### PR TITLE
feat(web): view connections across all servers, with owning server shown

### DIFF
--- a/web/src/entities/connection/model/types.ts
+++ b/web/src/entities/connection/model/types.ts
@@ -3,6 +3,11 @@ export interface Connection {
   instanceUid: string;
   namespace: string;
   type: string;
+  /**
+   * The server instance holding the connection. Populated only for cluster-scoped
+   * listings (scope=cluster); empty for the node-local listing.
+   */
+  serverId?: string;
   lastCommunicatedAt: string;
   alive: boolean;
 }

--- a/web/src/views/connections/ui/ConnectionsPage.tsx
+++ b/web/src/views/connections/ui/ConnectionsPage.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import {
   Alert,
   Box,
@@ -13,6 +14,8 @@ import {
   TableContainer,
   TableHead,
   TableRow,
+  ToggleButton,
+  ToggleButtonGroup,
 } from '@mui/material';
 import { Refresh as RefreshIcon } from '@mui/icons-material';
 import Link from 'next/link';
@@ -22,12 +25,32 @@ import { TimeDisplay } from '@shared/preferences';
 import { useCursorPagination } from '@shared/lib';
 import type { Connection } from '@entities/connection';
 
+// Page connections in small batches so a large cluster-wide listing never pulls
+// thousands of rows at once.
+const PAGE_SIZE = 20;
+
+type Scope = 'cluster' | 'local';
+
 export default function ConnectionsPage() {
   const { namespace } = useNamespace();
-  const pagination = useCursorPagination<Connection>(`/api/v1/namespaces/${namespace}/connections`);
+  const [scope, setScope] = useState<Scope>('cluster');
+  const isCluster = scope === 'cluster';
+
+  const pagination = useCursorPagination<Connection>(
+    `/api/v1/namespaces/${namespace}/connections`,
+    {
+      initialPageSize: PAGE_SIZE,
+      // Cluster scope aggregates every server's connections (each carries its
+      // owning serverId); local scope returns only this node's connections.
+      query: isCluster ? { scope: 'cluster' } : undefined,
+    },
+  );
   const { items, isLoading: loading, error: fetchError, refresh } = pagination;
   const error =
     fetchError instanceof Error ? fetchError.message : fetchError ? 'Failed to fetch' : null;
+
+  // Server column is only meaningful in the cluster view.
+  const columnCount = isCluster ? 6 : 5;
 
   return (
     <Box>
@@ -40,6 +63,21 @@ export default function ConnectionsPage() {
           </IconButton>
         }
       />
+
+      <ToggleButtonGroup
+        value={scope}
+        exclusive
+        size="small"
+        color="primary"
+        onChange={(_, value: Scope | null) => {
+          if (value !== null) setScope(value);
+        }}
+        sx={{ mb: 2 }}
+      >
+        <ToggleButton value="cluster">All servers</ToggleButton>
+        <ToggleButton value="local">This node</ToggleButton>
+      </ToggleButtonGroup>
+
       {error && (
         <Alert severity="error" sx={{ mb: 2 }}>
           {error}
@@ -51,6 +89,7 @@ export default function ConnectionsPage() {
             <TableRow>
               <TableCell>Connection ID</TableCell>
               <TableCell>Instance UID</TableCell>
+              {isCluster && <TableCell>Server</TableCell>}
               <TableCell>Type</TableCell>
               <TableCell>Alive</TableCell>
               <TableCell>Last communicated</TableCell>
@@ -59,23 +98,26 @@ export default function ConnectionsPage() {
           <TableBody>
             {loading ? (
               <TableRow>
-                <TableCell colSpan={5} align="center">
+                <TableCell colSpan={columnCount} align="center">
                   <CircularProgress size={24} />
                 </TableCell>
               </TableRow>
             ) : items.length === 0 ? (
               <TableRow>
-                <TableCell colSpan={5} align="center">
+                <TableCell colSpan={columnCount} align="center">
                   No connections
                 </TableCell>
               </TableRow>
             ) : (
               items.map((c) => (
-                <TableRow key={c.id} hover>
+                <TableRow key={isCluster ? `${c.serverId ?? ''}/${c.id}` : c.id} hover>
                   <TableCell sx={{ fontFamily: 'monospace' }}>{c.id}</TableCell>
                   <TableCell sx={{ fontFamily: 'monospace' }}>
                     <Link href={`/agents/${c.instanceUid}`}>{c.instanceUid}</Link>
                   </TableCell>
+                  {isCluster && (
+                    <TableCell sx={{ fontFamily: 'monospace' }}>{c.serverId || '—'}</TableCell>
+                  )}
                   <TableCell>{c.type}</TableCell>
                   <TableCell>
                     <Chip


### PR DESCRIPTION
Builds on #480 (cluster-wide connection listing API).

## What
The web Connections page can now show connections held by **every server**, and shows **which server** each connection is attached to.

- Defaults to a cluster-wide view (`scope=cluster`); a toggle switches to the node-local view ("This node").
- New **Server** column (cluster view) shows each connection's owning `serverId`.
- Lists **20 at a time** (cursor pagination) so a large cluster-wide result is never pulled at once.

## Notes
- Uses the existing `scope=cluster` parameter and `serverId` field added to the connections API in #480; cluster items aggregate every alive server's periodic snapshot.
- Table stays in a horizontally-scrolling `TableContainer`, so the extra column remains usable on narrow (mobile) viewports.

## Checks
`tsc --noEmit`, `eslint`, `vitest` (64 passed), and `next build` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)