### PR TITLE
test(rolebinding): fill validation and missing-param branches

### DIFF
--- a/pkg/apiserver/adapter/primary/http/v1/rolebinding/controller_gaps_test.go
+++ b/pkg/apiserver/adapter/primary/http/v1/rolebinding/controller_gaps_test.go
@@ -1,0 +1,106 @@
+package rolebinding_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gin-gonic/gin"
+	"github.com/stretchr/testify/require"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/primary/http/v1/rolebinding"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/primary/http/v1/rolebinding/usecasemock"
+	"github.com/minuk-dev/opampcommander/pkg/testutil"
+)
+
+func gapRouter(t *testing.T) *gin.Engine {
+	t.Helper()
+
+	ctrlBase := testutil.NewBase(t).ForController()
+	controller := rolebinding.NewController(usecasemock.NewMockUsecase(t), ctrlBase.Logger)
+	ctrlBase.SetupRouter(controller)
+
+	return ctrlBase.Router
+}
+
+func gapGET(t *testing.T, router *gin.Engine, target string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	recorder := httptest.NewRecorder()
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, target, nil)
+	require.NoError(t, err)
+	router.ServeHTTP(recorder, req)
+
+	return recorder
+}
+
+const gapBase = "/api/v1/namespaces/default/rolebindings"
+
+func TestRoleBindingController_ListValidation(t *testing.T) {
+	t.Parallel()
+
+	t.Run("invalid limit", func(t *testing.T) {
+		t.Parallel()
+
+		recorder := gapGET(t, gapRouter(t), gapBase+"?limit=abc")
+
+		require.Equal(t, http.StatusBadRequest, recorder.Code)
+	})
+
+	t.Run("invalid includeDeleted", func(t *testing.T) {
+		t.Parallel()
+
+		recorder := gapGET(t, gapRouter(t), gapBase+"?includeDeleted=maybe")
+
+		require.Equal(t, http.StatusBadRequest, recorder.Code)
+	})
+}
+
+func TestRoleBindingController_GetValidation(t *testing.T) {
+	t.Parallel()
+
+	recorder := gapGET(t, gapRouter(t), gapBase+"/rb-1?includeDeleted=nope")
+
+	require.Equal(t, http.StatusBadRequest, recorder.Code)
+}
+
+// TestRoleBindingController_MissingParams covers the required :namespace / :name validation
+// branches across every handler, unreachable through routing since the segments are never empty.
+func TestRoleBindingController_MissingParams(t *testing.T) {
+	t.Parallel()
+
+	controller := rolebinding.NewController(usecasemock.NewMockUsecase(t), testutil.NewBase(t).Logger)
+	ns := gin.Params{{Key: "namespace", Value: "default"}}
+
+	cases := []struct {
+		name    string
+		handler gin.HandlerFunc
+		params  gin.Params
+	}{
+		{"Get missing namespace", controller.Get, nil},
+		{"Get missing name", controller.Get, ns},
+		{"Create missing namespace", controller.Create, nil},
+		{"Update missing namespace", controller.Update, nil},
+		{"Update missing name", controller.Update, ns},
+		{"Delete missing namespace", controller.Delete, nil},
+		{"Delete missing name", controller.Delete, ns},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			recorder := httptest.NewRecorder()
+			ginCtx, _ := gin.CreateTestContext(recorder)
+			req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, "/", nil)
+			require.NoError(t, err)
+
+			ginCtx.Request = req
+			ginCtx.Params = tc.params
+
+			tc.handler(ginCtx)
+
+			require.Equal(t, http.StatusBadRequest, recorder.Code)
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Extends `pkg/apiserver/adapter/primary/http/v1/rolebinding/controller.go` tests to 100%, filling the branches the existing suite missed: `List` invalid `limit`/`includeDeleted`, `Get` invalid `includeDeleted`, and the required `:namespace`/`:name` validation branches across Get/Create/Update/Delete (via direct handler invocation).

Coverage: **56.6% → 100%**. `golangci-lint`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)