### PR TITLE
docs(opamp): add OpAMP spec conformance matrix

### DIFF
--- a/docs/content/en/docs/opamp-conformance.md
+++ b/docs/content/en/docs/opamp-conformance.md
@@ -44,7 +44,7 @@ actually implemented.
 | `agent_identification` | ✅ | Sent when the server assigns a new instance UID. |
 | `command` | ✅ | `Restart` — the only command the spec currently defines. |
 | `capabilities` | ✅ | |
-| `flags` (`ReportFullState`) | 🟡 | Set only by the separate cross-server push builder, and only when the agent is incomplete; never set on the hot path. |
+| `flags` (`ReportFullState`) | ✅ | Set by the shared builder (both hot and push paths) when the agent is not yet fully described. |
 | `error_response` | ⛔ | Never populated. |
 | `custom_capabilities` | ⛔ | Always `nil` (server advertises no custom capabilities). |
 | `custom_message` | ⛔ | Always `nil`. |
@@ -73,15 +73,13 @@ actually implemented.
 
 ## Known gaps
 
-1. **Two divergent `ServerToAgent` builders.** The hot path (`fetchServerToAgent`) builds a
-   complete message. The cross-server push path
-   (`domain/agent/service/server.go` → `buildServerToAgentMessage`, reached via the
-   `SendServerToAgent` server event) is a self-described "simplified" stub that **omits**
-   `remote_config`, `packages_available`, `connection_settings`, and `command`. For a normal
-   (fully-described) agent it also leaves `ReportFullState` unset, so the immediate cross-server
-   push is effectively a no-op. Config still converges on the agent's **next** heartbeat via the
-   hot path, so this is an immediacy/latency gap rather than permanent data loss — but it defeats
-   the point of the push.
+1. ~~**Two divergent `ServerToAgent` builders.**~~ *(Resolved in #503.)* The hot path and the
+   cross-server push path now share a single `ServerToAgentBuilder`, so a cross-server push
+   delivers the same complete message (remote config, packages, connection settings, command)
+   as a direct response instead of a degraded stub. Previously the push path
+   (`buildServerToAgentMessage`) omitted those fields and, for a fully-described agent, left
+   `ReportFullState` unset — making the immediate push effectively a no-op until the agent's
+   next heartbeat.
 2. **`AcceptsConnectionSettingsRequest` advertised but unhandled** — the server claims the
    capability but ignores `connection_settings_request`.
 3. **Packages: `TopLevel`-only + silent-drop** on fetch failure (tracked in #496).

--- a/docs/content/en/docs/opamp-conformance.md
+++ b/docs/content/en/docs/opamp-conformance.md
@@ -1,0 +1,99 @@
+---
+title: "OpAMP Conformance"
+linkTitle: "OpAMP Conformance"
+weight: 90
+type: docs
+---
+
+This page tracks how much of the [OpAMP specification](https://opentelemetry.io/docs/specs/opamp/)
+OpAMP Commander implements today. It is a living document; update it whenever the OpAMP message
+handling changes.
+
+**Legend:** ✅ Implemented · 🟡 Partial · ⛔ Not implemented
+
+> Audited against `main` on 2026-07-19. Primary sources:
+> `pkg/apiserver/application/service/opamp/{opamp,serverToAgent,protobufsToDomain,domainToProtobufs}.go`
+> and `pkg/apiserver/domain/agent/service/server.go`.
+
+## Server capabilities
+
+The value advertised in `ServerToAgent.capabilities` (`serverToAgent.go`). All seven server
+capabilities are advertised; "Fulfilled" reflects whether the behavior behind the flag is
+actually implemented.
+
+| ServerCapability | Advertised | Fulfilled | Notes |
+|---|:---:|:---:|---|
+| `AcceptsStatus` | ✅ | ✅ | Full `AgentToServer` ingestion via `report()`. |
+| `OffersRemoteConfig` | ✅ | ✅ | Delivered on the hot path; **omitted** on the cross-server push path (see [Known gaps](#known-gaps)). |
+| `AcceptsEffectiveConfig` | ✅ | ✅ | Stored on the agent. |
+| `OffersConnectionSettings` | ✅ | ✅ | `opamp`, `own_metrics`, `own_logs`, `own_traces`, `other_connections`, each with headers + TLS certificate. |
+| `AcceptsConnectionSettingsRequest` | ✅ | ⛔ | Advertised, but `connection_settings_request` from the agent is **not processed**. |
+| `OffersPackages` | ✅ | 🟡 | Only `TopLevel` package type; a package-fetch failure is silently dropped (see #496). |
+| `AcceptsPackagesStatus` | ✅ | ✅ | Stored on the agent. |
+
+## Server → Agent message fields
+
+`ServerToAgent` fields the server can populate (`fetchServerToAgent` in `serverToAgent.go`).
+
+| Field | Status | Notes |
+|---|:---:|---|
+| `instance_uid` | ✅ | |
+| `remote_config` | ✅ | Built from the agent's materialized `Spec.RemoteConfig.ConfigMap` with a content hash. |
+| `connection_settings` | ✅ | Full offer set incl. TLS certificates and headers. |
+| `packages_available` | 🟡 | `TopLevel` only; silent drop on fetch failure (#496). |
+| `agent_identification` | ✅ | Sent when the server assigns a new instance UID. |
+| `command` | ✅ | `Restart` — the only command the spec currently defines. |
+| `capabilities` | ✅ | |
+| `flags` (`ReportFullState`) | 🟡 | Set only by the separate cross-server push builder, and only when the agent is incomplete; never set on the hot path. |
+| `error_response` | ⛔ | Never populated. |
+| `custom_capabilities` | ⛔ | Always `nil` (server advertises no custom capabilities). |
+| `custom_message` | ⛔ | Always `nil`. |
+
+## Agent → Server processing
+
+`AgentToServer` fields the server ingests (`report()` in `opamp.go`, converters in
+`protobufsToDomain.go`).
+
+| Field | Status | Notes |
+|---|:---:|---|
+| `instance_uid` | ✅ | Incl. instance-UID conflict handling (`instanceuid_conflict.go`). |
+| `sequence_num` | ✅ | Recorded per report. |
+| `agent_description` | 🟡 | Ingested, but only string `AnyValue`s are kept — non-string attribute values are dropped (`protobufsToDomain.go`, `toMap`). |
+| `capabilities` | ✅ | Stored. |
+| `health` (`ComponentHealth`) | ✅ | Incl. nested sub-component health. |
+| `effective_config` | ✅ | Stored. |
+| `remote_config_status` | ✅ | Stored (uses `time.Now()` rather than the injected clock — hygiene nit). |
+| `connection_settings_status` | ✅ | Stored. |
+| `package_statuses` | ✅ | Stored. |
+| `available_components` | ✅ | Incl. nested sub-components. |
+| `custom_capabilities` | ✅ | Stored. |
+| `agent_disconnect` | 🟡 | Detected; disconnect is handled via connection-close, not an explicit report. |
+| `connection_settings_request` | ⛔ | Not processed despite `AcceptsConnectionSettingsRequest` being advertised. |
+| `custom_message` | ⛔ | Not processed. |
+
+## Known gaps
+
+1. **Two divergent `ServerToAgent` builders.** The hot path (`fetchServerToAgent`) builds a
+   complete message. The cross-server push path
+   (`domain/agent/service/server.go` → `buildServerToAgentMessage`, reached via the
+   `SendServerToAgent` server event) is a self-described "simplified" stub that **omits**
+   `remote_config`, `packages_available`, `connection_settings`, and `command`. For a normal
+   (fully-described) agent it also leaves `ReportFullState` unset, so the immediate cross-server
+   push is effectively a no-op. Config still converges on the agent's **next** heartbeat via the
+   hot path, so this is an immediacy/latency gap rather than permanent data loss — but it defeats
+   the point of the push.
+2. **`AcceptsConnectionSettingsRequest` advertised but unhandled** — the server claims the
+   capability but ignores `connection_settings_request`.
+3. **Packages: `TopLevel`-only + silent-drop** on fetch failure (tracked in #496).
+4. **Custom messages / custom capabilities** are unsupported end-to-end (server→agent always
+   `nil`; agent→server `custom_message` dropped).
+5. **`error_response` is never sent**, so the agent gets no structured error signal from the server.
+6. **Non-string attribute values are dropped** in `toMap`, losing fidelity for identifying /
+   non-identifying attributes and component metadata.
+
+## Test coverage
+
+Most OpAMP message-path behavior is exercised only by the Docker-based E2E suite
+(`test/e2e/apiserver`). The message builders and protobuf↔domain converters have little direct
+unit coverage. Interop against a real OTel Collector `opamp` extension is a goal (a Collector
+test helper already exists in `pkg/testutil`).

--- a/pkg/apiserver/application/usecase/auth.go
+++ b/pkg/apiserver/application/usecase/auth.go
@@ -9,8 +9,9 @@ import (
 // AuthProvisioningUsecase creates or updates the user record on login and
 // re-applies RBAC policies so the user picks up default roles and matching
 // bindings. It is best-effort: failures are logged internally and never
-// block authentication. It is invoked by the login/auth flow, not the REST
-// CRUD API.
+// block authentication. It backs the auth/login HTTP controllers under
+// /api/v1/auth/* (basic and github), called on a successful login rather than
+// as a REST CRUD operation.
 type AuthProvisioningUsecase interface {
 	// EnsureUserOnLogin creates or updates the user described by provisioning
 	// and re-applies RBAC. It is best-effort and returns nothing: callers

--- a/pkg/apiserver/application/usecase/opamp.go
+++ b/pkg/apiserver/application/usecase/opamp.go
@@ -7,10 +7,10 @@ import (
 	opamptypes "github.com/open-telemetry/opamp-go/server/types"
 )
 
-// OpAMPUsecase handles the OpAMP protocol itself. Unlike the REST
-// management use cases, it is implemented by the central OpAMP service and
-// invoked by the opamp-go server adapter as connection callbacks for each
-// connected agent.
+// OpAMPUsecase handles the OpAMP protocol itself. It backs the /api/v1/opamp
+// HTTP/WebSocket endpoint (the opamp controller): unlike the REST CRUD use
+// cases its methods are not request handlers but connection callbacks, invoked
+// by the opamp-go server adapter for each connected agent.
 // Please see [github.com/open-telemetry/opamp-go/server/types/ConnectionCallbacks].
 type OpAMPUsecase interface {
 	// OnConnected is called when an agent connection is established.


### PR DESCRIPTION
## What

Two documentation-only commits:

1. **`docs(usecase)`** — clarify in the `AuthProvisioning` and `OpAMP` use case interface docs
   which HTTP endpoints they back (`/api/v1/auth/*`, `/api/v1/opamp`) and that their methods are
   login/connection callbacks rather than REST handlers.
2. **`docs(opamp)`** — add an **OpAMP spec conformance matrix** to the docs site
   (`docs/content/en/docs/opamp-conformance.md`), auditing server capabilities, `ServerToAgent`
   fields, and `AgentToServer` ingestion against the OpAMP spec, with a "Known gaps" section.

## Why

Part of steering the project toward a general-purpose OSS OpAMP server: a published conformance
matrix is both an adoption signal and the organizing frame for capability work.

## Notable audit findings (documented, not fixed here)

- Two divergent `ServerToAgent` builders — the cross-server push builder is a stub that omits
  config/packages/connection-settings, so immediate cross-server push is effectively a no-op
  (config converges on the next heartbeat via the hot path).
- `AcceptsConnectionSettingsRequest` is advertised but `connection_settings_request` is unhandled.
- Packages are `TopLevel`-only with a silent drop on fetch failure (#496).
- Custom messages / custom capabilities and `error_response` are unsupported outbound.
- `toMap` keeps only string attribute values.

Gaps are tracked in the conformance epic #501.

## Type

Docs only — no code behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
