### PR TITLE
test(application): cover the untested application service orchestration layer (#485)

### DIFF
--- a/pkg/apiserver/application/service/admin/admin_test.go
+++ b/pkg/apiserver/application/service/admin/admin_test.go
@@ -1,0 +1,246 @@
+package admin_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/open-telemetry/opamp-go/protobufs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
+	adminsvc "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/admin"
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	"github.com/minuk-dev/opampcommander/pkg/testutil"
+)
+
+var errMock = errors.New("mock error")
+
+// mockConnectionUsecase is a mock implementation of agentport.ConnectionUsecase.
+// Only ListConnections is exercised by the admin service; the rest satisfy the interface.
+type mockConnectionUsecase struct {
+	mock.Mock
+}
+
+func (m *mockConnectionUsecase) ListConnections(
+	ctx context.Context, namespace string, options *model.ListOptions,
+) (*model.ListResponse[*agentmodel.Connection], error) {
+	args := m.Called(ctx, namespace, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	resp, ok := args.Get(0).(*model.ListResponse[*agentmodel.Connection])
+	if !ok {
+		return nil, errMock
+	}
+
+	return resp, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockConnectionUsecase) GetConnectionByInstanceUID(
+	ctx context.Context, instanceUID uuid.UUID,
+) (*agentmodel.Connection, error) {
+	args := m.Called(ctx, instanceUID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	conn, ok := args.Get(0).(*agentmodel.Connection)
+	if !ok {
+		return nil, errMock
+	}
+
+	return conn, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockConnectionUsecase) GetOrCreateConnectionByID(
+	ctx context.Context, id any,
+) (*agentmodel.Connection, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	conn, ok := args.Get(0).(*agentmodel.Connection)
+	if !ok {
+		return nil, errMock
+	}
+
+	return conn, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockConnectionUsecase) GetConnectionByID(ctx context.Context, id any) (*agentmodel.Connection, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	conn, ok := args.Get(0).(*agentmodel.Connection)
+	if !ok {
+		return nil, errMock
+	}
+
+	return conn, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockConnectionUsecase) SaveConnection(ctx context.Context, connection *agentmodel.Connection) error {
+	args := m.Called(ctx, connection)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+func (m *mockConnectionUsecase) DeleteConnection(ctx context.Context, connection *agentmodel.Connection) error {
+	args := m.Called(ctx, connection)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+func (m *mockConnectionUsecase) SendServerToAgent(
+	ctx context.Context, instanceUID uuid.UUID, message *protobufs.ServerToAgent,
+) error {
+	args := m.Called(ctx, instanceUID, message)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+// mockClusterConnectionUsecase is a mock implementation of agentport.ClusterConnectionUsecase.
+type mockClusterConnectionUsecase struct {
+	mock.Mock
+}
+
+func (m *mockClusterConnectionUsecase) ListClusterConnections(
+	ctx context.Context, namespace string, options *model.ListOptions,
+) (*model.ListResponse[*agentmodel.ServerConnection], error) {
+	args := m.Called(ctx, namespace, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	resp, ok := args.Get(0).(*model.ListResponse[*agentmodel.ServerConnection])
+	if !ok {
+		return nil, errMock
+	}
+
+	return resp, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func newSvc(t *testing.T, conn *mockConnectionUsecase, cluster *mockClusterConnectionUsecase) *adminsvc.Service {
+	t.Helper()
+
+	base := testutil.NewBase(t)
+
+	// agentUsecase and agentNotificationUsecase are unused by the listing methods under test.
+	return adminsvc.New(nil, conn, cluster, nil, base.Logger)
+}
+
+func TestService_ListConnections(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockConn := new(mockConnectionUsecase)
+		svc := newSvc(t, mockConn, new(mockClusterConnectionUsecase))
+
+		conn := &agentmodel.Connection{
+			UID:                uuid.New(),
+			InstanceUID:        uuid.New(),
+			Namespace:          "default",
+			Type:               agentmodel.ConnectionTypeWebSocket,
+			LastCommunicatedAt: time.Now(),
+		}
+		opts := &applicationport.ListOptions{Limit: 10}
+		resp := &model.ListResponse[*agentmodel.Connection]{Items: []*agentmodel.Connection{conn}, Continue: "next"}
+		mockConn.On("ListConnections", ctx, "default", opts.ToDomain()).Return(resp, nil)
+
+		result, err := svc.ListConnections(ctx, "default", opts)
+
+		require.NoError(t, err)
+		require.Len(t, result.Items, 1)
+		assert.Equal(t, conn.UID, result.Items[0].ID)
+		assert.Equal(t, "default", result.Items[0].Namespace)
+		// Node-local connections carry no owning ServerID.
+		assert.Empty(t, result.Items[0].ServerID)
+		assert.True(t, result.Items[0].Alive)
+		assert.Equal(t, "next", result.Metadata.Continue)
+		mockConn.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockConn := new(mockConnectionUsecase)
+		svc := newSvc(t, mockConn, new(mockClusterConnectionUsecase))
+
+		opts := &applicationport.ListOptions{Limit: 10}
+		mockConn.On("ListConnections", ctx, "default", opts.ToDomain()).Return(nil, errMock)
+
+		result, err := svc.ListConnections(ctx, "default", opts)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "failed to list connections")
+		mockConn.AssertExpectations(t)
+	})
+}
+
+func TestService_ListClusterConnections(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success carries owning ServerID", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockCluster := new(mockClusterConnectionUsecase)
+		svc := newSvc(t, new(mockConnectionUsecase), mockCluster)
+
+		serverConn := &agentmodel.ServerConnection{
+			ServerID:           "server-a",
+			UID:                uuid.New(),
+			InstanceUID:        uuid.New(),
+			Namespace:          "default",
+			Type:               agentmodel.ConnectionTypeWebSocket,
+			LastCommunicatedAt: time.Now(),
+		}
+		opts := &applicationport.ListOptions{Limit: 10}
+		resp := &model.ListResponse[*agentmodel.ServerConnection]{
+			Items:    []*agentmodel.ServerConnection{serverConn},
+			Continue: "next",
+		}
+		mockCluster.On("ListClusterConnections", ctx, "default", opts.ToDomain()).Return(resp, nil)
+
+		result, err := svc.ListClusterConnections(ctx, "default", opts)
+
+		require.NoError(t, err)
+		require.Len(t, result.Items, 1)
+		assert.Equal(t, "server-a", result.Items[0].ServerID)
+		assert.True(t, result.Items[0].Alive)
+		mockCluster.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockCluster := new(mockClusterConnectionUsecase)
+		svc := newSvc(t, new(mockConnectionUsecase), mockCluster)
+
+		opts := &applicationport.ListOptions{Limit: 10}
+		mockCluster.On("ListClusterConnections", ctx, "default", opts.ToDomain()).Return(nil, errMock)
+
+		result, err := svc.ListClusterConnections(ctx, "default", opts)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "failed to list cluster connections")
+		mockCluster.AssertExpectations(t)
+	})
+}

--- a/pkg/apiserver/application/service/admin/admin_test.go
+++ b/pkg/apiserver/application/service/admin/admin_test.go
@@ -115,9 +115,9 @@ type mockClusterConnectionUsecase struct {
 }
 
 func (m *mockClusterConnectionUsecase) ListClusterConnections(
-	ctx context.Context, namespace string, options *model.ListOptions,
+	ctx context.Context, namespace string, serverID string, options *model.ListOptions,
 ) (*model.ListResponse[*agentmodel.ServerConnection], error) {
-	args := m.Called(ctx, namespace, options)
+	args := m.Called(ctx, namespace, serverID, options)
 	if args.Get(0) == nil {
 		return nil, args.Error(1) //nolint:wrapcheck // mock error
 	}
@@ -215,9 +215,10 @@ func TestService_ListClusterConnections(t *testing.T) {
 			Items:    []*agentmodel.ServerConnection{serverConn},
 			Continue: "next",
 		}
-		mockCluster.On("ListClusterConnections", ctx, "default", opts.ToDomain()).Return(resp, nil)
+		// A non-empty serverID filters the cluster view to that one server.
+		mockCluster.On("ListClusterConnections", ctx, "default", "server-a", opts.ToDomain()).Return(resp, nil)
 
-		result, err := svc.ListClusterConnections(ctx, "default", opts)
+		result, err := svc.ListClusterConnections(ctx, "default", "server-a", opts)
 
 		require.NoError(t, err)
 		require.Len(t, result.Items, 1)
@@ -234,9 +235,9 @@ func TestService_ListClusterConnections(t *testing.T) {
 		svc := newSvc(t, new(mockConnectionUsecase), mockCluster)
 
 		opts := &applicationport.ListOptions{Limit: 10}
-		mockCluster.On("ListClusterConnections", ctx, "default", opts.ToDomain()).Return(nil, errMock)
+		mockCluster.On("ListClusterConnections", ctx, "default", "", opts.ToDomain()).Return(nil, errMock)
 
-		result, err := svc.ListClusterConnections(ctx, "default", opts)
+		result, err := svc.ListClusterConnections(ctx, "default", "", opts)
 
 		require.Error(t, err)
 		assert.Nil(t, result)

--- a/pkg/apiserver/application/service/agentgroup/agentgroup_manage_service_test.go
+++ b/pkg/apiserver/application/service/agentgroup/agentgroup_manage_service_test.go
@@ -1,0 +1,516 @@
+package agentgroup_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/minuk-dev/opampcommander/api/v1"
+	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
+	agentgroupsvc "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/agentgroup"
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	"github.com/minuk-dev/opampcommander/pkg/testutil"
+)
+
+var errMock = errors.New("mock error")
+
+// mockAgentGroupUsecase is a mock implementation of agentport.AgentGroupUsecase.
+type mockAgentGroupUsecase struct {
+	mock.Mock
+}
+
+func (m *mockAgentGroupUsecase) GetAgentGroup(
+	ctx context.Context, namespace, name string, options *model.GetOptions,
+) (*agentmodel.AgentGroup, error) {
+	args := m.Called(ctx, namespace, name, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	group, _ := args.Get(0).(*agentmodel.AgentGroup)
+
+	return group, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentGroupUsecase) ListAgentGroups(
+	ctx context.Context, options *model.ListOptions,
+) (*model.ListResponse[*agentmodel.AgentGroup], error) {
+	args := m.Called(ctx, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	resp, _ := args.Get(0).(*model.ListResponse[*agentmodel.AgentGroup])
+
+	return resp, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentGroupUsecase) SaveAgentGroup(
+	ctx context.Context, namespace, name string, agentGroup *agentmodel.AgentGroup,
+) (*agentmodel.AgentGroup, error) {
+	args := m.Called(ctx, namespace, name, agentGroup)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	group, _ := args.Get(0).(*agentmodel.AgentGroup)
+
+	return group, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentGroupUsecase) DeleteAgentGroup(
+	ctx context.Context, namespace, name string, deletedAt time.Time, deletedBy string,
+) error {
+	args := m.Called(ctx, namespace, name, deletedAt, deletedBy)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentGroupUsecase) GetAgentGroupsForAgent(
+	ctx context.Context, agent *agentmodel.Agent,
+) ([]*agentmodel.AgentGroup, error) {
+	args := m.Called(ctx, agent)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	groups, _ := args.Get(0).([]*agentmodel.AgentGroup)
+
+	return groups, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentGroupUsecase) PropagateAgentRemoteConfigChange(
+	ctx context.Context, namespace, remoteConfigName string,
+) error {
+	args := m.Called(ctx, namespace, remoteConfigName)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentGroupUsecase) ApplyMatchingAgentGroupsToAgent(ctx context.Context, agent *agentmodel.Agent) error {
+	args := m.Called(ctx, agent)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentGroupUsecase) ReconcileAgent(ctx context.Context, agent *agentmodel.Agent) error {
+	args := m.Called(ctx, agent)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentGroupUsecase) ReconcileAgentGroup(ctx context.Context, namespace, name string) error {
+	args := m.Called(ctx, namespace, name)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+// mockAgentUsecase is a mock implementation of agentport.AgentUsecase.
+type mockAgentUsecase struct {
+	mock.Mock
+}
+
+func (m *mockAgentUsecase) GetAgent(ctx context.Context, instanceUID uuid.UUID) (*agentmodel.Agent, error) {
+	args := m.Called(ctx, instanceUID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	agent, _ := args.Get(0).(*agentmodel.Agent)
+
+	return agent, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentUsecase) GetOrCreateAgent(ctx context.Context, instanceUID uuid.UUID) (*agentmodel.Agent, error) {
+	args := m.Called(ctx, instanceUID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	agent, _ := args.Get(0).(*agentmodel.Agent)
+
+	return agent, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentUsecase) ListAgentsBySelector(
+	ctx context.Context, selector agentmodel.AgentSelector, options *model.ListOptions,
+) (*model.ListResponse[*agentmodel.Agent], error) {
+	args := m.Called(ctx, selector, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	resp, _ := args.Get(0).(*model.ListResponse[*agentmodel.Agent])
+
+	return resp, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentUsecase) SaveAgent(ctx context.Context, agent *agentmodel.Agent) error {
+	args := m.Called(ctx, agent)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentUsecase) DeleteAgent(ctx context.Context, instanceUID uuid.UUID) error {
+	args := m.Called(ctx, instanceUID)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentUsecase) ListAgents(
+	ctx context.Context, namespace string, options *model.ListOptions,
+) (*model.ListResponse[*agentmodel.Agent], error) {
+	args := m.Called(ctx, namespace, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	resp, _ := args.Get(0).(*model.ListResponse[*agentmodel.Agent])
+
+	return resp, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentUsecase) SearchAgents(
+	ctx context.Context, namespace string, query string, options *model.ListOptions,
+) (*model.ListResponse[*agentmodel.Agent], error) {
+	args := m.Called(ctx, namespace, query, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	resp, _ := args.Get(0).(*model.ListResponse[*agentmodel.Agent])
+
+	return resp, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func newSvc(t *testing.T, group *mockAgentGroupUsecase, agent *mockAgentUsecase) *agentgroupsvc.ManageService {
+	t.Helper()
+
+	base := testutil.NewBase(t)
+
+	return agentgroupsvc.NewManageService(group, agent, base.Logger)
+}
+
+func newGroup(namespace, name string) *agentmodel.AgentGroup {
+	return agentmodel.NewAgentGroup(namespace, name, nil, time.Now(), "tester")
+}
+
+func apiGroup(namespace, name string) *v1.AgentGroup {
+	return &v1.AgentGroup{
+		Kind:       v1.AgentGroupKind,
+		APIVersion: v1.APIVersion,
+		Metadata:   v1.Metadata{Namespace: namespace, Name: name},
+	}
+}
+
+func TestService_GetAgentGroup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockGroup := new(mockAgentGroupUsecase)
+		svc := newSvc(t, mockGroup, new(mockAgentUsecase))
+
+		mockGroup.On("GetAgentGroup", ctx, "default", "g-1", (*model.GetOptions)(nil)).
+			Return(newGroup("default", "g-1"), nil)
+
+		result, err := svc.GetAgentGroup(ctx, "default", "g-1", nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, "g-1", result.Metadata.Name)
+		mockGroup.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockGroup := new(mockAgentGroupUsecase)
+		svc := newSvc(t, mockGroup, new(mockAgentUsecase))
+
+		mockGroup.On("GetAgentGroup", ctx, "default", "missing", (*model.GetOptions)(nil)).Return(nil, errMock)
+
+		result, err := svc.GetAgentGroup(ctx, "default", "missing", nil)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "get agent group")
+		mockGroup.AssertExpectations(t)
+	})
+}
+
+func TestService_ListAgentGroups(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockGroup := new(mockAgentGroupUsecase)
+		svc := newSvc(t, mockGroup, new(mockAgentUsecase))
+
+		opts := &applicationport.ListOptions{Limit: 10}
+		resp := &model.ListResponse[*agentmodel.AgentGroup]{
+			Items:    []*agentmodel.AgentGroup{newGroup("default", "g-1")},
+			Continue: "next",
+		}
+		mockGroup.On("ListAgentGroups", ctx, opts.ToDomain()).Return(resp, nil)
+
+		result, err := svc.ListAgentGroups(ctx, opts)
+
+		require.NoError(t, err)
+		assert.Equal(t, v1.AgentGroupKind, result.Kind)
+		assert.Len(t, result.Items, 1)
+		assert.Equal(t, "next", result.Metadata.Continue)
+		mockGroup.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockGroup := new(mockAgentGroupUsecase)
+		svc := newSvc(t, mockGroup, new(mockAgentUsecase))
+
+		opts := &applicationport.ListOptions{Limit: 10}
+		mockGroup.On("ListAgentGroups", ctx, opts.ToDomain()).Return(nil, errMock)
+
+		result, err := svc.ListAgentGroups(ctx, opts)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "list agent groups")
+		mockGroup.AssertExpectations(t)
+	})
+}
+
+func TestService_CreateAgentGroup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success when not already present", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockGroup := new(mockAgentGroupUsecase)
+		svc := newSvc(t, mockGroup, new(mockAgentUsecase))
+
+		mockGroup.On("GetAgentGroup", ctx, "default", "g-1", (*model.GetOptions)(nil)).
+			Return(nil, model.ErrResourceNotExist)
+		mockGroup.On("SaveAgentGroup", ctx, "default", "g-1", mock.Anything).
+			Return(newGroup("default", "g-1"), nil)
+
+		result, err := svc.CreateAgentGroup(ctx, apiGroup("default", "g-1"))
+
+		require.NoError(t, err)
+		assert.Equal(t, "g-1", result.Metadata.Name)
+		mockGroup.AssertExpectations(t)
+	})
+
+	t.Run("rejects when already exists", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockGroup := new(mockAgentGroupUsecase)
+		svc := newSvc(t, mockGroup, new(mockAgentUsecase))
+
+		mockGroup.On("GetAgentGroup", ctx, "default", "g-1", (*model.GetOptions)(nil)).
+			Return(newGroup("default", "g-1"), nil)
+
+		result, err := svc.CreateAgentGroup(ctx, apiGroup("default", "g-1"))
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, agentgroupsvc.ErrAgentGroupAlreadyExists)
+		mockGroup.AssertNotCalled(t, "SaveAgentGroup", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
+		mockGroup.AssertExpectations(t)
+	})
+
+	t.Run("save error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockGroup := new(mockAgentGroupUsecase)
+		svc := newSvc(t, mockGroup, new(mockAgentUsecase))
+
+		mockGroup.On("GetAgentGroup", ctx, "default", "g-1", (*model.GetOptions)(nil)).
+			Return(nil, model.ErrResourceNotExist)
+		mockGroup.On("SaveAgentGroup", ctx, "default", "g-1", mock.Anything).Return(nil, errMock)
+
+		result, err := svc.CreateAgentGroup(ctx, apiGroup("default", "g-1"))
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "create agent group")
+		mockGroup.AssertExpectations(t)
+	})
+}
+
+func TestService_UpdateAgentGroup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockGroup := new(mockAgentGroupUsecase)
+		svc := newSvc(t, mockGroup, new(mockAgentUsecase))
+
+		mockGroup.On("GetAgentGroup", ctx, "default", "g-1", (*model.GetOptions)(nil)).
+			Return(newGroup("default", "g-1"), nil)
+		mockGroup.On("SaveAgentGroup", ctx, "default", "g-1", mock.Anything).
+			Return(newGroup("default", "g-1"), nil)
+
+		result, err := svc.UpdateAgentGroup(ctx, "default", "g-1", apiGroup("default", "g-1"))
+
+		require.NoError(t, err)
+		assert.Equal(t, "g-1", result.Metadata.Name)
+		mockGroup.AssertExpectations(t)
+	})
+
+	t.Run("get error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockGroup := new(mockAgentGroupUsecase)
+		svc := newSvc(t, mockGroup, new(mockAgentUsecase))
+
+		mockGroup.On("GetAgentGroup", ctx, "default", "g-1", (*model.GetOptions)(nil)).Return(nil, errMock)
+
+		result, err := svc.UpdateAgentGroup(ctx, "default", "g-1", apiGroup("default", "g-1"))
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "get agent group for update")
+		mockGroup.AssertExpectations(t)
+	})
+}
+
+func TestService_DeleteAgentGroup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockGroup := new(mockAgentGroupUsecase)
+		svc := newSvc(t, mockGroup, new(mockAgentUsecase))
+
+		mockGroup.On("DeleteAgentGroup", ctx, "default", "g-1",
+			mock.AnythingOfType("time.Time"), mock.AnythingOfType("string")).Return(nil)
+
+		err := svc.DeleteAgentGroup(ctx, "default", "g-1")
+
+		require.NoError(t, err)
+		mockGroup.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockGroup := new(mockAgentGroupUsecase)
+		svc := newSvc(t, mockGroup, new(mockAgentUsecase))
+
+		mockGroup.On("DeleteAgentGroup", ctx, "default", "g-1",
+			mock.AnythingOfType("time.Time"), mock.AnythingOfType("string")).Return(errMock)
+
+		err := svc.DeleteAgentGroup(ctx, "default", "g-1")
+
+		require.Error(t, err)
+		mockGroup.AssertExpectations(t)
+	})
+}
+
+func TestService_ListAgentsByAgentGroup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockGroup := new(mockAgentGroupUsecase)
+		mockAgent := new(mockAgentUsecase)
+		svc := newSvc(t, mockGroup, mockAgent)
+
+		group := newGroup("default", "g-1")
+		mockGroup.On("GetAgentGroup", ctx, "default", "g-1", (*model.GetOptions)(nil)).Return(group, nil)
+		mockAgent.On("ListAgentsBySelector", ctx, group.Spec.Selector, mock.Anything).
+			Return(&model.ListResponse[*agentmodel.Agent]{Items: nil}, nil)
+
+		result, err := svc.ListAgentsByAgentGroup(ctx, "default", "g-1", &applicationport.ListOptions{Limit: 10})
+
+		require.NoError(t, err)
+		assert.Equal(t, v1.AgentKind, result.Kind)
+		mockGroup.AssertExpectations(t)
+		mockAgent.AssertExpectations(t)
+	})
+
+	t.Run("group lookup error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockGroup := new(mockAgentGroupUsecase)
+		svc := newSvc(t, mockGroup, new(mockAgentUsecase))
+
+		mockGroup.On("GetAgentGroup", ctx, "default", "g-1", (*model.GetOptions)(nil)).Return(nil, errMock)
+
+		result, err := svc.ListAgentsByAgentGroup(ctx, "default", "g-1", &applicationport.ListOptions{Limit: 10})
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "get agent group")
+		mockGroup.AssertExpectations(t)
+	})
+}
+
+func TestService_ListAgentGroupsByAgent(t *testing.T) {
+	t.Parallel()
+
+	t.Run("namespace mismatch returns ErrAgentNamespaceMismatch", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockGroup := new(mockAgentGroupUsecase)
+		mockAgent := new(mockAgentUsecase)
+		svc := newSvc(t, mockGroup, mockAgent)
+
+		instanceUID := uuid.New()
+		agent := agentmodel.NewAgent(instanceUID)
+		agent.Metadata.Namespace = "other"
+		mockAgent.On("GetAgent", ctx, instanceUID).Return(agent, nil)
+
+		result, err := svc.ListAgentGroupsByAgent(ctx, "default", instanceUID)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.ErrorIs(t, err, applicationport.ErrAgentNamespaceMismatch)
+		mockAgent.AssertExpectations(t)
+	})
+
+	t.Run("agent lookup error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockAgent := new(mockAgentUsecase)
+		svc := newSvc(t, new(mockAgentGroupUsecase), mockAgent)
+
+		instanceUID := uuid.New()
+		mockAgent.On("GetAgent", ctx, instanceUID).Return(nil, errMock)
+
+		result, err := svc.ListAgentGroupsByAgent(ctx, "default", instanceUID)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "get agent")
+		mockAgent.AssertExpectations(t)
+	})
+}

