### PR TITLE
test(e2e): quiet server logs so test failures are readable

### DIFF
--- a/pkg/apiserver/internal/app/app.go
+++ b/pkg/apiserver/internal/app/app.go
@@ -7,10 +7,12 @@ package app
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"time"
 
 	"go.uber.org/fx"
+	"go.uber.org/fx/fxevent"
 
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/config"
 	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent"
@@ -64,6 +66,16 @@ func appOptions(settings *config.ServerSettings) []fx.Option {
 		// Base utilities
 		helper.NewModule(),
 		management.NewModule(),
+
+		// Route FX's own lifecycle events (provided/invoked/OnStart/OnStop) through the
+		// app's slog logger instead of FX's default console logger. This makes those logs
+		// structured and, crucially, level-controlled — raising the configured log level
+		// (e.g. to warn in e2e tests) silences the otherwise very noisy "[Fx] HOOK ..."
+		// startup stream.
+		fx.WithLogger(func(logger *slog.Logger) fxevent.Logger {
+			return &fxevent.SlogLogger{Logger: logger}
+		}),
+
 		// Initialize HTTP server
 		fx.Invoke(func(*http.Server) {}),
 	}

--- a/pkg/testutil/apiserver.go
+++ b/pkg/testutil/apiserver.go
@@ -3,6 +3,7 @@ package testutil
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"path/filepath"
 	"runtime"
 	"time"
@@ -172,6 +173,10 @@ func buildServerSettings(
 				//exhaustruct:ignore
 				Log: observability.LogSettings{
 					Format: observability.LogFormatText,
+					// Keep test output readable: at info level the FX lifecycle stream and
+					// per-request logs bury the actual test failures. warn still surfaces
+					// genuine problems (errors/warnings) from the server under test.
+					Level: slog.LevelWarn,
 				},
 			},
 		},


### PR DESCRIPTION
## Problem

When an e2e/integration test fails, `go test` dumps the failing test's entire captured
output. Today that output is dominated by the FX lifecycle stream (`[Fx] HOOK ...`) and
per-request info logs, so the actual assertion failure is very hard to find — the pain that
prompted this (a failed e2e run was ~217k lines, almost all FX/slog noise).

## Change

- **Route FX lifecycle events through slog** at the composition root
  (`fx.WithLogger` → `fxevent.SlogLogger`) instead of FX's default console logger. FX startup
  logs become structured and, crucially, **level-controlled**. (The management module already
  did this for its scope; this extends it to the root app.)
- **Set the test server's log level to `warn`** in `pkg/testutil` so info-level FX/request
  noise is suppressed while genuine warnings/errors still surface.

## Verified

Standalone integration test with `go test -v`:

| | `[Fx] HOOK` | `level=INFO` | WARN/ERROR | total lines |
|---|---|---|---|---|
| before | 31 | 152 | 5 | 1232 |
| after  | 0  | 0   | 5 | 213  |

~83% less output; all FX-hook / info noise gone; warnings and errors preserved. Build, `go vet`,
the FX wiring-validation test, and lint all pass.

## Note

The FX→slog routing is a small production-visible change (startup logs become structured slog
instead of the `[Fx]` console format, and are now suppressible by log level) — arguably an
improvement, and consistent with what the management module already did.

🤖 Generated with [Claude Code](https://claude.com/claude-code)