### PR TITLE
ci(test): add octocov coverage report on PRs

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -10,6 +10,9 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # octocov posts the coverage report as a PR comment
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,6 +30,11 @@ jobs:
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Report coverage (octocov)
+        uses: k1LoW/octocov-action@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   test-e2e:
     runs-on: ubuntu-latest

--- a/.octocov.yml
+++ b/.octocov.yml
@@ -1,0 +1,16 @@
+# octocov renders a coverage + code-to-test-ratio report (a JaCoCo-like view) as a
+# pull-request comment and a GitHub Actions job summary, so results are readable without
+# digging through raw CI logs. See https://github.com/k1LoW/octocov
+coverage:
+  paths:
+    - coverage.txt
+codeToTestRatio:
+  code:
+    - "**/*.go"
+    - "!**/*_test.go"
+  test:
+    - "**/*_test.go"
+comment:
+  if: is_pull_request
+summary:
+  if: true


### PR DESCRIPTION
## What

Add [octocov](https://github.com/k1LoW/octocov) to the `test` job so every PR gets a
**coverage + code-to-test-ratio report** (a JaCoCo-like view) rendered as:

- a **PR comment**, and
- a **GitHub Actions job summary**

so results are visible without scrolling raw CI logs.

## Details

- `.octocov.yml` — reads the existing `coverage.txt` that `make test` already produces;
  adds a code-to-test ratio; comments on PRs and always writes the job summary.
- `test.yaml` — adds the `k1LoW/octocov-action@v1` step after the coverage run, and grants
  the `test` job `pull-requests: write` so octocov can post its comment.
- **Codecov is kept unchanged** — octocov is additive. It can replace Codecov later if desired.

## Note

This is the coverage half of the "see results without reading logs" improvement. Making
individual **test failures** easy to spot is handled by the companion PR that quiets the noisy
e2e logs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)