--- a/pkg/apiserver/application/service/agentgroup/agentgroup_manage_service_test.go
+++ b/pkg/apiserver/application/service/agentgroup/agentgroup_manage_service_test.go
@@ -198,15 +198,15 @@ func newSvc(t *testing.T, group *mockAgentGroupUsecase, agent *mockAgentUsecase)
 	return agentgroupsvc.NewManageService(group, agent, base.Logger)
 }
 
-func newGroup(namespace, name string) *agentmodel.AgentGroup {
-	return agentmodel.NewAgentGroup(namespace, name, nil, time.Now(), "tester")
+func newGroup() *agentmodel.AgentGroup {
+	return agentmodel.NewAgentGroup("default", "g-1", nil, time.Now(), "tester")
 }
 
-func apiGroup(namespace, name string) *v1.AgentGroup {
+func apiGroup() *v1.AgentGroup {
 	return &v1.AgentGroup{
 		Kind:       v1.AgentGroupKind,
 		APIVersion: v1.APIVersion,
-		Metadata:   v1.Metadata{Namespace: namespace, Name: name},
+		Metadata:   v1.Metadata{Namespace: "default", Name: "g-1"},
 	}
 }
 
@@ -221,7 +221,7 @@ func TestService_GetAgentGroup(t *testing.T) {
 		svc := newSvc(t, mockGroup, new(mockAgentUsecase))
 
 		mockGroup.On("GetAgentGroup", ctx, "default", "g-1", (*model.GetOptions)(nil)).
-			Return(newGroup("default", "g-1"), nil)
+			Return(newGroup(), nil)
 
 		result, err := svc.GetAgentGroup(ctx, "default", "g-1", nil)
 
@@ -260,7 +260,7 @@ func TestService_ListAgentGroups(t *testing.T) {
 
 		opts := &applicationport.ListOptions{Limit: 10}
 		resp := &model.ListResponse[*agentmodel.AgentGroup]{
-			Items:    []*agentmodel.AgentGroup{newGroup("default", "g-1")},
+			Items:    []*agentmodel.AgentGroup{newGroup()},
 			Continue: "next",
 		}
 		mockGroup.On("ListAgentGroups", ctx, opts.ToDomain()).Return(resp, nil)
@@ -306,9 +306,9 @@ func TestService_CreateAgentGroup(t *testing.T) {
 		mockGroup.On("GetAgentGroup", ctx, "default", "g-1", (*model.GetOptions)(nil)).
 			Return(nil, model.ErrResourceNotExist)
 		mockGroup.On("SaveAgentGroup", ctx, "default", "g-1", mock.Anything).
-			Return(newGroup("default", "g-1"), nil)
+			Return(newGroup(), nil)
 
-		result, err := svc.CreateAgentGroup(ctx, apiGroup("default", "g-1"))
+		result, err := svc.CreateAgentGroup(ctx, apiGroup())
 
 		require.NoError(t, err)
 		assert.Equal(t, "g-1", result.Metadata.Name)
@@ -323,13 +323,13 @@ func TestService_CreateAgentGroup(t *testing.T) {
 		svc := newSvc(t, mockGroup, new(mockAgentUsecase))
 
 		mockGroup.On("GetAgentGroup", ctx, "default", "g-1", (*model.GetOptions)(nil)).
-			Return(newGroup("default", "g-1"), nil)
+			Return(newGroup(), nil)
 
-		result, err := svc.CreateAgentGroup(ctx, apiGroup("default", "g-1"))
+		result, err := svc.CreateAgentGroup(ctx, apiGroup())
 
 		require.Error(t, err)
 		assert.Nil(t, result)
-		assert.ErrorIs(t, err, agentgroupsvc.ErrAgentGroupAlreadyExists)
+		require.ErrorIs(t, err, agentgroupsvc.ErrAgentGroupAlreadyExists)
 		mockGroup.AssertNotCalled(t, "SaveAgentGroup", mock.Anything, mock.Anything, mock.Anything, mock.Anything)
 		mockGroup.AssertExpectations(t)
 	})
@@ -345,7 +345,7 @@ func TestService_CreateAgentGroup(t *testing.T) {
 			Return(nil, model.ErrResourceNotExist)
 		mockGroup.On("SaveAgentGroup", ctx, "default", "g-1", mock.Anything).Return(nil, errMock)
 
-		result, err := svc.CreateAgentGroup(ctx, apiGroup("default", "g-1"))
+		result, err := svc.CreateAgentGroup(ctx, apiGroup())
 
 		require.Error(t, err)
 		assert.Nil(t, result)
@@ -365,11 +365,11 @@ func TestService_UpdateAgentGroup(t *testing.T) {
 		svc := newSvc(t, mockGroup, new(mockAgentUsecase))
 
 		mockGroup.On("GetAgentGroup", ctx, "default", "g-1", (*model.GetOptions)(nil)).
-			Return(newGroup("default", "g-1"), nil)
+			Return(newGroup(), nil)
 		mockGroup.On("SaveAgentGroup", ctx, "default", "g-1", mock.Anything).
-			Return(newGroup("default", "g-1"), nil)
+			Return(newGroup(), nil)
 
-		result, err := svc.UpdateAgentGroup(ctx, "default", "g-1", apiGroup("default", "g-1"))
+		result, err := svc.UpdateAgentGroup(ctx, "default", "g-1", apiGroup())
 
 		require.NoError(t, err)
 		assert.Equal(t, "g-1", result.Metadata.Name)
@@ -385,7 +385,7 @@ func TestService_UpdateAgentGroup(t *testing.T) {
 
 		mockGroup.On("GetAgentGroup", ctx, "default", "g-1", (*model.GetOptions)(nil)).Return(nil, errMock)
 
-		result, err := svc.UpdateAgentGroup(ctx, "default", "g-1", apiGroup("default", "g-1"))
+		result, err := svc.UpdateAgentGroup(ctx, "default", "g-1", apiGroup())
 
 		require.Error(t, err)
 		assert.Nil(t, result)
@@ -441,7 +441,7 @@ func TestService_ListAgentsByAgentGroup(t *testing.T) {
 		mockAgent := new(mockAgentUsecase)
 		svc := newSvc(t, mockGroup, mockAgent)
 
-		group := newGroup("default", "g-1")
+		group := newGroup()
 		mockGroup.On("GetAgentGroup", ctx, "default", "g-1", (*model.GetOptions)(nil)).Return(group, nil)
 		mockAgent.On("ListAgentsBySelector", ctx, group.Spec.Selector, mock.Anything).
 			Return(&model.ListResponse[*agentmodel.Agent]{Items: nil}, nil)
@@ -492,7 +492,7 @@ func TestService_ListAgentGroupsByAgent(t *testing.T) {
 
 		require.Error(t, err)
 		assert.Nil(t, result)
-		assert.ErrorIs(t, err, applicationport.ErrAgentNamespaceMismatch)
+		require.ErrorIs(t, err, applicationport.ErrAgentNamespaceMismatch)
 		mockAgent.AssertExpectations(t)
 	})
 

--- a/pkg/apiserver/application/service/agentpackage/agentpackage_test.go
+++ b/pkg/apiserver/application/service/agentpackage/agentpackage_test.go
@@ -121,17 +121,17 @@ func newSvc(t *testing.T, pkg *mockAgentPackageUsecase) *agentpackagesvc.Service
 	return agentpackagesvc.NewAgentPackageService(pkg, base.Logger)
 }
 
-func newPkg(namespace, name string) *agentmodel.AgentPackage {
+func newPkg() *agentmodel.AgentPackage {
 	return &agentmodel.AgentPackage{
-		Metadata: agentmodel.AgentPackageMetadata{Namespace: namespace, Name: name},
+		Metadata: agentmodel.AgentPackageMetadata{Namespace: "default", Name: "pkg-1"},
 	}
 }
 
-func apiPkg(namespace, name string) *v1.AgentPackage {
+func apiPkg() *v1.AgentPackage {
 	return &v1.AgentPackage{
 		Kind:       v1.AgentPackageKind,
 		APIVersion: v1.APIVersion,
-		Metadata:   v1.AgentPackageMetadata{Namespace: namespace, Name: name},
+		Metadata:   v1.AgentPackageMetadata{Namespace: "default", Name: "pkg-1"},
 	}
 }
 
@@ -146,7 +146,7 @@ func TestService_GetAgentPackage(t *testing.T) {
 		svc := newSvc(t, mockPkg)
 
 		mockPkg.On("GetAgentPackage", ctx, "default", "pkg-1", (*model.GetOptions)(nil)).
-			Return(newPkg("default", "pkg-1"), nil)
+			Return(newPkg(), nil)
 
 		result, err := svc.GetAgentPackage(ctx, "default", "pkg-1", nil)
 
@@ -186,7 +186,7 @@ func TestService_ListAgentPackages(t *testing.T) {
 
 		opts := &applicationport.ListOptions{Limit: 10}
 		resp := &model.ListResponse[*agentmodel.AgentPackage]{
-			Items:    []*agentmodel.AgentPackage{newPkg("default", "pkg-1")},
+			Items:    []*agentmodel.AgentPackage{newPkg()},
 			Continue: "next",
 		}
 		mockPkg.On("ListAgentPackages", ctx, opts.ToDomain()).Return(resp, nil)
@@ -231,9 +231,9 @@ func TestService_CreateAgentPackage(t *testing.T) {
 
 		mockPkg.On("CreateAgentPackage", ctx, mock.MatchedBy(func(p *agentmodel.AgentPackage) bool {
 			return p.Metadata.Name == "pkg-1"
-		}), mock.AnythingOfType("string")).Return(newPkg("default", "pkg-1"), nil)
+		}), mock.AnythingOfType("string")).Return(newPkg(), nil)
 
-		result, err := svc.CreateAgentPackage(ctx, apiPkg("default", "pkg-1"))
+		result, err := svc.CreateAgentPackage(ctx, apiPkg())
 
 		require.NoError(t, err)
 		assert.Equal(t, "pkg-1", result.Metadata.Name)
@@ -249,7 +249,7 @@ func TestService_CreateAgentPackage(t *testing.T) {
 
 		mockPkg.On("CreateAgentPackage", ctx, mock.Anything, mock.AnythingOfType("string")).Return(nil, errMock)
 
-		result, err := svc.CreateAgentPackage(ctx, apiPkg("default", "pkg-1"))
+		result, err := svc.CreateAgentPackage(ctx, apiPkg())
 
 		require.Error(t, err)
 		assert.Nil(t, result)
@@ -269,9 +269,9 @@ func TestService_UpdateAgentPackage(t *testing.T) {
 		svc := newSvc(t, mockPkg)
 
 		mockPkg.On("UpdateAgentPackage", ctx, "default", "pkg-1", mock.Anything).
-			Return(newPkg("default", "pkg-1"), nil)
+			Return(newPkg(), nil)
 
-		result, err := svc.UpdateAgentPackage(ctx, "default", "pkg-1", apiPkg("default", "pkg-1"))
+		result, err := svc.UpdateAgentPackage(ctx, "default", "pkg-1", apiPkg())
 
 		require.NoError(t, err)
 		assert.Equal(t, "pkg-1", result.Metadata.Name)
@@ -287,7 +287,7 @@ func TestService_UpdateAgentPackage(t *testing.T) {
 
 		mockPkg.On("UpdateAgentPackage", ctx, "default", "pkg-1", mock.Anything).Return(nil, errMock)
 
-		result, err := svc.UpdateAgentPackage(ctx, "default", "pkg-1", apiPkg("default", "pkg-1"))
+		result, err := svc.UpdateAgentPackage(ctx, "default", "pkg-1", apiPkg())
 
 		require.Error(t, err)
 		assert.Nil(t, result)

--- a/pkg/apiserver/application/service/agentpackage/agentpackage_test.go
+++ b/pkg/apiserver/application/service/agentpackage/agentpackage_test.go
@@ -1,0 +1,334 @@
+package agentpackage_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/minuk-dev/opampcommander/api/v1"
+	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
+	agentpackagesvc "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/agentpackage"
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	"github.com/minuk-dev/opampcommander/pkg/testutil"
+)
+
+var errMock = errors.New("mock error")
+
+// mockAgentPackageUsecase is a mock implementation of agentport.AgentPackageUsecase.
+type mockAgentPackageUsecase struct {
+	mock.Mock
+}
+
+func (m *mockAgentPackageUsecase) GetAgentPackage(
+	ctx context.Context, namespace, name string, options *model.GetOptions,
+) (*agentmodel.AgentPackage, error) {
+	args := m.Called(ctx, namespace, name, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	pkg, ok := args.Get(0).(*agentmodel.AgentPackage)
+	if !ok {
+		return nil, errMock
+	}
+
+	return pkg, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentPackageUsecase) ListAgentPackages(
+	ctx context.Context, options *model.ListOptions,
+) (*model.ListResponse[*agentmodel.AgentPackage], error) {
+	args := m.Called(ctx, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	resp, ok := args.Get(0).(*model.ListResponse[*agentmodel.AgentPackage])
+	if !ok {
+		return nil, errMock
+	}
+
+	return resp, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentPackageUsecase) SaveAgentPackage(
+	ctx context.Context, agentPackage *agentmodel.AgentPackage,
+) (*agentmodel.AgentPackage, error) {
+	args := m.Called(ctx, agentPackage)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	pkg, ok := args.Get(0).(*agentmodel.AgentPackage)
+	if !ok {
+		return nil, errMock
+	}
+
+	return pkg, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentPackageUsecase) CreateAgentPackage(
+	ctx context.Context, agentPackage *agentmodel.AgentPackage, actor string,
+) (*agentmodel.AgentPackage, error) {
+	args := m.Called(ctx, agentPackage, actor)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	pkg, ok := args.Get(0).(*agentmodel.AgentPackage)
+	if !ok {
+		return nil, errMock
+	}
+
+	return pkg, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentPackageUsecase) UpdateAgentPackage(
+	ctx context.Context, namespace, name string, agentPackage *agentmodel.AgentPackage,
+) (*agentmodel.AgentPackage, error) {
+	args := m.Called(ctx, namespace, name, agentPackage)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	pkg, ok := args.Get(0).(*agentmodel.AgentPackage)
+	if !ok {
+		return nil, errMock
+	}
+
+	return pkg, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentPackageUsecase) DeleteAgentPackage(
+	ctx context.Context, namespace, name string, deletedAt time.Time, deletedBy string,
+) error {
+	args := m.Called(ctx, namespace, name, deletedAt, deletedBy)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+func newSvc(t *testing.T, pkg *mockAgentPackageUsecase) *agentpackagesvc.Service {
+	t.Helper()
+
+	base := testutil.NewBase(t)
+
+	return agentpackagesvc.NewAgentPackageService(pkg, base.Logger)
+}
+
+func newPkg(namespace, name string) *agentmodel.AgentPackage {
+	return &agentmodel.AgentPackage{
+		Metadata: agentmodel.AgentPackageMetadata{Namespace: namespace, Name: name},
+	}
+}
+
+func apiPkg(namespace, name string) *v1.AgentPackage {
+	return &v1.AgentPackage{
+		Kind:       v1.AgentPackageKind,
+		APIVersion: v1.APIVersion,
+		Metadata:   v1.AgentPackageMetadata{Namespace: namespace, Name: name},
+	}
+}
+
+func TestService_GetAgentPackage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockPkg := new(mockAgentPackageUsecase)
+		svc := newSvc(t, mockPkg)
+
+		mockPkg.On("GetAgentPackage", ctx, "default", "pkg-1", (*model.GetOptions)(nil)).
+			Return(newPkg("default", "pkg-1"), nil)
+
+		result, err := svc.GetAgentPackage(ctx, "default", "pkg-1", nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, "default", result.Metadata.Namespace)
+		assert.Equal(t, "pkg-1", result.Metadata.Name)
+		mockPkg.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockPkg := new(mockAgentPackageUsecase)
+		svc := newSvc(t, mockPkg)
+
+		mockPkg.On("GetAgentPackage", ctx, "default", "missing", (*model.GetOptions)(nil)).Return(nil, errMock)
+
+		result, err := svc.GetAgentPackage(ctx, "default", "missing", nil)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "get agent package")
+		mockPkg.AssertExpectations(t)
+	})
+}
+
+func TestService_ListAgentPackages(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockPkg := new(mockAgentPackageUsecase)
+		svc := newSvc(t, mockPkg)
+
+		opts := &applicationport.ListOptions{Limit: 10}
+		resp := &model.ListResponse[*agentmodel.AgentPackage]{
+			Items:    []*agentmodel.AgentPackage{newPkg("default", "pkg-1")},
+			Continue: "next",
+		}
+		mockPkg.On("ListAgentPackages", ctx, opts.ToDomain()).Return(resp, nil)
+
+		result, err := svc.ListAgentPackages(ctx, opts)
+
+		require.NoError(t, err)
+		assert.Equal(t, v1.AgentPackageKind, result.Kind)
+		assert.Len(t, result.Items, 1)
+		assert.Equal(t, "next", result.Metadata.Continue)
+		mockPkg.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockPkg := new(mockAgentPackageUsecase)
+		svc := newSvc(t, mockPkg)
+
+		opts := &applicationport.ListOptions{Limit: 10}
+		mockPkg.On("ListAgentPackages", ctx, opts.ToDomain()).Return(nil, errMock)
+
+		result, err := svc.ListAgentPackages(ctx, opts)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "list agent packages")
+		mockPkg.AssertExpectations(t)
+	})
+}
+
+func TestService_CreateAgentPackage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockPkg := new(mockAgentPackageUsecase)
+		svc := newSvc(t, mockPkg)
+
+		mockPkg.On("CreateAgentPackage", ctx, mock.MatchedBy(func(p *agentmodel.AgentPackage) bool {
+			return p.Metadata.Name == "pkg-1"
+		}), mock.AnythingOfType("string")).Return(newPkg("default", "pkg-1"), nil)
+
+		result, err := svc.CreateAgentPackage(ctx, apiPkg("default", "pkg-1"))
+
+		require.NoError(t, err)
+		assert.Equal(t, "pkg-1", result.Metadata.Name)
+		mockPkg.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockPkg := new(mockAgentPackageUsecase)
+		svc := newSvc(t, mockPkg)
+
+		mockPkg.On("CreateAgentPackage", ctx, mock.Anything, mock.AnythingOfType("string")).Return(nil, errMock)
+
+		result, err := svc.CreateAgentPackage(ctx, apiPkg("default", "pkg-1"))
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "create agent package")
+		mockPkg.AssertExpectations(t)
+	})
+}
+
+func TestService_UpdateAgentPackage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockPkg := new(mockAgentPackageUsecase)
+		svc := newSvc(t, mockPkg)
+
+		mockPkg.On("UpdateAgentPackage", ctx, "default", "pkg-1", mock.Anything).
+			Return(newPkg("default", "pkg-1"), nil)
+
+		result, err := svc.UpdateAgentPackage(ctx, "default", "pkg-1", apiPkg("default", "pkg-1"))
+
+		require.NoError(t, err)
+		assert.Equal(t, "pkg-1", result.Metadata.Name)
+		mockPkg.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockPkg := new(mockAgentPackageUsecase)
+		svc := newSvc(t, mockPkg)
+
+		mockPkg.On("UpdateAgentPackage", ctx, "default", "pkg-1", mock.Anything).Return(nil, errMock)
+
+		result, err := svc.UpdateAgentPackage(ctx, "default", "pkg-1", apiPkg("default", "pkg-1"))
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "update agent package")
+		mockPkg.AssertExpectations(t)
+	})
+}
+
+func TestService_DeleteAgentPackage(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockPkg := new(mockAgentPackageUsecase)
+		svc := newSvc(t, mockPkg)
+
+		mockPkg.On("DeleteAgentPackage", ctx, "default", "pkg-1",
+			mock.AnythingOfType("time.Time"), mock.AnythingOfType("string")).Return(nil)
+
+		err := svc.DeleteAgentPackage(ctx, "default", "pkg-1")
+
+		require.NoError(t, err)
+		mockPkg.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockPkg := new(mockAgentPackageUsecase)
+		svc := newSvc(t, mockPkg)
+
+		mockPkg.On("DeleteAgentPackage", ctx, "default", "pkg-1",
+			mock.AnythingOfType("time.Time"), mock.AnythingOfType("string")).Return(errMock)
+
+		err := svc.DeleteAgentPackage(ctx, "default", "pkg-1")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "delete agent package")
+		mockPkg.AssertExpectations(t)
+	})
+}

