### PR TITLE
fix(opamp): preserve non-string agent attribute values

### DIFF
--- a/pkg/apiserver/application/service/opamp/protobufsToDomain.go
+++ b/pkg/apiserver/application/service/opamp/protobufsToDomain.go
@@ -1,6 +1,8 @@
 package opamp
 
 import (
+	"encoding/base64"
+	"strconv"
 	"time"
 
 	"github.com/open-telemetry/opamp-go/protobufs"
@@ -61,11 +63,38 @@ func customCapabilitiesToDomain(customCapabilities *protobufs.CustomCapabilities
 func toMap(proto []*protobufs.KeyValue) map[string]string {
 	retval := make(map[string]string, len(proto))
 	for _, kv := range proto {
-		// iss#1: Handle other types.
-		retval[kv.GetKey()] = kv.GetValue().GetStringValue()
+		retval[kv.GetKey()] = anyValueToString(kv.GetValue())
 	}
 
 	return retval
+}
+
+// anyValueToString renders an OpAMP AnyValue as a string for storage in the agent's
+// string-keyed attribute maps. Scalar values keep their natural representation (so a
+// non-string identifying attribute such as an int process.pid is preserved instead of being
+// silently dropped to ""); bytes are base64-encoded and nested array/kvlist values fall back
+// to their protobuf text form.
+func anyValueToString(value *protobufs.AnyValue) string {
+	if value == nil {
+		return ""
+	}
+
+	switch value.GetValue().(type) {
+	case *protobufs.AnyValue_StringValue:
+		return value.GetStringValue()
+	case *protobufs.AnyValue_BoolValue:
+		return strconv.FormatBool(value.GetBoolValue())
+	case *protobufs.AnyValue_IntValue:
+		return strconv.FormatInt(value.GetIntValue(), 10)
+	case *protobufs.AnyValue_DoubleValue:
+		return strconv.FormatFloat(value.GetDoubleValue(), 'g', -1, 64)
+	case *protobufs.AnyValue_BytesValue:
+		return base64.StdEncoding.EncodeToString(value.GetBytesValue())
+	case *protobufs.AnyValue_ArrayValue, *protobufs.AnyValue_KvlistValue:
+		return value.String()
+	default:
+		return ""
+	}
 }
 
 func healthToDomain(health *protobufs.ComponentHealth) *agentmodel.AgentComponentHealth {

--- a/pkg/apiserver/application/service/opamp/protobufstodomain_test.go
+++ b/pkg/apiserver/application/service/opamp/protobufstodomain_test.go
@@ -1,0 +1,70 @@
+//nolint:testpackage // white-box test of the unexported protobuf->domain converters
+package opamp
+
+import (
+	"testing"
+
+	"github.com/open-telemetry/opamp-go/protobufs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func strValue(s string) *protobufs.AnyValue {
+	return &protobufs.AnyValue{Value: &protobufs.AnyValue_StringValue{StringValue: s}}
+}
+
+// TestDescToDomain_PreservesNonStringAttributes guards against the fidelity bug where only
+// string AnyValues were kept: an agent reporting int/bool/double identifying attributes must
+// have them preserved (as their string form), because AgentGroup selectors match on these.
+func TestDescToDomain_PreservesNonStringAttributes(t *testing.T) {
+	t.Parallel()
+
+	desc := &protobufs.AgentDescription{
+		IdentifyingAttributes: []*protobufs.KeyValue{
+			{Key: "service.name", Value: strValue("collector")},
+			{Key: "process.pid", Value: &protobufs.AnyValue{Value: &protobufs.AnyValue_IntValue{IntValue: 4321}}},
+			{Key: "feature.enabled", Value: &protobufs.AnyValue{Value: &protobufs.AnyValue_BoolValue{BoolValue: true}}},
+			{Key: "cpu.ratio", Value: &protobufs.AnyValue{Value: &protobufs.AnyValue_DoubleValue{DoubleValue: 0.5}}},
+		},
+		NonIdentifyingAttributes: nil,
+	}
+
+	got := descToDomain(desc)
+
+	require.NotNil(t, got)
+	assert.Equal(t, map[string]string{
+		"service.name":    "collector",
+		"process.pid":     "4321",
+		"feature.enabled": "true",
+		"cpu.ratio":       "0.5",
+	}, got.IdentifyingAttributes)
+}
+
+func TestAnyValueToString(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   *protobufs.AnyValue
+		want string
+	}{
+		{"nil", nil, ""},
+		{"string", strValue("x"), "x"},
+		{"int", &protobufs.AnyValue{Value: &protobufs.AnyValue_IntValue{IntValue: -7}}, "-7"},
+		{"bool", &protobufs.AnyValue{Value: &protobufs.AnyValue_BoolValue{BoolValue: false}}, "false"},
+		{"double", &protobufs.AnyValue{Value: &protobufs.AnyValue_DoubleValue{DoubleValue: 1.25}}, "1.25"},
+		{
+			"bytes",
+			&protobufs.AnyValue{Value: &protobufs.AnyValue_BytesValue{BytesValue: []byte{0x01, 0x02}}},
+			"AQI=",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			assert.Equal(t, tt.want, anyValueToString(tt.in))
+		})
+	}
+}


### PR DESCRIPTION
## Problem

`toMap` (used for an agent's identifying / non-identifying attributes and component metadata)
read only `kv.GetValue().GetStringValue()`. Any attribute an agent reports as a **non-string**
`AnyValue` — int, bool, double, bytes — was silently coerced to `""`.

This is a real correctness bug, not just fidelity: **AgentGroup selectors match on these
attributes**, so an agent reporting e.g. an integer `process.pid` (or a boolean flag) could
silently fail to match a group, and the value shown on the API surface was wrong.

## Change

Introduce `anyValueToString`, rendering every `AnyValue` kind:

- string → as-is
- bool / int / double → natural string form (`strconv`)
- bytes → base64
- array / kvlist → protobuf text form (best-effort, so nested values are preserved rather than dropped)

`toMap` now uses it for every value.

## Tests

- `TestDescToDomain_PreservesNonStringAttributes` — an agent description with int/bool/double
  identifying attributes round-trips to the expected string map.
- `TestAnyValueToString` — table test across the scalar/bytes kinds (incl. nil).

Lint clean; opamp package tests pass.

Refs #501 (conformance — attribute fidelity gap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)