--- a/pkg/apiserver/application/service/agentremoteconfig/agentremoteconfig_test.go
+++ b/pkg/apiserver/application/service/agentremoteconfig/agentremoteconfig_test.go
@@ -1,0 +1,437 @@
+package agentremoteconfig_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/minuk-dev/opampcommander/api/v1"
+	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
+	arcsvc "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/agentremoteconfig"
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	"github.com/minuk-dev/opampcommander/pkg/testutil"
+)
+
+var errMock = errors.New("mock error")
+
+// mockAgentRemoteConfigUsecase is a mock implementation of agentport.AgentRemoteConfigUsecase.
+type mockAgentRemoteConfigUsecase struct {
+	mock.Mock
+}
+
+func (m *mockAgentRemoteConfigUsecase) GetAgentRemoteConfig(
+	ctx context.Context, namespace, name string, options *model.GetOptions,
+) (*agentmodel.AgentRemoteConfig, error) {
+	args := m.Called(ctx, namespace, name, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	cfg, ok := args.Get(0).(*agentmodel.AgentRemoteConfig)
+	if !ok {
+		return nil, errMock
+	}
+
+	return cfg, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentRemoteConfigUsecase) ListAgentRemoteConfigs(
+	ctx context.Context, options *model.ListOptions,
+) (*model.ListResponse[*agentmodel.AgentRemoteConfig], error) {
+	args := m.Called(ctx, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	resp, ok := args.Get(0).(*model.ListResponse[*agentmodel.AgentRemoteConfig])
+	if !ok {
+		return nil, errMock
+	}
+
+	return resp, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentRemoteConfigUsecase) SaveAgentRemoteConfig(
+	ctx context.Context, agentRemoteConfig *agentmodel.AgentRemoteConfig,
+) (*agentmodel.AgentRemoteConfig, error) {
+	args := m.Called(ctx, agentRemoteConfig)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	cfg, ok := args.Get(0).(*agentmodel.AgentRemoteConfig)
+	if !ok {
+		return nil, errMock
+	}
+
+	return cfg, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentRemoteConfigUsecase) CreateAgentRemoteConfig(
+	ctx context.Context, agentRemoteConfig *agentmodel.AgentRemoteConfig, actor string,
+) (*agentmodel.AgentRemoteConfig, error) {
+	args := m.Called(ctx, agentRemoteConfig, actor)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	cfg, ok := args.Get(0).(*agentmodel.AgentRemoteConfig)
+	if !ok {
+		return nil, errMock
+	}
+
+	return cfg, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentRemoteConfigUsecase) UpdateAgentRemoteConfig(
+	ctx context.Context, namespace, name string, agentRemoteConfig *agentmodel.AgentRemoteConfig,
+) (*agentmodel.AgentRemoteConfig, error) {
+	args := m.Called(ctx, namespace, name, agentRemoteConfig)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	cfg, ok := args.Get(0).(*agentmodel.AgentRemoteConfig)
+	if !ok {
+		return nil, errMock
+	}
+
+	return cfg, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentRemoteConfigUsecase) DeleteAgentRemoteConfig(
+	ctx context.Context, namespace, name string, deletedAt time.Time, deletedBy string,
+) error {
+	args := m.Called(ctx, namespace, name, deletedAt, deletedBy)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentRemoteConfigUsecase) ReconcileAgentRemoteConfig(
+	ctx context.Context, namespace, name string,
+) error {
+	args := m.Called(ctx, namespace, name)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+// stubAgentGroupUsecase is a no-op agentport.AgentGroupUsecase. PropagateAgentRemoteConfigChange
+// signals propagateCh so a test can wait for the fire-and-forget propagation goroutine to run
+// before completing (avoiding goroutine leaks racing the test).
+type stubAgentGroupUsecase struct {
+	propagateCh chan struct{}
+}
+
+func (s *stubAgentGroupUsecase) PropagateAgentRemoteConfigChange(_ context.Context, _, _ string) error {
+	if s.propagateCh != nil {
+		s.propagateCh <- struct{}{}
+	}
+
+	return nil
+}
+
+func (*stubAgentGroupUsecase) GetAgentGroup(
+	context.Context, string, string, *model.GetOptions,
+) (*agentmodel.AgentGroup, error) {
+	return nil, nil //nolint:nilnil // stub
+}
+
+func (*stubAgentGroupUsecase) ListAgentGroups(
+	context.Context, *model.ListOptions,
+) (*model.ListResponse[*agentmodel.AgentGroup], error) {
+	return nil, nil //nolint:nilnil // stub
+}
+
+func (*stubAgentGroupUsecase) SaveAgentGroup(
+	context.Context, string, string, *agentmodel.AgentGroup,
+) (*agentmodel.AgentGroup, error) {
+	return nil, nil //nolint:nilnil // stub
+}
+
+func (*stubAgentGroupUsecase) DeleteAgentGroup(context.Context, string, string, time.Time, string) error {
+	return nil
+}
+
+func (*stubAgentGroupUsecase) GetAgentGroupsForAgent(
+	context.Context, *agentmodel.Agent,
+) ([]*agentmodel.AgentGroup, error) {
+	return nil, nil
+}
+
+func (*stubAgentGroupUsecase) ApplyMatchingAgentGroupsToAgent(context.Context, *agentmodel.Agent) error {
+	return nil
+}
+
+func (*stubAgentGroupUsecase) ReconcileAgent(context.Context, *agentmodel.Agent) error { return nil }
+
+func (*stubAgentGroupUsecase) ReconcileAgentGroup(context.Context, string, string) error { return nil }
+
+// stubEndpointDetectionUsecase is a no-op agentport.EndpointDetectionUsecase.
+// ReconcileEndpointsFromRemoteConfig signals detectCh so a test can wait for the
+// fire-and-forget detection goroutine to run.
+type stubEndpointDetectionUsecase struct {
+	detectCh chan struct{}
+}
+
+func (s *stubEndpointDetectionUsecase) ReconcileEndpointsFromRemoteConfig(
+	context.Context, *agentmodel.AgentRemoteConfig,
+) error {
+	if s.detectCh != nil {
+		s.detectCh <- struct{}{}
+	}
+
+	return nil
+}
+
+func (*stubEndpointDetectionUsecase) ExtractEndpointsFromAgent(
+	*agentmodel.Agent,
+) ([]*agentmodel.Endpoint, error) {
+	return nil, nil
+}
+
+func newSvc(
+	t *testing.T, arc *mockAgentRemoteConfigUsecase, group *stubAgentGroupUsecase, det *stubEndpointDetectionUsecase,
+) *arcsvc.Service {
+	t.Helper()
+
+	base := testutil.NewBase(t)
+
+	return arcsvc.NewAgentRemoteConfigService(arc, group, det, base.Logger)
+}
+
+func newARC(namespace, name string) *agentmodel.AgentRemoteConfig {
+	return &agentmodel.AgentRemoteConfig{
+		Metadata: agentmodel.AgentRemoteConfigMetadata{Namespace: namespace, Name: name},
+	}
+}
+
+func apiARC(namespace, name string) *v1.AgentRemoteConfig {
+	return &v1.AgentRemoteConfig{
+		Kind:       v1.AgentRemoteConfigKind,
+		APIVersion: v1.APIVersion,
+		Metadata:   v1.AgentRemoteConfigMetadata{Namespace: namespace, Name: name},
+	}
+}
+
+// waitSignal fails the test if the fire-and-forget goroutine does not signal in time.
+func waitSignal(t *testing.T, ch chan struct{}) {
+	t.Helper()
+
+	select {
+	case <-ch:
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for background side effect")
+	}
+}
+
+func TestService_GetAgentRemoteConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockARC := new(mockAgentRemoteConfigUsecase)
+		svc := newSvc(t, mockARC, &stubAgentGroupUsecase{}, &stubEndpointDetectionUsecase{})
+
+		mockARC.On("GetAgentRemoteConfig", ctx, "default", "cfg-1", (*model.GetOptions)(nil)).
+			Return(newARC("default", "cfg-1"), nil)
+
+		result, err := svc.GetAgentRemoteConfig(ctx, "default", "cfg-1", nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, "cfg-1", result.Metadata.Name)
+		mockARC.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockARC := new(mockAgentRemoteConfigUsecase)
+		svc := newSvc(t, mockARC, &stubAgentGroupUsecase{}, &stubEndpointDetectionUsecase{})
+
+		mockARC.On("GetAgentRemoteConfig", ctx, "default", "missing", (*model.GetOptions)(nil)).Return(nil, errMock)
+
+		result, err := svc.GetAgentRemoteConfig(ctx, "default", "missing", nil)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "get agent remote config")
+		mockARC.AssertExpectations(t)
+	})
+}
+
+func TestService_ListAgentRemoteConfigs(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockARC := new(mockAgentRemoteConfigUsecase)
+		svc := newSvc(t, mockARC, &stubAgentGroupUsecase{}, &stubEndpointDetectionUsecase{})
+
+		opts := &applicationport.ListOptions{Limit: 10}
+		resp := &model.ListResponse[*agentmodel.AgentRemoteConfig]{
+			Items:    []*agentmodel.AgentRemoteConfig{newARC("default", "cfg-1")},
+			Continue: "next",
+		}
+		mockARC.On("ListAgentRemoteConfigs", ctx, opts.ToDomain()).Return(resp, nil)
+
+		result, err := svc.ListAgentRemoteConfigs(ctx, opts)
+
+		require.NoError(t, err)
+		assert.Equal(t, v1.AgentRemoteConfigKind, result.Kind)
+		assert.Len(t, result.Items, 1)
+		assert.Equal(t, "next", result.Metadata.Continue)
+		mockARC.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockARC := new(mockAgentRemoteConfigUsecase)
+		svc := newSvc(t, mockARC, &stubAgentGroupUsecase{}, &stubEndpointDetectionUsecase{})
+
+		opts := &applicationport.ListOptions{Limit: 10}
+		mockARC.On("ListAgentRemoteConfigs", ctx, opts.ToDomain()).Return(nil, errMock)
+
+		result, err := svc.ListAgentRemoteConfigs(ctx, opts)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "list agent remote configs")
+		mockARC.AssertExpectations(t)
+	})
+}
+
+func TestService_CreateAgentRemoteConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success triggers propagation and endpoint detection", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockARC := new(mockAgentRemoteConfigUsecase)
+		group := &stubAgentGroupUsecase{propagateCh: make(chan struct{}, 1)}
+		det := &stubEndpointDetectionUsecase{detectCh: make(chan struct{}, 1)}
+		svc := newSvc(t, mockARC, group, det)
+
+		mockARC.On("CreateAgentRemoteConfig", ctx, mock.Anything, mock.AnythingOfType("string")).
+			Return(newARC("default", "cfg-1"), nil)
+
+		result, err := svc.CreateAgentRemoteConfig(ctx, apiARC("default", "cfg-1"))
+
+		require.NoError(t, err)
+		assert.Equal(t, "cfg-1", result.Metadata.Name)
+		waitSignal(t, group.propagateCh)
+		waitSignal(t, det.detectCh)
+		mockARC.AssertExpectations(t)
+	})
+
+	t.Run("error skips side effects", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockARC := new(mockAgentRemoteConfigUsecase)
+		svc := newSvc(t, mockARC, &stubAgentGroupUsecase{}, &stubEndpointDetectionUsecase{})
+
+		mockARC.On("CreateAgentRemoteConfig", ctx, mock.Anything, mock.AnythingOfType("string")).Return(nil, errMock)
+
+		result, err := svc.CreateAgentRemoteConfig(ctx, apiARC("default", "cfg-1"))
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "create agent remote config")
+		mockARC.AssertExpectations(t)
+	})
+}
+
+func TestService_UpdateAgentRemoteConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success triggers propagation and endpoint detection", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockARC := new(mockAgentRemoteConfigUsecase)
+		group := &stubAgentGroupUsecase{propagateCh: make(chan struct{}, 1)}
+		det := &stubEndpointDetectionUsecase{detectCh: make(chan struct{}, 1)}
+		svc := newSvc(t, mockARC, group, det)
+
+		mockARC.On("UpdateAgentRemoteConfig", ctx, "default", "cfg-1", mock.Anything).
+			Return(newARC("default", "cfg-1"), nil)
+
+		result, err := svc.UpdateAgentRemoteConfig(ctx, "default", "cfg-1", apiARC("default", "cfg-1"))
+
+		require.NoError(t, err)
+		assert.Equal(t, "cfg-1", result.Metadata.Name)
+		waitSignal(t, group.propagateCh)
+		waitSignal(t, det.detectCh)
+		mockARC.AssertExpectations(t)
+	})
+
+	t.Run("error skips side effects", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockARC := new(mockAgentRemoteConfigUsecase)
+		svc := newSvc(t, mockARC, &stubAgentGroupUsecase{}, &stubEndpointDetectionUsecase{})
+
+		mockARC.On("UpdateAgentRemoteConfig", ctx, "default", "cfg-1", mock.Anything).Return(nil, errMock)
+
+		result, err := svc.UpdateAgentRemoteConfig(ctx, "default", "cfg-1", apiARC("default", "cfg-1"))
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "update agent remote config")
+		mockARC.AssertExpectations(t)
+	})
+}
+
+func TestService_DeleteAgentRemoteConfig(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success triggers propagation", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockARC := new(mockAgentRemoteConfigUsecase)
+		group := &stubAgentGroupUsecase{propagateCh: make(chan struct{}, 1)}
+		svc := newSvc(t, mockARC, group, &stubEndpointDetectionUsecase{})
+
+		mockARC.On("DeleteAgentRemoteConfig", ctx, "default", "cfg-1",
+			mock.AnythingOfType("time.Time"), mock.AnythingOfType("string")).Return(nil)
+
+		err := svc.DeleteAgentRemoteConfig(ctx, "default", "cfg-1")
+
+		require.NoError(t, err)
+		waitSignal(t, group.propagateCh)
+		mockARC.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockARC := new(mockAgentRemoteConfigUsecase)
+		svc := newSvc(t, mockARC, &stubAgentGroupUsecase{}, &stubEndpointDetectionUsecase{})
+
+		mockARC.On("DeleteAgentRemoteConfig", ctx, "default", "cfg-1",
+			mock.AnythingOfType("time.Time"), mock.AnythingOfType("string")).Return(errMock)
+
+		err := svc.DeleteAgentRemoteConfig(ctx, "default", "cfg-1")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "delete agent remote config")
+		mockARC.AssertExpectations(t)
+	})
+}

--- a/pkg/apiserver/application/service/agentremoteconfig/agentremoteconfig_test.go
+++ b/pkg/apiserver/application/service/agentremoteconfig/agentremoteconfig_test.go
@@ -205,17 +205,17 @@ func newSvc(
 	return arcsvc.NewAgentRemoteConfigService(arc, group, det, base.Logger)
 }
 
-func newARC(namespace, name string) *agentmodel.AgentRemoteConfig {
+func newARC() *agentmodel.AgentRemoteConfig {
 	return &agentmodel.AgentRemoteConfig{
-		Metadata: agentmodel.AgentRemoteConfigMetadata{Namespace: namespace, Name: name},
+		Metadata: agentmodel.AgentRemoteConfigMetadata{Namespace: "default", Name: "cfg-1"},
 	}
 }
 
-func apiARC(namespace, name string) *v1.AgentRemoteConfig {
+func apiARC() *v1.AgentRemoteConfig {
 	return &v1.AgentRemoteConfig{
 		Kind:       v1.AgentRemoteConfigKind,
 		APIVersion: v1.APIVersion,
-		Metadata:   v1.AgentRemoteConfigMetadata{Namespace: namespace, Name: name},
+		Metadata:   v1.AgentRemoteConfigMetadata{Namespace: "default", Name: "cfg-1"},
 	}
 }
 
@@ -241,7 +241,7 @@ func TestService_GetAgentRemoteConfig(t *testing.T) {
 		svc := newSvc(t, mockARC, &stubAgentGroupUsecase{}, &stubEndpointDetectionUsecase{})
 
 		mockARC.On("GetAgentRemoteConfig", ctx, "default", "cfg-1", (*model.GetOptions)(nil)).
-			Return(newARC("default", "cfg-1"), nil)
+			Return(newARC(), nil)
 
 		result, err := svc.GetAgentRemoteConfig(ctx, "default", "cfg-1", nil)
 
@@ -280,7 +280,7 @@ func TestService_ListAgentRemoteConfigs(t *testing.T) {
 
 		opts := &applicationport.ListOptions{Limit: 10}
 		resp := &model.ListResponse[*agentmodel.AgentRemoteConfig]{
-			Items:    []*agentmodel.AgentRemoteConfig{newARC("default", "cfg-1")},
+			Items:    []*agentmodel.AgentRemoteConfig{newARC()},
 			Continue: "next",
 		}
 		mockARC.On("ListAgentRemoteConfigs", ctx, opts.ToDomain()).Return(resp, nil)
@@ -326,9 +326,9 @@ func TestService_CreateAgentRemoteConfig(t *testing.T) {
 		svc := newSvc(t, mockARC, group, det)
 
 		mockARC.On("CreateAgentRemoteConfig", ctx, mock.Anything, mock.AnythingOfType("string")).
-			Return(newARC("default", "cfg-1"), nil)
+			Return(newARC(), nil)
 
-		result, err := svc.CreateAgentRemoteConfig(ctx, apiARC("default", "cfg-1"))
+		result, err := svc.CreateAgentRemoteConfig(ctx, apiARC())
 
 		require.NoError(t, err)
 		assert.Equal(t, "cfg-1", result.Metadata.Name)
@@ -346,7 +346,7 @@ func TestService_CreateAgentRemoteConfig(t *testing.T) {
 
 		mockARC.On("CreateAgentRemoteConfig", ctx, mock.Anything, mock.AnythingOfType("string")).Return(nil, errMock)
 
-		result, err := svc.CreateAgentRemoteConfig(ctx, apiARC("default", "cfg-1"))
+		result, err := svc.CreateAgentRemoteConfig(ctx, apiARC())
 
 		require.Error(t, err)
 		assert.Nil(t, result)
@@ -368,9 +368,9 @@ func TestService_UpdateAgentRemoteConfig(t *testing.T) {
 		svc := newSvc(t, mockARC, group, det)
 
 		mockARC.On("UpdateAgentRemoteConfig", ctx, "default", "cfg-1", mock.Anything).
-			Return(newARC("default", "cfg-1"), nil)
+			Return(newARC(), nil)
 
-		result, err := svc.UpdateAgentRemoteConfig(ctx, "default", "cfg-1", apiARC("default", "cfg-1"))
+		result, err := svc.UpdateAgentRemoteConfig(ctx, "default", "cfg-1", apiARC())
 
 		require.NoError(t, err)
 		assert.Equal(t, "cfg-1", result.Metadata.Name)
@@ -388,7 +388,7 @@ func TestService_UpdateAgentRemoteConfig(t *testing.T) {
 
 		mockARC.On("UpdateAgentRemoteConfig", ctx, "default", "cfg-1", mock.Anything).Return(nil, errMock)
 
-		result, err := svc.UpdateAgentRemoteConfig(ctx, "default", "cfg-1", apiARC("default", "cfg-1"))
+		result, err := svc.UpdateAgentRemoteConfig(ctx, "default", "cfg-1", apiARC())
 
 		require.Error(t, err)
 		assert.Nil(t, result)

--- a/pkg/apiserver/application/service/auth/auth_test.go
+++ b/pkg/apiserver/application/service/auth/auth_test.go
@@ -1,0 +1,197 @@
+package auth_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
+	authsvc "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/auth"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	usermodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user"
+	"github.com/minuk-dev/opampcommander/pkg/testutil"
+)
+
+// mockUserUsecase is a mock implementation of userport.UserUsecase.
+type mockUserUsecase struct {
+	mock.Mock
+}
+
+func (m *mockUserUsecase) GetUser(
+	ctx context.Context, uid uuid.UUID, options *model.GetOptions,
+) (*usermodel.User, error) {
+	args := m.Called(ctx, uid, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	user, _ := args.Get(0).(*usermodel.User)
+
+	return user, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockUserUsecase) GetUserByEmail(ctx context.Context, email string) (*usermodel.User, error) {
+	args := m.Called(ctx, email)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	user, _ := args.Get(0).(*usermodel.User)
+
+	return user, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockUserUsecase) GetUserByEmailIncludingDeleted(
+	ctx context.Context, email string,
+) (*usermodel.User, error) {
+	args := m.Called(ctx, email)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	user, _ := args.Get(0).(*usermodel.User)
+
+	return user, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockUserUsecase) GetUserByUsername(ctx context.Context, username string) (*usermodel.User, error) {
+	args := m.Called(ctx, username)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	user, _ := args.Get(0).(*usermodel.User)
+
+	return user, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockUserUsecase) ListUsers(
+	ctx context.Context, options *model.ListOptions,
+) (*model.ListResponse[*usermodel.User], error) {
+	args := m.Called(ctx, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	resp, _ := args.Get(0).(*model.ListResponse[*usermodel.User])
+
+	return resp, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockUserUsecase) SaveUser(ctx context.Context, user *usermodel.User) error {
+	args := m.Called(ctx, user)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+func (m *mockUserUsecase) DeleteUser(ctx context.Context, uid uuid.UUID) error {
+	args := m.Called(ctx, uid)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+// stubRBACUsecase is a no-op userport.RBACUsecase whose SyncPolicies records that it ran.
+type stubRBACUsecase struct {
+	synced bool
+}
+
+func (s *stubRBACUsecase) SyncPolicies(context.Context) error {
+	s.synced = true
+
+	return nil
+}
+
+func (*stubRBACUsecase) CheckPermission(context.Context, uuid.UUID, string, string, string) (bool, error) {
+	return true, nil
+}
+
+func (*stubRBACUsecase) GetUserPermissions(context.Context, uuid.UUID) ([]*usermodel.Permission, error) {
+	return nil, nil
+}
+
+func (*stubRBACUsecase) GetEffectivePermissions(context.Context, uuid.UUID) ([]*usermodel.Permission, error) {
+	return nil, nil
+}
+
+func newSvc(t *testing.T, user *mockUserUsecase, rbac *stubRBACUsecase) *authsvc.Service {
+	t.Helper()
+
+	base := testutil.NewBase(t)
+
+	return authsvc.New(user, rbac, base.Logger)
+}
+
+func provisioning(email string) applicationport.LoginProvisioning {
+	return applicationport.LoginProvisioning{
+		Provider: usermodel.IdentityProviderGitHub,
+		Username: "octocat",
+		Email:    email,
+		Groups:   []string{"acme"},
+	}
+}
+
+func TestService_EnsureUserOnLogin(t *testing.T) {
+	t.Parallel()
+
+	t.Run("existing user is updated and policies synced", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockUser := new(mockUserUsecase)
+		rbac := &stubRBACUsecase{}
+		svc := newSvc(t, mockUser, rbac)
+
+		existing := usermodel.NewUser("octo@example.com", "octocat")
+		mockUser.On("GetUserByEmail", ctx, "octo@example.com").Return(existing, nil)
+		mockUser.On("SaveUser", ctx, existing).Return(nil)
+
+		svc.EnsureUserOnLogin(ctx, provisioning("octo@example.com"))
+
+		mockUser.AssertCalled(t, "SaveUser", ctx, existing)
+		require.True(t, rbac.synced)
+		// The login-type label is synced onto the existing user.
+		require.Equal(t, usermodel.IdentityProviderGitHub, existing.Metadata.Labels[usermodel.LabelLoginType])
+	})
+
+	t.Run("new user is created when none exists", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockUser := new(mockUserUsecase)
+		rbac := &stubRBACUsecase{}
+		svc := newSvc(t, mockUser, rbac)
+
+		mockUser.On("GetUserByEmail", ctx, "new@example.com").Return(nil, model.ErrResourceNotExist)
+		mockUser.On("GetUserByEmailIncludingDeleted", ctx, "new@example.com").
+			Return(nil, model.ErrResourceNotExist)
+		mockUser.On("SaveUser", ctx, mock.MatchedBy(func(u *usermodel.User) bool {
+			return u.Spec.Email == "new@example.com"
+		})).Return(nil)
+
+		svc.EnsureUserOnLogin(ctx, provisioning("new@example.com"))
+
+		mockUser.AssertExpectations(t)
+		require.True(t, rbac.synced)
+	})
+
+	t.Run("soft-deleted user is not recreated", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockUser := new(mockUserUsecase)
+		rbac := &stubRBACUsecase{}
+		svc := newSvc(t, mockUser, rbac)
+
+		deleted := usermodel.NewUser("gone@example.com", "gone")
+		mockUser.On("GetUserByEmail", ctx, "gone@example.com").Return(nil, model.ErrResourceNotExist)
+		mockUser.On("GetUserByEmailIncludingDeleted", ctx, "gone@example.com").Return(deleted, nil)
+
+		svc.EnsureUserOnLogin(ctx, provisioning("gone@example.com"))
+
+		mockUser.AssertNotCalled(t, "SaveUser", mock.Anything, mock.Anything)
+		require.False(t, rbac.synced)
+	})
+}

--- a/pkg/apiserver/application/service/auth/auth_test.go
+++ b/pkg/apiserver/application/service/auth/auth_test.go
@@ -186,6 +186,7 @@ func TestService_EnsureUserOnLogin(t *testing.T) {
 		svc := newSvc(t, mockUser, rbac)
 
 		deleted := usermodel.NewUser("gone@example.com", "gone")
+
 		mockUser.On("GetUserByEmail", ctx, "gone@example.com").Return(nil, model.ErrResourceNotExist)
 		mockUser.On("GetUserByEmailIncludingDeleted", ctx, "gone@example.com").Return(deleted, nil)
 

--- a/pkg/apiserver/application/service/certificate/certificate_test.go
+++ b/pkg/apiserver/application/service/certificate/certificate_test.go
@@ -1,0 +1,346 @@
+package certificate_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/minuk-dev/opampcommander/api/v1"
+	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
+	certificatesvc "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/certificate"
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	"github.com/minuk-dev/opampcommander/pkg/testutil"
+)
+
+var errMock = errors.New("mock error")
+
+// mockCertificateUsecase is a mock implementation of agentport.CertificateUsecase.
+type mockCertificateUsecase struct {
+	mock.Mock
+}
+
+func (m *mockCertificateUsecase) GetCertificate(
+	ctx context.Context, namespace, name string, options *model.GetOptions,
+) (*agentmodel.Certificate, error) {
+	args := m.Called(ctx, namespace, name, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	cert, ok := args.Get(0).(*agentmodel.Certificate)
+	if !ok {
+		return nil, errMock
+	}
+
+	return cert, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockCertificateUsecase) SaveCertificate(
+	ctx context.Context, certificate *agentmodel.Certificate,
+) (*agentmodel.Certificate, error) {
+	args := m.Called(ctx, certificate)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	cert, ok := args.Get(0).(*agentmodel.Certificate)
+	if !ok {
+		return nil, errMock
+	}
+
+	return cert, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockCertificateUsecase) CreateCertificate(
+	ctx context.Context, certificate *agentmodel.Certificate, actor string,
+) (*agentmodel.Certificate, error) {
+	args := m.Called(ctx, certificate, actor)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	cert, ok := args.Get(0).(*agentmodel.Certificate)
+	if !ok {
+		return nil, errMock
+	}
+
+	return cert, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockCertificateUsecase) UpdateCertificate(
+	ctx context.Context, namespace, name string, certificate *agentmodel.Certificate, actor string,
+) (*agentmodel.Certificate, error) {
+	args := m.Called(ctx, namespace, name, certificate, actor)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	cert, ok := args.Get(0).(*agentmodel.Certificate)
+	if !ok {
+		return nil, errMock
+	}
+
+	return cert, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockCertificateUsecase) ListCertificate(
+	ctx context.Context, options *model.ListOptions,
+) (*model.ListResponse[*agentmodel.Certificate], error) {
+	args := m.Called(ctx, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	resp, ok := args.Get(0).(*model.ListResponse[*agentmodel.Certificate])
+	if !ok {
+		return nil, errMock
+	}
+
+	return resp, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockCertificateUsecase) DeleteCertificate(
+	ctx context.Context, namespace, name string, deletedAt time.Time, deletedBy string,
+) (*agentmodel.Certificate, error) {
+	args := m.Called(ctx, namespace, name, deletedAt, deletedBy)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	cert, ok := args.Get(0).(*agentmodel.Certificate)
+	if !ok {
+		return nil, errMock
+	}
+
+	return cert, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func newSvc(t *testing.T, cert *mockCertificateUsecase) *certificatesvc.Service {
+	t.Helper()
+
+	base := testutil.NewBase(t)
+
+	return certificatesvc.NewCertificateService(cert, base.Logger)
+}
+
+func newCert(namespace, name string) *agentmodel.Certificate {
+	return &agentmodel.Certificate{
+		Metadata: agentmodel.CertificateMetadata{Namespace: namespace, Name: name},
+		Spec:     agentmodel.CertificateSpec{Cert: []byte("cert"), PrivateKey: []byte("key")},
+	}
+}
+
+func apiCert(namespace, name string) *v1.Certificate {
+	return &v1.Certificate{
+		Kind:       v1.CertificateKind,
+		APIVersion: v1.APIVersion,
+		Metadata:   v1.CertificateMetadata{Namespace: namespace, Name: name},
+	}
+}
+
+func TestService_GetCertificate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockCert := new(mockCertificateUsecase)
+		svc := newSvc(t, mockCert)
+
+		mockCert.On("GetCertificate", ctx, "default", "cert-1", (*model.GetOptions)(nil)).
+			Return(newCert("default", "cert-1"), nil)
+
+		result, err := svc.GetCertificate(ctx, "default", "cert-1", nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, "default", result.Metadata.Namespace)
+		assert.Equal(t, "cert-1", result.Metadata.Name)
+		mockCert.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockCert := new(mockCertificateUsecase)
+		svc := newSvc(t, mockCert)
+
+		mockCert.On("GetCertificate", ctx, "default", "missing", (*model.GetOptions)(nil)).Return(nil, errMock)
+
+		result, err := svc.GetCertificate(ctx, "default", "missing", nil)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "get certificate")
+		mockCert.AssertExpectations(t)
+	})
+}
+
+func TestService_ListCertificates(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockCert := new(mockCertificateUsecase)
+		svc := newSvc(t, mockCert)
+
+		opts := &applicationport.ListOptions{Limit: 10}
+		resp := &model.ListResponse[*agentmodel.Certificate]{
+			Items:    []*agentmodel.Certificate{newCert("default", "cert-1")},
+			Continue: "next",
+		}
+		mockCert.On("ListCertificate", ctx, opts.ToDomain()).Return(resp, nil)
+
+		result, err := svc.ListCertificates(ctx, opts)
+
+		require.NoError(t, err)
+		assert.Equal(t, v1.CertificateKind, result.Kind)
+		assert.Len(t, result.Items, 1)
+		assert.Equal(t, "next", result.Metadata.Continue)
+		mockCert.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockCert := new(mockCertificateUsecase)
+		svc := newSvc(t, mockCert)
+
+		opts := &applicationport.ListOptions{Limit: 10}
+		mockCert.On("ListCertificate", ctx, opts.ToDomain()).Return(nil, errMock)
+
+		result, err := svc.ListCertificates(ctx, opts)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "list certificates")
+		mockCert.AssertExpectations(t)
+	})
+}
+
+func TestService_CreateCertificate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockCert := new(mockCertificateUsecase)
+		svc := newSvc(t, mockCert)
+
+		mockCert.On("CreateCertificate", ctx, mock.MatchedBy(func(c *agentmodel.Certificate) bool {
+			return c.Metadata.Name == "cert-1"
+		}), mock.AnythingOfType("string")).Return(newCert("default", "cert-1"), nil)
+
+		result, err := svc.CreateCertificate(ctx, apiCert("default", "cert-1"))
+
+		require.NoError(t, err)
+		assert.Equal(t, "cert-1", result.Metadata.Name)
+		mockCert.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockCert := new(mockCertificateUsecase)
+		svc := newSvc(t, mockCert)
+
+		mockCert.On("CreateCertificate", ctx, mock.Anything, mock.AnythingOfType("string")).Return(nil, errMock)
+
+		result, err := svc.CreateCertificate(ctx, apiCert("default", "cert-1"))
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "create certificate")
+		mockCert.AssertExpectations(t)
+	})
+}
+
+func TestService_UpdateCertificate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockCert := new(mockCertificateUsecase)
+		svc := newSvc(t, mockCert)
+
+		mockCert.On("UpdateCertificate", ctx, "default", "cert-1", mock.Anything, mock.AnythingOfType("string")).
+			Return(newCert("default", "cert-1"), nil)
+
+		result, err := svc.UpdateCertificate(ctx, "default", "cert-1", apiCert("default", "cert-1"))
+
+		require.NoError(t, err)
+		assert.Equal(t, "cert-1", result.Metadata.Name)
+		mockCert.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockCert := new(mockCertificateUsecase)
+		svc := newSvc(t, mockCert)
+
+		mockCert.On("UpdateCertificate", ctx, "default", "cert-1", mock.Anything, mock.AnythingOfType("string")).
+			Return(nil, errMock)
+
+		result, err := svc.UpdateCertificate(ctx, "default", "cert-1", apiCert("default", "cert-1"))
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "update certificate")
+		mockCert.AssertExpectations(t)
+	})
+}
+
+func TestService_DeleteCertificate(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockCert := new(mockCertificateUsecase)
+		svc := newSvc(t, mockCert)
+
+		mockCert.On("DeleteCertificate", ctx, "default", "cert-1",
+			mock.AnythingOfType("time.Time"), mock.AnythingOfType("string")).
+			Return(newCert("default", "cert-1"), nil)
+
+		err := svc.DeleteCertificate(ctx, "default", "cert-1")
+
+		require.NoError(t, err)
+		mockCert.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockCert := new(mockCertificateUsecase)
+		svc := newSvc(t, mockCert)
+
+		mockCert.On("DeleteCertificate", ctx, "default", "cert-1",
+			mock.AnythingOfType("time.Time"), mock.AnythingOfType("string")).
+			Return(nil, errMock)
+
+		err := svc.DeleteCertificate(ctx, "default", "cert-1")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "delete certificate")
+		mockCert.AssertExpectations(t)
+	})
+}

--- a/pkg/apiserver/application/service/certificate/certificate_test.go
+++ b/pkg/apiserver/application/service/certificate/certificate_test.go
@@ -129,18 +129,18 @@ func newSvc(t *testing.T, cert *mockCertificateUsecase) *certificatesvc.Service 
 	return certificatesvc.NewCertificateService(cert, base.Logger)
 }
 
-func newCert(namespace, name string) *agentmodel.Certificate {
+func newCert() *agentmodel.Certificate {
 	return &agentmodel.Certificate{
-		Metadata: agentmodel.CertificateMetadata{Namespace: namespace, Name: name},
+		Metadata: agentmodel.CertificateMetadata{Namespace: "default", Name: "cert-1"},
 		Spec:     agentmodel.CertificateSpec{Cert: []byte("cert"), PrivateKey: []byte("key")},
 	}
 }
 
-func apiCert(namespace, name string) *v1.Certificate {
+func apiCert() *v1.Certificate {
 	return &v1.Certificate{
 		Kind:       v1.CertificateKind,
 		APIVersion: v1.APIVersion,
-		Metadata:   v1.CertificateMetadata{Namespace: namespace, Name: name},
+		Metadata:   v1.CertificateMetadata{Namespace: "default", Name: "cert-1"},
 	}
 }
 
@@ -155,7 +155,7 @@ func TestService_GetCertificate(t *testing.T) {
 		svc := newSvc(t, mockCert)
 
 		mockCert.On("GetCertificate", ctx, "default", "cert-1", (*model.GetOptions)(nil)).
-			Return(newCert("default", "cert-1"), nil)
+			Return(newCert(), nil)
 
 		result, err := svc.GetCertificate(ctx, "default", "cert-1", nil)
 
@@ -195,7 +195,7 @@ func TestService_ListCertificates(t *testing.T) {
 
 		opts := &applicationport.ListOptions{Limit: 10}
 		resp := &model.ListResponse[*agentmodel.Certificate]{
-			Items:    []*agentmodel.Certificate{newCert("default", "cert-1")},
+			Items:    []*agentmodel.Certificate{newCert()},
 			Continue: "next",
 		}
 		mockCert.On("ListCertificate", ctx, opts.ToDomain()).Return(resp, nil)
@@ -240,9 +240,9 @@ func TestService_CreateCertificate(t *testing.T) {
 
 		mockCert.On("CreateCertificate", ctx, mock.MatchedBy(func(c *agentmodel.Certificate) bool {
 			return c.Metadata.Name == "cert-1"
-		}), mock.AnythingOfType("string")).Return(newCert("default", "cert-1"), nil)
+		}), mock.AnythingOfType("string")).Return(newCert(), nil)
 
-		result, err := svc.CreateCertificate(ctx, apiCert("default", "cert-1"))
+		result, err := svc.CreateCertificate(ctx, apiCert())
 
 		require.NoError(t, err)
 		assert.Equal(t, "cert-1", result.Metadata.Name)
@@ -258,7 +258,7 @@ func TestService_CreateCertificate(t *testing.T) {
 
 		mockCert.On("CreateCertificate", ctx, mock.Anything, mock.AnythingOfType("string")).Return(nil, errMock)
 
-		result, err := svc.CreateCertificate(ctx, apiCert("default", "cert-1"))
+		result, err := svc.CreateCertificate(ctx, apiCert())
 
 		require.Error(t, err)
 		assert.Nil(t, result)
@@ -278,9 +278,9 @@ func TestService_UpdateCertificate(t *testing.T) {
 		svc := newSvc(t, mockCert)
 
 		mockCert.On("UpdateCertificate", ctx, "default", "cert-1", mock.Anything, mock.AnythingOfType("string")).
-			Return(newCert("default", "cert-1"), nil)
+			Return(newCert(), nil)
 
-		result, err := svc.UpdateCertificate(ctx, "default", "cert-1", apiCert("default", "cert-1"))
+		result, err := svc.UpdateCertificate(ctx, "default", "cert-1", apiCert())
 
 		require.NoError(t, err)
 		assert.Equal(t, "cert-1", result.Metadata.Name)
@@ -297,7 +297,7 @@ func TestService_UpdateCertificate(t *testing.T) {
 		mockCert.On("UpdateCertificate", ctx, "default", "cert-1", mock.Anything, mock.AnythingOfType("string")).
 			Return(nil, errMock)
 
-		result, err := svc.UpdateCertificate(ctx, "default", "cert-1", apiCert("default", "cert-1"))
+		result, err := svc.UpdateCertificate(ctx, "default", "cert-1", apiCert())
 
 		require.Error(t, err)
 		assert.Nil(t, result)
@@ -318,7 +318,7 @@ func TestService_DeleteCertificate(t *testing.T) {
 
 		mockCert.On("DeleteCertificate", ctx, "default", "cert-1",
 			mock.AnythingOfType("time.Time"), mock.AnythingOfType("string")).
-			Return(newCert("default", "cert-1"), nil)
+			Return(newCert(), nil)
 
 		err := svc.DeleteCertificate(ctx, "default", "cert-1")
 

--- a/pkg/apiserver/application/service/container/container_test.go
+++ b/pkg/apiserver/application/service/container/container_test.go
@@ -162,15 +162,13 @@ func newSvc(t *testing.T, container *mockContainerUsecase, agent *mockAgentUseca
 	return containersvc.New(container, agent, base.Logger)
 }
 
-func newContainer(id string, agentUIDs ...uuid.UUID) *agentmodel.Container {
+func newContainer(id string) *agentmodel.Container {
 	return &agentmodel.Container{
 		Metadata: agentmodel.ContainerMetadata{
 			ID:   id,
 			Name: "container-" + id,
 		},
-		Status: agentmodel.ContainerStatus{
-			AgentInstanceUIDs: agentUIDs,
-		},
+		Status: agentmodel.ContainerStatus{},
 	}
 }
 

--- a/pkg/apiserver/application/service/container/container_test.go
+++ b/pkg/apiserver/application/service/container/container_test.go
@@ -1,0 +1,298 @@
+package container_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/minuk-dev/opampcommander/api/v1"
+	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
+	containersvc "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/container"
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	"github.com/minuk-dev/opampcommander/pkg/testutil"
+)
+
+var errMock = errors.New("mock error")
+
+// mockContainerUsecase is a mock implementation of agentport.ContainerUsecase.
+type mockContainerUsecase struct {
+	mock.Mock
+}
+
+func (m *mockContainerUsecase) GetContainer(ctx context.Context, id string) (*agentmodel.Container, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	container, ok := args.Get(0).(*agentmodel.Container)
+	if !ok {
+		return nil, errMock
+	}
+
+	return container, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockContainerUsecase) ListContainers(
+	ctx context.Context, options *model.ListOptions,
+) (*model.ListResponse[*agentmodel.Container], error) {
+	args := m.Called(ctx, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	resp, ok := args.Get(0).(*model.ListResponse[*agentmodel.Container])
+	if !ok {
+		return nil, errMock
+	}
+
+	return resp, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockContainerUsecase) ObserveAgent(ctx context.Context, agent *agentmodel.Agent) error {
+	args := m.Called(ctx, agent)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+// mockAgentUsecase is a mock implementation of agentport.AgentUsecase.
+type mockAgentUsecase struct {
+	mock.Mock
+}
+
+func (m *mockAgentUsecase) GetAgent(ctx context.Context, instanceUID uuid.UUID) (*agentmodel.Agent, error) {
+	args := m.Called(ctx, instanceUID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	agent, ok := args.Get(0).(*agentmodel.Agent)
+	if !ok {
+		return nil, errMock
+	}
+
+	return agent, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentUsecase) GetOrCreateAgent(ctx context.Context, instanceUID uuid.UUID) (*agentmodel.Agent, error) {
+	args := m.Called(ctx, instanceUID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	agent, ok := args.Get(0).(*agentmodel.Agent)
+	if !ok {
+		return nil, errMock
+	}
+
+	return agent, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentUsecase) ListAgentsBySelector(
+	ctx context.Context, selector agentmodel.AgentSelector, options *model.ListOptions,
+) (*model.ListResponse[*agentmodel.Agent], error) {
+	args := m.Called(ctx, selector, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	resp, ok := args.Get(0).(*model.ListResponse[*agentmodel.Agent])
+	if !ok {
+		return nil, errMock
+	}
+
+	return resp, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentUsecase) SaveAgent(ctx context.Context, agent *agentmodel.Agent) error {
+	args := m.Called(ctx, agent)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentUsecase) DeleteAgent(ctx context.Context, instanceUID uuid.UUID) error {
+	args := m.Called(ctx, instanceUID)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentUsecase) ListAgents(
+	ctx context.Context, namespace string, options *model.ListOptions,
+) (*model.ListResponse[*agentmodel.Agent], error) {
+	args := m.Called(ctx, namespace, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	resp, ok := args.Get(0).(*model.ListResponse[*agentmodel.Agent])
+	if !ok {
+		return nil, errMock
+	}
+
+	return resp, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentUsecase) SearchAgents(
+	ctx context.Context, namespace string, query string, options *model.ListOptions,
+) (*model.ListResponse[*agentmodel.Agent], error) {
+	args := m.Called(ctx, namespace, query, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	resp, ok := args.Get(0).(*model.ListResponse[*agentmodel.Agent])
+	if !ok {
+		return nil, errMock
+	}
+
+	return resp, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func newSvc(t *testing.T, container *mockContainerUsecase, agent *mockAgentUsecase) *containersvc.Service {
+	t.Helper()
+
+	base := testutil.NewBase(t)
+
+	return containersvc.New(container, agent, base.Logger)
+}
+
+func newContainer(id string, agentUIDs ...uuid.UUID) *agentmodel.Container {
+	return &agentmodel.Container{
+		Metadata: agentmodel.ContainerMetadata{
+			ID:   id,
+			Name: "container-" + id,
+		},
+		Status: agentmodel.ContainerStatus{
+			AgentInstanceUIDs: agentUIDs,
+		},
+	}
+}
+
+func TestService_GetContainer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockContainer := new(mockContainerUsecase)
+		svc := newSvc(t, mockContainer, new(mockAgentUsecase))
+
+		mockContainer.On("GetContainer", ctx, "c-1").Return(newContainer("c-1"), nil)
+
+		result, err := svc.GetContainer(ctx, "c-1")
+
+		require.NoError(t, err)
+		assert.Equal(t, v1.ContainerKind, result.Kind)
+		assert.Equal(t, "c-1", result.Metadata.ID)
+		mockContainer.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockContainer := new(mockContainerUsecase)
+		svc := newSvc(t, mockContainer, new(mockAgentUsecase))
+
+		mockContainer.On("GetContainer", ctx, "missing").Return(nil, errMock)
+
+		result, err := svc.GetContainer(ctx, "missing")
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "failed to get container")
+		mockContainer.AssertExpectations(t)
+	})
+}
+
+func TestService_ListContainers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockContainer := new(mockContainerUsecase)
+		svc := newSvc(t, mockContainer, new(mockAgentUsecase))
+
+		opts := &applicationport.ListOptions{Limit: 10}
+		resp := &model.ListResponse[*agentmodel.Container]{
+			Items:    []*agentmodel.Container{newContainer("c-1"), newContainer("c-2")},
+			Continue: "next",
+		}
+		mockContainer.On("ListContainers", ctx, opts.ToDomain()).Return(resp, nil)
+
+		result, err := svc.ListContainers(ctx, opts)
+
+		require.NoError(t, err)
+		assert.Equal(t, v1.ContainerKind, result.Kind)
+		assert.Len(t, result.Items, 2)
+		assert.Equal(t, "next", result.Metadata.Continue)
+		mockContainer.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockContainer := new(mockContainerUsecase)
+		svc := newSvc(t, mockContainer, new(mockAgentUsecase))
+
+		opts := &applicationport.ListOptions{Limit: 10}
+		mockContainer.On("ListContainers", ctx, opts.ToDomain()).Return(nil, errMock)
+
+		result, err := svc.ListContainers(ctx, opts)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "failed to list containers")
+		mockContainer.AssertExpectations(t)
+	})
+}
+
+func TestService_ListAgentsByContainer(t *testing.T) {
+	t.Parallel()
+
+	t.Run("container with no agents returns empty list", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockContainer := new(mockContainerUsecase)
+		mockAgent := new(mockAgentUsecase)
+		svc := newSvc(t, mockContainer, mockAgent)
+
+		mockContainer.On("GetContainer", ctx, "c-1").Return(newContainer("c-1"), nil)
+
+		result, err := svc.ListAgentsByContainer(ctx, "c-1", &applicationport.ListOptions{Limit: 10})
+
+		require.NoError(t, err)
+		assert.Equal(t, v1.AgentKind, result.Kind)
+		assert.Empty(t, result.Items)
+		mockAgent.AssertNotCalled(t, "GetAgent", mock.Anything, mock.Anything)
+		mockContainer.AssertExpectations(t)
+	})
+
+	t.Run("container lookup error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockContainer := new(mockContainerUsecase)
+		svc := newSvc(t, mockContainer, new(mockAgentUsecase))
+
+		mockContainer.On("GetContainer", ctx, "missing").Return(nil, errMock)
+
+		result, err := svc.ListAgentsByContainer(ctx, "missing", &applicationport.ListOptions{Limit: 10})
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "failed to get container")
+		mockContainer.AssertExpectations(t)
+	})
+}

--- a/pkg/apiserver/application/service/endpoint/endpoint_test.go
+++ b/pkg/apiserver/application/service/endpoint/endpoint_test.go
@@ -1,0 +1,333 @@
+package endpoint_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/minuk-dev/opampcommander/api/v1"
+	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
+	endpointsvc "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/endpoint"
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	"github.com/minuk-dev/opampcommander/pkg/testutil"
+)
+
+var errMock = errors.New("mock error")
+
+// mockEndpointUsecase is a mock implementation of agentport.EndpointUsecase.
+type mockEndpointUsecase struct {
+	mock.Mock
+}
+
+func (m *mockEndpointUsecase) GetEndpoint(
+	ctx context.Context, namespace, name string, options *model.GetOptions,
+) (*agentmodel.Endpoint, error) {
+	args := m.Called(ctx, namespace, name, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	ep, ok := args.Get(0).(*agentmodel.Endpoint)
+	if !ok {
+		return nil, errMock
+	}
+
+	return ep, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockEndpointUsecase) ListEndpoints(
+	ctx context.Context, namespace string, options *model.ListOptions,
+) (*model.ListResponse[*agentmodel.Endpoint], error) {
+	args := m.Called(ctx, namespace, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	resp, ok := args.Get(0).(*model.ListResponse[*agentmodel.Endpoint])
+	if !ok {
+		return nil, errMock
+	}
+
+	return resp, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockEndpointUsecase) SaveEndpoint(
+	ctx context.Context, endpoint *agentmodel.Endpoint,
+) (*agentmodel.Endpoint, error) {
+	args := m.Called(ctx, endpoint)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	ep, ok := args.Get(0).(*agentmodel.Endpoint)
+	if !ok {
+		return nil, errMock
+	}
+
+	return ep, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockEndpointUsecase) CreateEndpoint(
+	ctx context.Context, endpoint *agentmodel.Endpoint, actor string,
+) (*agentmodel.Endpoint, error) {
+	args := m.Called(ctx, endpoint, actor)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	ep, ok := args.Get(0).(*agentmodel.Endpoint)
+	if !ok {
+		return nil, errMock
+	}
+
+	return ep, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockEndpointUsecase) UpdateEndpoint(
+	ctx context.Context, namespace, name string, endpoint *agentmodel.Endpoint,
+) (*agentmodel.Endpoint, error) {
+	args := m.Called(ctx, namespace, name, endpoint)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	ep, ok := args.Get(0).(*agentmodel.Endpoint)
+	if !ok {
+		return nil, errMock
+	}
+
+	return ep, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockEndpointUsecase) DeleteEndpoint(
+	ctx context.Context, namespace, name string, deletedAt time.Time, deletedBy string,
+) error {
+	args := m.Called(ctx, namespace, name, deletedAt, deletedBy)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+func newSvc(t *testing.T, ep *mockEndpointUsecase) *endpointsvc.Service {
+	t.Helper()
+
+	base := testutil.NewBase(t)
+
+	return endpointsvc.NewEndpointService(ep, base.Logger)
+}
+
+func newEndpoint(namespace, name string) *agentmodel.Endpoint {
+	return &agentmodel.Endpoint{
+		Metadata: agentmodel.EndpointMetadata{Namespace: namespace, Name: name},
+	}
+}
+
+func apiEndpoint(namespace, name string) *v1.Endpoint {
+	return &v1.Endpoint{
+		Kind:       v1.EndpointKind,
+		APIVersion: v1.APIVersion,
+		Metadata:   v1.EndpointMetadata{Namespace: namespace, Name: name},
+	}
+}
+
+func TestService_GetEndpoint(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockEP := new(mockEndpointUsecase)
+		svc := newSvc(t, mockEP)
+
+		mockEP.On("GetEndpoint", ctx, "default", "ep-1", (*model.GetOptions)(nil)).
+			Return(newEndpoint("default", "ep-1"), nil)
+
+		result, err := svc.GetEndpoint(ctx, "default", "ep-1", nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, "ep-1", result.Metadata.Name)
+		mockEP.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockEP := new(mockEndpointUsecase)
+		svc := newSvc(t, mockEP)
+
+		mockEP.On("GetEndpoint", ctx, "default", "missing", (*model.GetOptions)(nil)).Return(nil, errMock)
+
+		result, err := svc.GetEndpoint(ctx, "default", "missing", nil)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "get endpoint")
+		mockEP.AssertExpectations(t)
+	})
+}
+
+func TestService_ListEndpoints(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockEP := new(mockEndpointUsecase)
+		svc := newSvc(t, mockEP)
+
+		opts := &applicationport.ListOptions{Limit: 10}
+		resp := &model.ListResponse[*agentmodel.Endpoint]{
+			Items:    []*agentmodel.Endpoint{newEndpoint("default", "ep-1")},
+			Continue: "next",
+		}
+		mockEP.On("ListEndpoints", ctx, "default", opts.ToDomain()).Return(resp, nil)
+
+		result, err := svc.ListEndpoints(ctx, "default", opts)
+
+		require.NoError(t, err)
+		assert.Equal(t, v1.EndpointKind, result.Kind)
+		assert.Len(t, result.Items, 1)
+		assert.Equal(t, "next", result.Metadata.Continue)
+		mockEP.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockEP := new(mockEndpointUsecase)
+		svc := newSvc(t, mockEP)
+
+		opts := &applicationport.ListOptions{Limit: 10}
+		mockEP.On("ListEndpoints", ctx, "default", opts.ToDomain()).Return(nil, errMock)
+
+		result, err := svc.ListEndpoints(ctx, "default", opts)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "list endpoints")
+		mockEP.AssertExpectations(t)
+	})
+}
+
+func TestService_CreateEndpoint(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockEP := new(mockEndpointUsecase)
+		svc := newSvc(t, mockEP)
+
+		mockEP.On("CreateEndpoint", ctx, mock.MatchedBy(func(e *agentmodel.Endpoint) bool {
+			return e.Metadata.Name == "ep-1"
+		}), mock.AnythingOfType("string")).Return(newEndpoint("default", "ep-1"), nil)
+
+		result, err := svc.CreateEndpoint(ctx, apiEndpoint("default", "ep-1"))
+
+		require.NoError(t, err)
+		assert.Equal(t, "ep-1", result.Metadata.Name)
+		mockEP.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockEP := new(mockEndpointUsecase)
+		svc := newSvc(t, mockEP)
+
+		mockEP.On("CreateEndpoint", ctx, mock.Anything, mock.AnythingOfType("string")).Return(nil, errMock)
+
+		result, err := svc.CreateEndpoint(ctx, apiEndpoint("default", "ep-1"))
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "create endpoint")
+		mockEP.AssertExpectations(t)
+	})
+}
+
+func TestService_UpdateEndpoint(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockEP := new(mockEndpointUsecase)
+		svc := newSvc(t, mockEP)
+
+		mockEP.On("UpdateEndpoint", ctx, "default", "ep-1", mock.Anything).
+			Return(newEndpoint("default", "ep-1"), nil)
+
+		result, err := svc.UpdateEndpoint(ctx, "default", "ep-1", apiEndpoint("default", "ep-1"))
+
+		require.NoError(t, err)
+		assert.Equal(t, "ep-1", result.Metadata.Name)
+		mockEP.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockEP := new(mockEndpointUsecase)
+		svc := newSvc(t, mockEP)
+
+		mockEP.On("UpdateEndpoint", ctx, "default", "ep-1", mock.Anything).Return(nil, errMock)
+
+		result, err := svc.UpdateEndpoint(ctx, "default", "ep-1", apiEndpoint("default", "ep-1"))
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "update endpoint")
+		mockEP.AssertExpectations(t)
+	})
+}
+
+func TestService_DeleteEndpoint(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockEP := new(mockEndpointUsecase)
+		svc := newSvc(t, mockEP)
+
+		mockEP.On("DeleteEndpoint", ctx, "default", "ep-1",
+			mock.AnythingOfType("time.Time"), mock.AnythingOfType("string")).Return(nil)
+
+		err := svc.DeleteEndpoint(ctx, "default", "ep-1")
+
+		require.NoError(t, err)
+		mockEP.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockEP := new(mockEndpointUsecase)
+		svc := newSvc(t, mockEP)
+
+		mockEP.On("DeleteEndpoint", ctx, "default", "ep-1",
+			mock.AnythingOfType("time.Time"), mock.AnythingOfType("string")).Return(errMock)
+
+		err := svc.DeleteEndpoint(ctx, "default", "ep-1")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "delete endpoint")
+		mockEP.AssertExpectations(t)
+	})
+}

--- a/pkg/apiserver/application/service/endpoint/endpoint_test.go
+++ b/pkg/apiserver/application/service/endpoint/endpoint_test.go
@@ -121,17 +121,17 @@ func newSvc(t *testing.T, ep *mockEndpointUsecase) *endpointsvc.Service {
 	return endpointsvc.NewEndpointService(ep, base.Logger)
 }
 
-func newEndpoint(namespace, name string) *agentmodel.Endpoint {
+func newEndpoint() *agentmodel.Endpoint {
 	return &agentmodel.Endpoint{
-		Metadata: agentmodel.EndpointMetadata{Namespace: namespace, Name: name},
+		Metadata: agentmodel.EndpointMetadata{Namespace: "default", Name: "ep-1"},
 	}
 }
 
-func apiEndpoint(namespace, name string) *v1.Endpoint {
+func apiEndpoint() *v1.Endpoint {
 	return &v1.Endpoint{
 		Kind:       v1.EndpointKind,
 		APIVersion: v1.APIVersion,
-		Metadata:   v1.EndpointMetadata{Namespace: namespace, Name: name},
+		Metadata:   v1.EndpointMetadata{Namespace: "default", Name: "ep-1"},
 	}
 }
 
@@ -146,7 +146,7 @@ func TestService_GetEndpoint(t *testing.T) {
 		svc := newSvc(t, mockEP)
 
 		mockEP.On("GetEndpoint", ctx, "default", "ep-1", (*model.GetOptions)(nil)).
-			Return(newEndpoint("default", "ep-1"), nil)
+			Return(newEndpoint(), nil)
 
 		result, err := svc.GetEndpoint(ctx, "default", "ep-1", nil)
 
@@ -185,7 +185,7 @@ func TestService_ListEndpoints(t *testing.T) {
 
 		opts := &applicationport.ListOptions{Limit: 10}
 		resp := &model.ListResponse[*agentmodel.Endpoint]{
-			Items:    []*agentmodel.Endpoint{newEndpoint("default", "ep-1")},
+			Items:    []*agentmodel.Endpoint{newEndpoint()},
 			Continue: "next",
 		}
 		mockEP.On("ListEndpoints", ctx, "default", opts.ToDomain()).Return(resp, nil)
@@ -230,9 +230,9 @@ func TestService_CreateEndpoint(t *testing.T) {
 
 		mockEP.On("CreateEndpoint", ctx, mock.MatchedBy(func(e *agentmodel.Endpoint) bool {
 			return e.Metadata.Name == "ep-1"
-		}), mock.AnythingOfType("string")).Return(newEndpoint("default", "ep-1"), nil)
+		}), mock.AnythingOfType("string")).Return(newEndpoint(), nil)
 
-		result, err := svc.CreateEndpoint(ctx, apiEndpoint("default", "ep-1"))
+		result, err := svc.CreateEndpoint(ctx, apiEndpoint())
 
 		require.NoError(t, err)
 		assert.Equal(t, "ep-1", result.Metadata.Name)
@@ -248,7 +248,7 @@ func TestService_CreateEndpoint(t *testing.T) {
 
 		mockEP.On("CreateEndpoint", ctx, mock.Anything, mock.AnythingOfType("string")).Return(nil, errMock)
 
-		result, err := svc.CreateEndpoint(ctx, apiEndpoint("default", "ep-1"))
+		result, err := svc.CreateEndpoint(ctx, apiEndpoint())
 
 		require.Error(t, err)
 		assert.Nil(t, result)
@@ -268,9 +268,9 @@ func TestService_UpdateEndpoint(t *testing.T) {
 		svc := newSvc(t, mockEP)
 
 		mockEP.On("UpdateEndpoint", ctx, "default", "ep-1", mock.Anything).
-			Return(newEndpoint("default", "ep-1"), nil)
+			Return(newEndpoint(), nil)
 
-		result, err := svc.UpdateEndpoint(ctx, "default", "ep-1", apiEndpoint("default", "ep-1"))
+		result, err := svc.UpdateEndpoint(ctx, "default", "ep-1", apiEndpoint())
 
 		require.NoError(t, err)
 		assert.Equal(t, "ep-1", result.Metadata.Name)
@@ -286,7 +286,7 @@ func TestService_UpdateEndpoint(t *testing.T) {
 
 		mockEP.On("UpdateEndpoint", ctx, "default", "ep-1", mock.Anything).Return(nil, errMock)
 
-		result, err := svc.UpdateEndpoint(ctx, "default", "ep-1", apiEndpoint("default", "ep-1"))
+		result, err := svc.UpdateEndpoint(ctx, "default", "ep-1", apiEndpoint())
 
 		require.Error(t, err)
 		assert.Nil(t, result)

--- a/pkg/apiserver/application/service/endpointmetrics/endpointmetrics_test.go
+++ b/pkg/apiserver/application/service/endpointmetrics/endpointmetrics_test.go
@@ -1,0 +1,171 @@
+package endpointmetrics_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/minuk-dev/opampcommander/api/v1"
+	endpointmetricssvc "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/endpointmetrics"
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent"
+	"github.com/minuk-dev/opampcommander/pkg/testutil"
+)
+
+var errMock = errors.New("mock error")
+
+const testDefaultWindow = time.Minute
+
+// mockEndpointMetricsUsecase is a mock implementation of agentport.EndpointMetricsUsecase.
+type mockEndpointMetricsUsecase struct {
+	mock.Mock
+}
+
+func (m *mockEndpointMetricsUsecase) GetEndpointThroughput(
+	ctx context.Context, namespace, name string, window time.Duration, evaluatedAt time.Time,
+) (*agentmodel.EndpointThroughput, error) {
+	args := m.Called(ctx, namespace, name, window, evaluatedAt)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	tp, ok := args.Get(0).(*agentmodel.EndpointThroughput)
+	if !ok {
+		return nil, errMock
+	}
+
+	return tp, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockEndpointMetricsUsecase) ListEndpointThroughput(
+	ctx context.Context, namespace string, window time.Duration, evaluatedAt time.Time,
+) ([]*agentmodel.EndpointThroughput, error) {
+	args := m.Called(ctx, namespace, window, evaluatedAt)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	tps, ok := args.Get(0).([]*agentmodel.EndpointThroughput)
+	if !ok {
+		return nil, errMock
+	}
+
+	return tps, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func newSvc(t *testing.T, m *mockEndpointMetricsUsecase) *endpointmetricssvc.Service {
+	t.Helper()
+
+	base := testutil.NewBase(t)
+
+	return endpointmetricssvc.NewEndpointMetricsService(m, testDefaultWindow, base.Logger)
+}
+
+func newThroughput(namespace, name string, window time.Duration) *agentmodel.EndpointThroughput {
+	return &agentmodel.EndpointThroughput{
+		Namespace:   namespace,
+		Name:        name,
+		EvaluatedAt: time.Now(),
+		Window:      window,
+	}
+}
+
+func TestService_GetEndpointThroughput(t *testing.T) {
+	t.Parallel()
+
+	t.Run("uses supplied window", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockUC := new(mockEndpointMetricsUsecase)
+		svc := newSvc(t, mockUC)
+
+		window := 10 * time.Minute
+		mockUC.On("GetEndpointThroughput", ctx, "default", "ep-1", window, mock.AnythingOfType("time.Time")).
+			Return(newThroughput("default", "ep-1", window), nil)
+
+		result, err := svc.GetEndpointThroughput(ctx, "default", "ep-1", window)
+
+		require.NoError(t, err)
+		assert.Equal(t, "ep-1", result.Name)
+		mockUC.AssertExpectations(t)
+	})
+
+	t.Run("falls back to default window when window non-positive", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockUC := new(mockEndpointMetricsUsecase)
+		svc := newSvc(t, mockUC)
+
+		mockUC.On("GetEndpointThroughput", ctx, "default", "ep-1", testDefaultWindow, mock.AnythingOfType("time.Time")).
+			Return(newThroughput("default", "ep-1", testDefaultWindow), nil)
+
+		_, err := svc.GetEndpointThroughput(ctx, "default", "ep-1", 0)
+
+		require.NoError(t, err)
+		mockUC.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockUC := new(mockEndpointMetricsUsecase)
+		svc := newSvc(t, mockUC)
+
+		mockUC.On("GetEndpointThroughput", ctx, "default", "ep-1", testDefaultWindow, mock.AnythingOfType("time.Time")).
+			Return(nil, errMock)
+
+		result, err := svc.GetEndpointThroughput(ctx, "default", "ep-1", 0)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "get endpoint throughput")
+		mockUC.AssertExpectations(t)
+	})
+}
+
+func TestService_ListEndpointThroughput(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockUC := new(mockEndpointMetricsUsecase)
+		svc := newSvc(t, mockUC)
+
+		mockUC.On("ListEndpointThroughput", ctx, "default", testDefaultWindow, mock.AnythingOfType("time.Time")).
+			Return([]*agentmodel.EndpointThroughput{newThroughput("default", "ep-1", testDefaultWindow)}, nil)
+
+		result, err := svc.ListEndpointThroughput(ctx, "default", 0)
+
+		require.NoError(t, err)
+		assert.Equal(t, v1.EndpointThroughputKind, result.Kind)
+		assert.Len(t, result.Items, 1)
+		mockUC.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockUC := new(mockEndpointMetricsUsecase)
+		svc := newSvc(t, mockUC)
+
+		mockUC.On("ListEndpointThroughput", ctx, "default", testDefaultWindow, mock.AnythingOfType("time.Time")).
+			Return(nil, errMock)
+
+		result, err := svc.ListEndpointThroughput(ctx, "default", 0)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "list endpoint throughput")
+		mockUC.AssertExpectations(t)
+	})
+}

--- a/pkg/apiserver/application/service/host/host_test.go
+++ b/pkg/apiserver/application/service/host/host_test.go
@@ -163,7 +163,7 @@ func newSvc(t *testing.T, host *mockHostUsecase, agent *mockAgentUsecase) *hosts
 	return hostsvc.New(host, agent, base.Logger)
 }
 
-func newHost(id string, agentUIDs ...uuid.UUID) *agentmodel.Host {
+func newHost(id string) *agentmodel.Host {
 	return &agentmodel.Host{
 		Metadata: agentmodel.HostMetadata{
 			ID:          id,
@@ -171,9 +171,7 @@ func newHost(id string, agentUIDs ...uuid.UUID) *agentmodel.Host {
 			FirstSeenAt: time.Now(),
 			LastSeenAt:  time.Now(),
 		},
-		Status: agentmodel.HostStatus{
-			AgentInstanceUIDs: agentUIDs,
-		},
+		Status: agentmodel.HostStatus{},
 	}
 }
 

--- a/pkg/apiserver/application/service/host/host_test.go
+++ b/pkg/apiserver/application/service/host/host_test.go
@@ -1,0 +1,302 @@
+package host_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/minuk-dev/opampcommander/api/v1"
+	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
+	hostsvc "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/host"
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	"github.com/minuk-dev/opampcommander/pkg/testutil"
+)
+
+var errMock = errors.New("mock error")
+
+// mockHostUsecase is a mock implementation of agentport.HostUsecase.
+type mockHostUsecase struct {
+	mock.Mock
+}
+
+func (m *mockHostUsecase) GetHost(ctx context.Context, id string) (*agentmodel.Host, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	host, ok := args.Get(0).(*agentmodel.Host)
+	if !ok {
+		return nil, errMock
+	}
+
+	return host, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockHostUsecase) ListHosts(
+	ctx context.Context, options *model.ListOptions,
+) (*model.ListResponse[*agentmodel.Host], error) {
+	args := m.Called(ctx, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	resp, ok := args.Get(0).(*model.ListResponse[*agentmodel.Host])
+	if !ok {
+		return nil, errMock
+	}
+
+	return resp, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockHostUsecase) ObserveAgent(ctx context.Context, agent *agentmodel.Agent) error {
+	args := m.Called(ctx, agent)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+// mockAgentUsecase is a mock implementation of agentport.AgentUsecase.
+type mockAgentUsecase struct {
+	mock.Mock
+}
+
+func (m *mockAgentUsecase) GetAgent(ctx context.Context, instanceUID uuid.UUID) (*agentmodel.Agent, error) {
+	args := m.Called(ctx, instanceUID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	agent, ok := args.Get(0).(*agentmodel.Agent)
+	if !ok {
+		return nil, errMock
+	}
+
+	return agent, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentUsecase) GetOrCreateAgent(ctx context.Context, instanceUID uuid.UUID) (*agentmodel.Agent, error) {
+	args := m.Called(ctx, instanceUID)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	agent, ok := args.Get(0).(*agentmodel.Agent)
+	if !ok {
+		return nil, errMock
+	}
+
+	return agent, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentUsecase) ListAgentsBySelector(
+	ctx context.Context, selector agentmodel.AgentSelector, options *model.ListOptions,
+) (*model.ListResponse[*agentmodel.Agent], error) {
+	args := m.Called(ctx, selector, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	resp, ok := args.Get(0).(*model.ListResponse[*agentmodel.Agent])
+	if !ok {
+		return nil, errMock
+	}
+
+	return resp, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentUsecase) SaveAgent(ctx context.Context, agent *agentmodel.Agent) error {
+	args := m.Called(ctx, agent)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentUsecase) DeleteAgent(ctx context.Context, instanceUID uuid.UUID) error {
+	args := m.Called(ctx, instanceUID)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentUsecase) ListAgents(
+	ctx context.Context, namespace string, options *model.ListOptions,
+) (*model.ListResponse[*agentmodel.Agent], error) {
+	args := m.Called(ctx, namespace, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	resp, ok := args.Get(0).(*model.ListResponse[*agentmodel.Agent])
+	if !ok {
+		return nil, errMock
+	}
+
+	return resp, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockAgentUsecase) SearchAgents(
+	ctx context.Context, namespace string, query string, options *model.ListOptions,
+) (*model.ListResponse[*agentmodel.Agent], error) {
+	args := m.Called(ctx, namespace, query, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	resp, ok := args.Get(0).(*model.ListResponse[*agentmodel.Agent])
+	if !ok {
+		return nil, errMock
+	}
+
+	return resp, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func newSvc(t *testing.T, host *mockHostUsecase, agent *mockAgentUsecase) *hostsvc.Service {
+	t.Helper()
+
+	base := testutil.NewBase(t)
+
+	return hostsvc.New(host, agent, base.Logger)
+}
+
+func newHost(id string, agentUIDs ...uuid.UUID) *agentmodel.Host {
+	return &agentmodel.Host{
+		Metadata: agentmodel.HostMetadata{
+			ID:          id,
+			Name:        "host-" + id,
+			FirstSeenAt: time.Now(),
+			LastSeenAt:  time.Now(),
+		},
+		Status: agentmodel.HostStatus{
+			AgentInstanceUIDs: agentUIDs,
+		},
+	}
+}
+
+func TestService_GetHost(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockHost := new(mockHostUsecase)
+		svc := newSvc(t, mockHost, new(mockAgentUsecase))
+
+		mockHost.On("GetHost", ctx, "host-1").Return(newHost("host-1"), nil)
+
+		result, err := svc.GetHost(ctx, "host-1")
+
+		require.NoError(t, err)
+		assert.Equal(t, v1.HostKind, result.Kind)
+		assert.Equal(t, "host-1", result.Metadata.ID)
+		mockHost.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockHost := new(mockHostUsecase)
+		svc := newSvc(t, mockHost, new(mockAgentUsecase))
+
+		mockHost.On("GetHost", ctx, "missing").Return(nil, errMock)
+
+		result, err := svc.GetHost(ctx, "missing")
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "failed to get host")
+		mockHost.AssertExpectations(t)
+	})
+}
+
+func TestService_ListHosts(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockHost := new(mockHostUsecase)
+		svc := newSvc(t, mockHost, new(mockAgentUsecase))
+
+		opts := &applicationport.ListOptions{Limit: 10}
+		resp := &model.ListResponse[*agentmodel.Host]{
+			Items:    []*agentmodel.Host{newHost("host-1"), newHost("host-2")},
+			Continue: "next",
+		}
+		mockHost.On("ListHosts", ctx, opts.ToDomain()).Return(resp, nil)
+
+		result, err := svc.ListHosts(ctx, opts)
+
+		require.NoError(t, err)
+		assert.Equal(t, v1.HostKind, result.Kind)
+		assert.Len(t, result.Items, 2)
+		assert.Equal(t, "next", result.Metadata.Continue)
+		mockHost.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockHost := new(mockHostUsecase)
+		svc := newSvc(t, mockHost, new(mockAgentUsecase))
+
+		opts := &applicationport.ListOptions{Limit: 10}
+		mockHost.On("ListHosts", ctx, opts.ToDomain()).Return(nil, errMock)
+
+		result, err := svc.ListHosts(ctx, opts)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "failed to list hosts")
+		mockHost.AssertExpectations(t)
+	})
+}
+
+func TestService_ListAgentsByHost(t *testing.T) {
+	t.Parallel()
+
+	t.Run("host with no agents returns empty list", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockHost := new(mockHostUsecase)
+		mockAgent := new(mockAgentUsecase)
+		svc := newSvc(t, mockHost, mockAgent)
+
+		mockHost.On("GetHost", ctx, "host-1").Return(newHost("host-1"), nil)
+
+		result, err := svc.ListAgentsByHost(ctx, "host-1", &applicationport.ListOptions{Limit: 10})
+
+		require.NoError(t, err)
+		assert.Equal(t, v1.AgentKind, result.Kind)
+		assert.Empty(t, result.Items)
+		// No agent lookups should happen when the host has no associated agents.
+		mockAgent.AssertNotCalled(t, "GetAgent", mock.Anything, mock.Anything)
+		mockHost.AssertExpectations(t)
+	})
+
+	t.Run("host lookup error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockHost := new(mockHostUsecase)
+		svc := newSvc(t, mockHost, new(mockAgentUsecase))
+
+		mockHost.On("GetHost", ctx, "missing").Return(nil, errMock)
+
+		result, err := svc.ListAgentsByHost(ctx, "missing", &applicationport.ListOptions{Limit: 10})
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "failed to get host")
+		mockHost.AssertExpectations(t)
+	})
+}

--- a/pkg/apiserver/application/service/namespace/namespace_manage_service_test.go
+++ b/pkg/apiserver/application/service/namespace/namespace_manage_service_test.go
@@ -118,11 +118,11 @@ func newSvc(t *testing.T, ns *mockNamespaceUsecase) *namespacesvc.Service {
 	return namespacesvc.NewNamespaceService(ns, base.Logger)
 }
 
-func apiNamespace(name string) *v1.Namespace {
+func apiNamespace() *v1.Namespace {
 	return &v1.Namespace{
 		Kind:       v1.NamespaceKind,
 		APIVersion: v1.APIVersion,
-		Metadata:   v1.NamespaceMetadata{Name: name},
+		Metadata:   v1.NamespaceMetadata{Name: "production"},
 	}
 }
 
@@ -225,7 +225,7 @@ func TestService_CreateNamespace(t *testing.T) {
 			return ns.Metadata.Name == "production"
 		}), mock.AnythingOfType("string")).Return(agentmodel.NewNamespace("production"), nil)
 
-		result, err := svc.CreateNamespace(ctx, apiNamespace("production"))
+		result, err := svc.CreateNamespace(ctx, apiNamespace())
 
 		require.NoError(t, err)
 		assert.Equal(t, "production", result.Metadata.Name)
@@ -242,7 +242,7 @@ func TestService_CreateNamespace(t *testing.T) {
 		mockNS.On("CreateNamespace", ctx, mock.Anything, mock.AnythingOfType("string")).
 			Return(nil, errMock)
 
-		result, err := svc.CreateNamespace(ctx, apiNamespace("production"))
+		result, err := svc.CreateNamespace(ctx, apiNamespace())
 
 		require.Error(t, err)
 		assert.Nil(t, result)
@@ -264,7 +264,7 @@ func TestService_UpdateNamespace(t *testing.T) {
 		mockNS.On("UpdateNamespace", ctx, "production", mock.Anything).
 			Return(agentmodel.NewNamespace("production"), nil)
 
-		result, err := svc.UpdateNamespace(ctx, "production", apiNamespace("production"))
+		result, err := svc.UpdateNamespace(ctx, "production", apiNamespace())
 
 		require.NoError(t, err)
 		assert.Equal(t, "production", result.Metadata.Name)
@@ -280,7 +280,7 @@ func TestService_UpdateNamespace(t *testing.T) {
 
 		mockNS.On("UpdateNamespace", ctx, "production", mock.Anything).Return(nil, errMock)
 
-		result, err := svc.UpdateNamespace(ctx, "production", apiNamespace("production"))
+		result, err := svc.UpdateNamespace(ctx, "production", apiNamespace())
 
 		require.Error(t, err)
 		assert.Nil(t, result)

--- a/pkg/apiserver/application/service/namespace/namespace_manage_service_test.go
+++ b/pkg/apiserver/application/service/namespace/namespace_manage_service_test.go
@@ -1,0 +1,325 @@
+package namespace_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/minuk-dev/opampcommander/api/v1"
+	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
+	namespacesvc "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/namespace"
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	"github.com/minuk-dev/opampcommander/pkg/testutil"
+)
+
+var errMock = errors.New("mock error")
+
+// mockNamespaceUsecase is a mock implementation of agentport.NamespaceUsecase.
+type mockNamespaceUsecase struct {
+	mock.Mock
+}
+
+func (m *mockNamespaceUsecase) GetNamespace(
+	ctx context.Context, name string, options *model.GetOptions,
+) (*agentmodel.Namespace, error) {
+	args := m.Called(ctx, name, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	ns, ok := args.Get(0).(*agentmodel.Namespace)
+	if !ok {
+		return nil, errMock
+	}
+
+	return ns, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockNamespaceUsecase) ListNamespaces(
+	ctx context.Context, options *model.ListOptions,
+) (*model.ListResponse[*agentmodel.Namespace], error) {
+	args := m.Called(ctx, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	resp, ok := args.Get(0).(*model.ListResponse[*agentmodel.Namespace])
+	if !ok {
+		return nil, errMock
+	}
+
+	return resp, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockNamespaceUsecase) SaveNamespace(
+	ctx context.Context, namespace *agentmodel.Namespace,
+) (*agentmodel.Namespace, error) {
+	args := m.Called(ctx, namespace)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	ns, ok := args.Get(0).(*agentmodel.Namespace)
+	if !ok {
+		return nil, errMock
+	}
+
+	return ns, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockNamespaceUsecase) CreateNamespace(
+	ctx context.Context, namespace *agentmodel.Namespace, actor string,
+) (*agentmodel.Namespace, error) {
+	args := m.Called(ctx, namespace, actor)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	ns, ok := args.Get(0).(*agentmodel.Namespace)
+	if !ok {
+		return nil, errMock
+	}
+
+	return ns, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockNamespaceUsecase) UpdateNamespace(
+	ctx context.Context, name string, namespace *agentmodel.Namespace,
+) (*agentmodel.Namespace, error) {
+	args := m.Called(ctx, name, namespace)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	ns, ok := args.Get(0).(*agentmodel.Namespace)
+	if !ok {
+		return nil, errMock
+	}
+
+	return ns, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockNamespaceUsecase) DeleteNamespace(ctx context.Context, name string, actor string) error {
+	args := m.Called(ctx, name, actor)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+func newSvc(t *testing.T, ns *mockNamespaceUsecase) *namespacesvc.Service {
+	t.Helper()
+
+	base := testutil.NewBase(t)
+
+	return namespacesvc.NewNamespaceService(ns, base.Logger)
+}
+
+func apiNamespace(name string) *v1.Namespace {
+	return &v1.Namespace{
+		Kind:       v1.NamespaceKind,
+		APIVersion: v1.APIVersion,
+		Metadata:   v1.NamespaceMetadata{Name: name},
+	}
+}
+
+func TestService_GetNamespace(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockNS := new(mockNamespaceUsecase)
+		svc := newSvc(t, mockNS)
+
+		mockNS.On("GetNamespace", ctx, "production", (*model.GetOptions)(nil)).
+			Return(agentmodel.NewNamespace("production"), nil)
+
+		result, err := svc.GetNamespace(ctx, "production", nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, v1.NamespaceKind, result.Kind)
+		assert.Equal(t, "production", result.Metadata.Name)
+		mockNS.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockNS := new(mockNamespaceUsecase)
+		svc := newSvc(t, mockNS)
+
+		mockNS.On("GetNamespace", ctx, "missing", (*model.GetOptions)(nil)).Return(nil, errMock)
+
+		result, err := svc.GetNamespace(ctx, "missing", nil)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "get namespace")
+		mockNS.AssertExpectations(t)
+	})
+}
+
+func TestService_ListNamespaces(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockNS := new(mockNamespaceUsecase)
+		svc := newSvc(t, mockNS)
+
+		opts := &applicationport.ListOptions{Limit: 10}
+		resp := &model.ListResponse[*agentmodel.Namespace]{
+			Items:    []*agentmodel.Namespace{agentmodel.NewNamespace("default"), agentmodel.NewNamespace("prod")},
+			Continue: "next",
+		}
+		mockNS.On("ListNamespaces", ctx, opts.ToDomain()).Return(resp, nil)
+
+		result, err := svc.ListNamespaces(ctx, opts)
+
+		require.NoError(t, err)
+		assert.Equal(t, v1.NamespaceKind, result.Kind)
+		assert.Len(t, result.Items, 2)
+		assert.Equal(t, "next", result.Metadata.Continue)
+		mockNS.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockNS := new(mockNamespaceUsecase)
+		svc := newSvc(t, mockNS)
+
+		opts := &applicationport.ListOptions{Limit: 10}
+		mockNS.On("ListNamespaces", ctx, opts.ToDomain()).Return(nil, errMock)
+
+		result, err := svc.ListNamespaces(ctx, opts)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "list namespaces")
+		mockNS.AssertExpectations(t)
+	})
+}
+
+func TestService_CreateNamespace(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockNS := new(mockNamespaceUsecase)
+		svc := newSvc(t, mockNS)
+
+		// actor resolves to the anonymous user when no user is present in the context.
+		mockNS.On("CreateNamespace", ctx, mock.MatchedBy(func(ns *agentmodel.Namespace) bool {
+			return ns.Metadata.Name == "production"
+		}), mock.AnythingOfType("string")).Return(agentmodel.NewNamespace("production"), nil)
+
+		result, err := svc.CreateNamespace(ctx, apiNamespace("production"))
+
+		require.NoError(t, err)
+		assert.Equal(t, "production", result.Metadata.Name)
+		mockNS.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockNS := new(mockNamespaceUsecase)
+		svc := newSvc(t, mockNS)
+
+		mockNS.On("CreateNamespace", ctx, mock.Anything, mock.AnythingOfType("string")).
+			Return(nil, errMock)
+
+		result, err := svc.CreateNamespace(ctx, apiNamespace("production"))
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "create namespace")
+		mockNS.AssertExpectations(t)
+	})
+}
+
+func TestService_UpdateNamespace(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockNS := new(mockNamespaceUsecase)
+		svc := newSvc(t, mockNS)
+
+		mockNS.On("UpdateNamespace", ctx, "production", mock.Anything).
+			Return(agentmodel.NewNamespace("production"), nil)
+
+		result, err := svc.UpdateNamespace(ctx, "production", apiNamespace("production"))
+
+		require.NoError(t, err)
+		assert.Equal(t, "production", result.Metadata.Name)
+		mockNS.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockNS := new(mockNamespaceUsecase)
+		svc := newSvc(t, mockNS)
+
+		mockNS.On("UpdateNamespace", ctx, "production", mock.Anything).Return(nil, errMock)
+
+		result, err := svc.UpdateNamespace(ctx, "production", apiNamespace("production"))
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "update namespace")
+		mockNS.AssertExpectations(t)
+	})
+}
+
+func TestService_DeleteNamespace(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockNS := new(mockNamespaceUsecase)
+		svc := newSvc(t, mockNS)
+
+		mockNS.On("DeleteNamespace", ctx, "production", mock.AnythingOfType("string")).Return(nil)
+
+		err := svc.DeleteNamespace(ctx, "production")
+
+		require.NoError(t, err)
+		mockNS.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockNS := new(mockNamespaceUsecase)
+		svc := newSvc(t, mockNS)
+
+		mockNS.On("DeleteNamespace", ctx, "production", mock.AnythingOfType("string")).Return(errMock)
+
+		err := svc.DeleteNamespace(ctx, "production")
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "delete namespace")
+		mockNS.AssertExpectations(t)
+	})
+}

--- a/pkg/apiserver/application/service/reconcile/reconcile_test.go
+++ b/pkg/apiserver/application/service/reconcile/reconcile_test.go
@@ -1,0 +1,98 @@
+package reconcile_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	reconcilesvc "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/reconcile"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	domainreconcile "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/reconcile"
+)
+
+var errReconcile = errors.New("reconcile failed")
+
+// fakeReconciler is a domainreconcile.Reconciler whose Reconcile returns reconcileErr,
+// recording the last namespace/name it was called with.
+type fakeReconciler struct {
+	kind          string
+	reconcileErr  error
+	lastNamespace string
+	lastName      string
+}
+
+func (f *fakeReconciler) Kind() string { return f.kind }
+
+func (f *fakeReconciler) Reconcile(_ context.Context, namespace, name string) error {
+	f.lastNamespace = namespace
+	f.lastName = name
+
+	return f.reconcileErr
+}
+
+func newSvc(t *testing.T, reconcilers ...domainreconcile.Reconciler) *reconcilesvc.Service {
+	t.Helper()
+
+	registry, err := domainreconcile.NewService(reconcilers)
+	require.NoError(t, err)
+
+	return reconcilesvc.New(registry)
+}
+
+func TestService_Reconcile(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success delegates to the matching reconciler", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		rec := &fakeReconciler{kind: "AgentGroup"}
+		svc := newSvc(t, rec)
+
+		err := svc.Reconcile(ctx, "AgentGroup", "default", "group-1")
+
+		require.NoError(t, err)
+		assert.Equal(t, "default", rec.lastNamespace)
+		assert.Equal(t, "group-1", rec.lastName)
+	})
+
+	t.Run("unknown kind maps to ErrInvalidArgument", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		svc := newSvc(t, &fakeReconciler{kind: "AgentGroup"})
+
+		err := svc.Reconcile(ctx, "Nonexistent", "default", "x")
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, model.ErrInvalidArgument)
+		assert.ErrorIs(t, err, domainreconcile.ErrUnknownKind)
+	})
+
+	t.Run("reconciler error is wrapped", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		svc := newSvc(t, &fakeReconciler{kind: "AgentGroup", reconcileErr: errReconcile})
+
+		err := svc.Reconcile(ctx, "AgentGroup", "default", "group-1")
+
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errReconcile)
+		assert.NotErrorIs(t, err, model.ErrInvalidArgument)
+	})
+}
+
+func TestService_ReconcileKinds(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	svc := newSvc(t, &fakeReconciler{kind: "AgentGroup"}, &fakeReconciler{kind: "AgentRemoteConfig"})
+
+	kinds := svc.ReconcileKinds(ctx)
+
+	assert.Equal(t, []string{"AgentGroup", "AgentRemoteConfig"}, kinds)
+}

--- a/pkg/apiserver/application/service/reconcile/reconcile_test.go
+++ b/pkg/apiserver/application/service/reconcile/reconcile_test.go
@@ -68,8 +68,8 @@ func TestService_Reconcile(t *testing.T) {
 		err := svc.Reconcile(ctx, "Nonexistent", "default", "x")
 
 		require.Error(t, err)
-		assert.ErrorIs(t, err, model.ErrInvalidArgument)
-		assert.ErrorIs(t, err, domainreconcile.ErrUnknownKind)
+		require.ErrorIs(t, err, model.ErrInvalidArgument)
+		require.ErrorIs(t, err, domainreconcile.ErrUnknownKind)
 	})
 
 	t.Run("reconciler error is wrapped", func(t *testing.T) {
@@ -81,8 +81,8 @@ func TestService_Reconcile(t *testing.T) {
 		err := svc.Reconcile(ctx, "AgentGroup", "default", "group-1")
 
 		require.Error(t, err)
-		assert.ErrorIs(t, err, errReconcile)
-		assert.NotErrorIs(t, err, model.ErrInvalidArgument)
+		require.ErrorIs(t, err, errReconcile)
+		require.NotErrorIs(t, err, model.ErrInvalidArgument)
 	})
 }
 

--- a/pkg/apiserver/application/service/role/service_test.go
+++ b/pkg/apiserver/application/service/role/service_test.go
@@ -121,18 +121,18 @@ func newSvc(t *testing.T, role *mockRoleUsecase) *rolesvc.Service {
 	return rolesvc.New(role, base.Logger)
 }
 
-func newRole(displayName string) *usermodel.Role {
-	role := usermodel.NewRole(displayName, false)
+func newRole() *usermodel.Role {
+	role := usermodel.NewRole("Viewer", false)
 	role.Spec.Permissions = []string{"agent:read"}
 
 	return role
 }
 
-func apiRole(displayName string) *v1.Role {
+func apiRole() *v1.Role {
 	return &v1.Role{
 		Kind:       v1.RoleKind,
 		APIVersion: v1.APIVersion,
-		Spec:       v1.RoleSpec{DisplayName: displayName, Permissions: []string{"agent:read"}},
+		Spec:       v1.RoleSpec{DisplayName: "Viewer", Permissions: []string{"agent:read"}},
 	}
 }
 
@@ -147,7 +147,7 @@ func TestService_GetRole(t *testing.T) {
 		svc := newSvc(t, mockRole)
 
 		uid := uuid.New()
-		mockRole.On("GetRole", ctx, uid, (*model.GetOptions)(nil)).Return(newRole("Viewer"), nil)
+		mockRole.On("GetRole", ctx, uid, (*model.GetOptions)(nil)).Return(newRole(), nil)
 
 		result, err := svc.GetRole(ctx, uid, nil)
 
@@ -188,7 +188,7 @@ func TestService_ListRoles(t *testing.T) {
 
 		opts := &applicationport.ListOptions{Limit: 10}
 		resp := &model.ListResponse[*usermodel.Role]{
-			Items:    []*usermodel.Role{newRole("Viewer")},
+			Items:    []*usermodel.Role{newRole()},
 			Continue: "next",
 		}
 		mockRole.On("ListRoles", ctx, opts.ToDomain()).Return(resp, nil)
@@ -233,9 +233,9 @@ func TestService_CreateRole(t *testing.T) {
 
 		mockRole.On("CreateRole", ctx, mock.MatchedBy(func(r *usermodel.Role) bool {
 			return r.Spec.DisplayName == "Viewer" && len(r.Spec.Permissions) == 1
-		})).Return(newRole("Viewer"), nil)
+		})).Return(newRole(), nil)
 
-		result, err := svc.CreateRole(ctx, apiRole("Viewer"))
+		result, err := svc.CreateRole(ctx, apiRole())
 
 		require.NoError(t, err)
 		assert.Equal(t, "Viewer", result.Spec.DisplayName)
@@ -251,7 +251,7 @@ func TestService_CreateRole(t *testing.T) {
 
 		mockRole.On("CreateRole", ctx, mock.Anything).Return(nil, errMock)
 
-		result, err := svc.CreateRole(ctx, apiRole("Viewer"))
+		result, err := svc.CreateRole(ctx, apiRole())
 
 		require.Error(t, err)
 		assert.Nil(t, result)
@@ -271,9 +271,9 @@ func TestService_UpdateRole(t *testing.T) {
 		svc := newSvc(t, mockRole)
 
 		uid := uuid.New()
-		mockRole.On("UpdateRole", ctx, uid, mock.Anything).Return(newRole("Viewer"), nil)
+		mockRole.On("UpdateRole", ctx, uid, mock.Anything).Return(newRole(), nil)
 
-		result, err := svc.UpdateRole(ctx, uid, apiRole("Viewer"))
+		result, err := svc.UpdateRole(ctx, uid, apiRole())
 
 		require.NoError(t, err)
 		assert.Equal(t, "Viewer", result.Spec.DisplayName)
@@ -290,7 +290,7 @@ func TestService_UpdateRole(t *testing.T) {
 		uid := uuid.New()
 		mockRole.On("UpdateRole", ctx, uid, mock.Anything).Return(nil, errMock)
 
-		result, err := svc.UpdateRole(ctx, uid, apiRole("Viewer"))
+		result, err := svc.UpdateRole(ctx, uid, apiRole())
 
 		require.Error(t, err)
 		assert.Nil(t, result)

--- a/pkg/apiserver/application/service/role/service_test.go
+++ b/pkg/apiserver/application/service/role/service_test.go
@@ -1,0 +1,337 @@
+package role_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/minuk-dev/opampcommander/api/v1"
+	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
+	rolesvc "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/role"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	usermodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user"
+	"github.com/minuk-dev/opampcommander/pkg/testutil"
+)
+
+var errMock = errors.New("mock error")
+
+// mockRoleUsecase is a mock implementation of userport.RoleUsecase.
+type mockRoleUsecase struct {
+	mock.Mock
+}
+
+func (m *mockRoleUsecase) GetRole(
+	ctx context.Context, uid uuid.UUID, options *model.GetOptions,
+) (*usermodel.Role, error) {
+	args := m.Called(ctx, uid, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	role, ok := args.Get(0).(*usermodel.Role)
+	if !ok {
+		return nil, errMock
+	}
+
+	return role, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockRoleUsecase) GetRoleByName(ctx context.Context, displayName string) (*usermodel.Role, error) {
+	args := m.Called(ctx, displayName)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	role, ok := args.Get(0).(*usermodel.Role)
+	if !ok {
+		return nil, errMock
+	}
+
+	return role, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockRoleUsecase) ListRoles(
+	ctx context.Context, options *model.ListOptions,
+) (*model.ListResponse[*usermodel.Role], error) {
+	args := m.Called(ctx, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	resp, ok := args.Get(0).(*model.ListResponse[*usermodel.Role])
+	if !ok {
+		return nil, errMock
+	}
+
+	return resp, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockRoleUsecase) SaveRole(ctx context.Context, role *usermodel.Role) error {
+	args := m.Called(ctx, role)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+func (m *mockRoleUsecase) CreateRole(ctx context.Context, role *usermodel.Role) (*usermodel.Role, error) {
+	args := m.Called(ctx, role)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	r, ok := args.Get(0).(*usermodel.Role)
+	if !ok {
+		return nil, errMock
+	}
+
+	return r, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockRoleUsecase) UpdateRole(
+	ctx context.Context, uid uuid.UUID, role *usermodel.Role,
+) (*usermodel.Role, error) {
+	args := m.Called(ctx, uid, role)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	r, ok := args.Get(0).(*usermodel.Role)
+	if !ok {
+		return nil, errMock
+	}
+
+	return r, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockRoleUsecase) DeleteRole(ctx context.Context, uid uuid.UUID) error {
+	args := m.Called(ctx, uid)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+func newSvc(t *testing.T, role *mockRoleUsecase) *rolesvc.Service {
+	t.Helper()
+
+	base := testutil.NewBase(t)
+
+	return rolesvc.New(role, base.Logger)
+}
+
+func newRole(displayName string) *usermodel.Role {
+	role := usermodel.NewRole(displayName, false)
+	role.Spec.Permissions = []string{"agent:read"}
+
+	return role
+}
+
+func apiRole(displayName string) *v1.Role {
+	return &v1.Role{
+		Kind:       v1.RoleKind,
+		APIVersion: v1.APIVersion,
+		Spec:       v1.RoleSpec{DisplayName: displayName, Permissions: []string{"agent:read"}},
+	}
+}
+
+func TestService_GetRole(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockRole := new(mockRoleUsecase)
+		svc := newSvc(t, mockRole)
+
+		uid := uuid.New()
+		mockRole.On("GetRole", ctx, uid, (*model.GetOptions)(nil)).Return(newRole("Viewer"), nil)
+
+		result, err := svc.GetRole(ctx, uid, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, v1.RoleKind, result.Kind)
+		assert.Equal(t, "Viewer", result.Spec.DisplayName)
+		mockRole.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockRole := new(mockRoleUsecase)
+		svc := newSvc(t, mockRole)
+
+		uid := uuid.New()
+		mockRole.On("GetRole", ctx, uid, (*model.GetOptions)(nil)).Return(nil, errMock)
+
+		result, err := svc.GetRole(ctx, uid, nil)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "failed to get role")
+		mockRole.AssertExpectations(t)
+	})
+}
+
+func TestService_ListRoles(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockRole := new(mockRoleUsecase)
+		svc := newSvc(t, mockRole)
+
+		opts := &applicationport.ListOptions{Limit: 10}
+		resp := &model.ListResponse[*usermodel.Role]{
+			Items:    []*usermodel.Role{newRole("Viewer")},
+			Continue: "next",
+		}
+		mockRole.On("ListRoles", ctx, opts.ToDomain()).Return(resp, nil)
+
+		result, err := svc.ListRoles(ctx, opts)
+
+		require.NoError(t, err)
+		assert.Equal(t, v1.RoleKind, result.Kind)
+		assert.Len(t, result.Items, 1)
+		assert.Equal(t, "next", result.Metadata.Continue)
+		mockRole.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockRole := new(mockRoleUsecase)
+		svc := newSvc(t, mockRole)
+
+		opts := &applicationport.ListOptions{Limit: 10}
+		mockRole.On("ListRoles", ctx, opts.ToDomain()).Return(nil, errMock)
+
+		result, err := svc.ListRoles(ctx, opts)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "failed to list roles")
+		mockRole.AssertExpectations(t)
+	})
+}
+
+func TestService_CreateRole(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockRole := new(mockRoleUsecase)
+		svc := newSvc(t, mockRole)
+
+		mockRole.On("CreateRole", ctx, mock.MatchedBy(func(r *usermodel.Role) bool {
+			return r.Spec.DisplayName == "Viewer" && len(r.Spec.Permissions) == 1
+		})).Return(newRole("Viewer"), nil)
+
+		result, err := svc.CreateRole(ctx, apiRole("Viewer"))
+
+		require.NoError(t, err)
+		assert.Equal(t, "Viewer", result.Spec.DisplayName)
+		mockRole.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockRole := new(mockRoleUsecase)
+		svc := newSvc(t, mockRole)
+
+		mockRole.On("CreateRole", ctx, mock.Anything).Return(nil, errMock)
+
+		result, err := svc.CreateRole(ctx, apiRole("Viewer"))
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "failed to create role")
+		mockRole.AssertExpectations(t)
+	})
+}
+
+func TestService_UpdateRole(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockRole := new(mockRoleUsecase)
+		svc := newSvc(t, mockRole)
+
+		uid := uuid.New()
+		mockRole.On("UpdateRole", ctx, uid, mock.Anything).Return(newRole("Viewer"), nil)
+
+		result, err := svc.UpdateRole(ctx, uid, apiRole("Viewer"))
+
+		require.NoError(t, err)
+		assert.Equal(t, "Viewer", result.Spec.DisplayName)
+		mockRole.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockRole := new(mockRoleUsecase)
+		svc := newSvc(t, mockRole)
+
+		uid := uuid.New()
+		mockRole.On("UpdateRole", ctx, uid, mock.Anything).Return(nil, errMock)
+
+		result, err := svc.UpdateRole(ctx, uid, apiRole("Viewer"))
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "failed to update role")
+		mockRole.AssertExpectations(t)
+	})
+}
+
+func TestService_DeleteRole(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockRole := new(mockRoleUsecase)
+		svc := newSvc(t, mockRole)
+
+		uid := uuid.New()
+		mockRole.On("DeleteRole", ctx, uid).Return(nil)
+
+		err := svc.DeleteRole(ctx, uid)
+
+		require.NoError(t, err)
+		mockRole.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockRole := new(mockRoleUsecase)
+		svc := newSvc(t, mockRole)
+
+		uid := uuid.New()
+		mockRole.On("DeleteRole", ctx, uid).Return(errMock)
+
+		err := svc.DeleteRole(ctx, uid)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to delete role")
+		mockRole.AssertExpectations(t)
+	})
+}

--- a/pkg/apiserver/application/service/server/server_test.go
+++ b/pkg/apiserver/application/service/server/server_test.go
@@ -1,0 +1,153 @@
+package server_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/minuk-dev/opampcommander/api/v1"
+	serversvc "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/server"
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/serverevent"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	"github.com/minuk-dev/opampcommander/pkg/testutil"
+)
+
+var errMock = errors.New("mock error")
+
+// mockServerUsecase is a mock implementation of agentport.ServerUsecase.
+type mockServerUsecase struct {
+	mock.Mock
+}
+
+func (m *mockServerUsecase) GetServer(ctx context.Context, id string) (*agentmodel.Server, error) {
+	args := m.Called(ctx, id)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	srv, ok := args.Get(0).(*agentmodel.Server)
+	if !ok {
+		return nil, errMock
+	}
+
+	return srv, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockServerUsecase) ListServers(ctx context.Context) ([]*agentmodel.Server, error) {
+	args := m.Called(ctx)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	servers, ok := args.Get(0).([]*agentmodel.Server)
+	if !ok {
+		return nil, errMock
+	}
+
+	return servers, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockServerUsecase) SendMessageToServerByServerID(
+	ctx context.Context, serverID string, message serverevent.Message,
+) error {
+	args := m.Called(ctx, serverID, message)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+func (m *mockServerUsecase) SendMessageToServer(
+	ctx context.Context, server *agentmodel.Server, message serverevent.Message,
+) error {
+	args := m.Called(ctx, server, message)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+func newSvc(t *testing.T, srv *mockServerUsecase) *serversvc.Service {
+	t.Helper()
+
+	base := testutil.NewBase(t)
+
+	return serversvc.New(srv, base.Logger)
+}
+
+func TestService_ListServers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockUsecase := new(mockServerUsecase)
+		svc := newSvc(t, mockUsecase)
+
+		heartbeat := time.Now()
+		servers := []*agentmodel.Server{
+			{
+				ID:              "server-a",
+				LastHeartbeatAt: heartbeat,
+				Conditions: []model.Condition{
+					{
+						Type:    "Ready",
+						Status:  "True",
+						Reason:  "Healthy",
+						Message: "all good",
+					},
+				},
+			},
+		}
+		mockUsecase.On("ListServers", ctx).Return(servers, nil)
+
+		result, err := svc.ListServers(ctx)
+
+		require.NoError(t, err)
+		assert.Equal(t, v1.ServerKind, result.Kind)
+		require.Len(t, result.Items, 1)
+		assert.Equal(t, "server-a", result.Items[0].ID)
+		require.Len(t, result.Items[0].Conditions, 1)
+		assert.Equal(t, v1.ServerConditionType("Ready"), result.Items[0].Conditions[0].Type)
+		assert.Equal(t, v1.ServerConditionStatus("True"), result.Items[0].Conditions[0].Status)
+		mockUsecase.AssertExpectations(t)
+	})
+
+	t.Run("maps empty conditions to nil", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockUsecase := new(mockServerUsecase)
+		svc := newSvc(t, mockUsecase)
+
+		servers := []*agentmodel.Server{{ID: "server-b", LastHeartbeatAt: time.Now()}}
+		mockUsecase.On("ListServers", ctx).Return(servers, nil)
+
+		result, err := svc.ListServers(ctx)
+
+		require.NoError(t, err)
+		require.Len(t, result.Items, 1)
+		assert.Nil(t, result.Items[0].Conditions)
+		mockUsecase.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockUsecase := new(mockServerUsecase)
+		svc := newSvc(t, mockUsecase)
+
+		mockUsecase.On("ListServers", ctx).Return(nil, errMock)
+
+		result, err := svc.ListServers(ctx)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "failed to list servers")
+		mockUsecase.AssertExpectations(t)
+	})
+}

--- a/pkg/apiserver/application/service/user/service_test.go
+++ b/pkg/apiserver/application/service/user/service_test.go
@@ -264,6 +264,7 @@ func TestService_CreateUser(t *testing.T) {
 			APIVersion: v1.APIVersion,
 			Spec:       v1.UserSpec{Email: "a@example.com", Username: "alice"},
 		}
+
 		mockUser.On("SaveUser", ctx, mock.MatchedBy(func(u *usermodel.User) bool {
 			return u.Spec.Email == "a@example.com"
 		})).Return(nil)
@@ -283,6 +284,7 @@ func TestService_CreateUser(t *testing.T) {
 		svc := newSvc(t, mockUser)
 
 		apiUser := &v1.User{Spec: v1.UserSpec{Email: "a@example.com", Username: "alice"}}
+
 		mockUser.On("SaveUser", ctx, mock.Anything).Return(errMock)
 
 		result, err := svc.CreateUser(ctx, apiUser)

--- a/pkg/apiserver/application/service/user/service_test.go
+++ b/pkg/apiserver/application/service/user/service_test.go
@@ -1,0 +1,332 @@
+package user_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+
+	v1 "github.com/minuk-dev/opampcommander/api/v1"
+	applicationport "github.com/minuk-dev/opampcommander/pkg/apiserver/application/port"
+	usersvc "github.com/minuk-dev/opampcommander/pkg/apiserver/application/service/user"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	usermodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user"
+	"github.com/minuk-dev/opampcommander/pkg/testutil"
+)
+
+var errMock = errors.New("mock error")
+
+// mockUserUsecase is a mock implementation of userport.UserUsecase.
+type mockUserUsecase struct {
+	mock.Mock
+}
+
+func (m *mockUserUsecase) GetUser(
+	ctx context.Context, uid uuid.UUID, options *model.GetOptions,
+) (*usermodel.User, error) {
+	args := m.Called(ctx, uid, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	user, _ := args.Get(0).(*usermodel.User)
+
+	return user, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockUserUsecase) GetUserByEmail(ctx context.Context, email string) (*usermodel.User, error) {
+	args := m.Called(ctx, email)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	user, _ := args.Get(0).(*usermodel.User)
+
+	return user, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockUserUsecase) GetUserByEmailIncludingDeleted(
+	ctx context.Context, email string,
+) (*usermodel.User, error) {
+	args := m.Called(ctx, email)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	user, _ := args.Get(0).(*usermodel.User)
+
+	return user, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockUserUsecase) GetUserByUsername(ctx context.Context, username string) (*usermodel.User, error) {
+	args := m.Called(ctx, username)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	user, _ := args.Get(0).(*usermodel.User)
+
+	return user, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockUserUsecase) ListUsers(
+	ctx context.Context, options *model.ListOptions,
+) (*model.ListResponse[*usermodel.User], error) {
+	args := m.Called(ctx, options)
+	if args.Get(0) == nil {
+		return nil, args.Error(1) //nolint:wrapcheck // mock error
+	}
+
+	resp, _ := args.Get(0).(*model.ListResponse[*usermodel.User])
+
+	return resp, args.Error(1) //nolint:wrapcheck // mock error
+}
+
+func (m *mockUserUsecase) SaveUser(ctx context.Context, user *usermodel.User) error {
+	args := m.Called(ctx, user)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+func (m *mockUserUsecase) DeleteUser(ctx context.Context, uid uuid.UUID) error {
+	args := m.Called(ctx, uid)
+
+	return args.Error(0) //nolint:wrapcheck // mock error
+}
+
+// stubRBACUsecase is a no-op userport.RBACUsecase.
+type stubRBACUsecase struct{}
+
+func (*stubRBACUsecase) SyncPolicies(context.Context) error { return nil }
+
+func (*stubRBACUsecase) CheckPermission(context.Context, uuid.UUID, string, string, string) (bool, error) {
+	return true, nil
+}
+
+func (*stubRBACUsecase) GetUserPermissions(context.Context, uuid.UUID) ([]*usermodel.Permission, error) {
+	return nil, nil
+}
+
+func (*stubRBACUsecase) GetEffectivePermissions(context.Context, uuid.UUID) ([]*usermodel.Permission, error) {
+	return nil, nil
+}
+
+// newSvc builds the user service. roleUsecase, roleBindingPersistencePort, rbacEnforcerPort and
+// passwordHasher are unused by the CRUD methods under test, so they are left nil.
+func newSvc(t *testing.T, user *mockUserUsecase) *usersvc.Service {
+	t.Helper()
+
+	base := testutil.NewBase(t)
+
+	return usersvc.New(user, nil, nil, nil, &stubRBACUsecase{}, nil, base.Logger)
+}
+
+func TestService_GetUser(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockUser := new(mockUserUsecase)
+		svc := newSvc(t, mockUser)
+
+		uid := uuid.New()
+		mockUser.On("GetUser", ctx, uid, (*model.GetOptions)(nil)).
+			Return(usermodel.NewUser("a@example.com", "alice"), nil)
+
+		result, err := svc.GetUser(ctx, uid, nil)
+
+		require.NoError(t, err)
+		assert.Equal(t, v1.UserKind, result.Kind)
+		assert.Equal(t, "a@example.com", result.Spec.Email)
+		mockUser.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockUser := new(mockUserUsecase)
+		svc := newSvc(t, mockUser)
+
+		uid := uuid.New()
+		mockUser.On("GetUser", ctx, uid, (*model.GetOptions)(nil)).Return(nil, errMock)
+
+		result, err := svc.GetUser(ctx, uid, nil)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "failed to get user")
+		mockUser.AssertExpectations(t)
+	})
+}
+
+func TestService_GetUserByEmail(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockUser := new(mockUserUsecase)
+		svc := newSvc(t, mockUser)
+
+		mockUser.On("GetUserByEmail", ctx, "a@example.com").
+			Return(usermodel.NewUser("a@example.com", "alice"), nil)
+
+		result, err := svc.GetUserByEmail(ctx, "a@example.com")
+
+		require.NoError(t, err)
+		assert.Equal(t, "a@example.com", result.Spec.Email)
+		mockUser.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockUser := new(mockUserUsecase)
+		svc := newSvc(t, mockUser)
+
+		mockUser.On("GetUserByEmail", ctx, "missing@example.com").Return(nil, errMock)
+
+		result, err := svc.GetUserByEmail(ctx, "missing@example.com")
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "failed to get user by email")
+		mockUser.AssertExpectations(t)
+	})
+}
+
+func TestService_ListUsers(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockUser := new(mockUserUsecase)
+		svc := newSvc(t, mockUser)
+
+		opts := &applicationport.ListOptions{Limit: 10}
+		resp := &model.ListResponse[*usermodel.User]{
+			Items:    []*usermodel.User{usermodel.NewUser("a@example.com", "alice")},
+			Continue: "next",
+		}
+		mockUser.On("ListUsers", ctx, opts.ToDomain()).Return(resp, nil)
+
+		result, err := svc.ListUsers(ctx, opts)
+
+		require.NoError(t, err)
+		assert.Equal(t, v1.UserKind, result.Kind)
+		assert.Len(t, result.Items, 1)
+		assert.Equal(t, "next", result.Metadata.Continue)
+		mockUser.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockUser := new(mockUserUsecase)
+		svc := newSvc(t, mockUser)
+
+		opts := &applicationport.ListOptions{Limit: 10}
+		mockUser.On("ListUsers", ctx, opts.ToDomain()).Return(nil, errMock)
+
+		result, err := svc.ListUsers(ctx, opts)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "failed to list users")
+		mockUser.AssertExpectations(t)
+	})
+}
+
+func TestService_CreateUser(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success without password", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockUser := new(mockUserUsecase)
+		svc := newSvc(t, mockUser)
+
+		apiUser := &v1.User{
+			Kind:       v1.UserKind,
+			APIVersion: v1.APIVersion,
+			Spec:       v1.UserSpec{Email: "a@example.com", Username: "alice"},
+		}
+		mockUser.On("SaveUser", ctx, mock.MatchedBy(func(u *usermodel.User) bool {
+			return u.Spec.Email == "a@example.com"
+		})).Return(nil)
+
+		result, err := svc.CreateUser(ctx, apiUser)
+
+		require.NoError(t, err)
+		assert.Equal(t, "a@example.com", result.Spec.Email)
+		mockUser.AssertExpectations(t)
+	})
+
+	t.Run("save error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockUser := new(mockUserUsecase)
+		svc := newSvc(t, mockUser)
+
+		apiUser := &v1.User{Spec: v1.UserSpec{Email: "a@example.com", Username: "alice"}}
+		mockUser.On("SaveUser", ctx, mock.Anything).Return(errMock)
+
+		result, err := svc.CreateUser(ctx, apiUser)
+
+		require.Error(t, err)
+		assert.Nil(t, result)
+		assert.Contains(t, err.Error(), "failed to create user")
+		mockUser.AssertExpectations(t)
+	})
+}
+
+func TestService_DeleteUser(t *testing.T) {
+	t.Parallel()
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockUser := new(mockUserUsecase)
+		svc := newSvc(t, mockUser)
+
+		uid := uuid.New()
+		mockUser.On("DeleteUser", ctx, uid).Return(nil)
+
+		err := svc.DeleteUser(ctx, uid)
+
+		require.NoError(t, err)
+		mockUser.AssertExpectations(t)
+	})
+
+	t.Run("error", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		mockUser := new(mockUserUsecase)
+		svc := newSvc(t, mockUser)
+
+		uid := uuid.New()
+		mockUser.On("DeleteUser", ctx, uid).Return(errMock)
+
+		err := svc.DeleteUser(ctx, uid)
+
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "failed to delete user")
+		mockUser.AssertExpectations(t)
+	})
+}


### PR DESCRIPTION
## Summary

Closes #485.

The domain layer was well covered, but the `application/service` layer had almost no tests: of 18 services only `agent`, `rolebinding`, and `opamp` had any. This PR adds table-driven unit tests for the **15 previously-untested services**, exercising the orchestration each layer owns — domain ↔ `api/v1` DTO mapping, error wrapping/propagation, and delegation to the right usecase.

Tests only; **no production code changed**. Follows the existing `rolebinding` test pattern (hand-written domain-port mocks + `testutil.NewBase`).

## Services covered

| Service | Notable coverage |
|---|---|
| server, host, container, namespace | CRUD/read mapping, empty-list and error paths |
| certificate, agentpackage, agentremoteconfig | CRUD orchestration; ARC also verifies the fire-and-forget group-propagation and endpoint-detection side effects via synchronizing stubs |
| endpoint, endpointmetrics, role | CRUD, default-window fallback |
| admin, reconcile | connection listing (node-local vs cluster ServerID), unknown-kind → `ErrInvalidArgument` mapping |
| auth, user | `EnsureUserOnLogin` provisioning paths (existing / new / soft-deleted), user CRUD |
| agentgroup | CRUD, already-exists guard, selector-based agent listing, namespace-mismatch path |

Some deep paths with many collaborators (e.g. `user.GetMyProfile`'s RBAC-enforcer wiring) are intentionally left for a follow-up.

## Verification

- `go test -race ./pkg/apiserver/application/service/...` — all pass
- `golangci-lint run ./pkg/apiserver/application/service/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)