### PR TITLE
fix(agent): return 400 (not 500) on a malformed Update body

### DIFF
--- a/pkg/apiserver/adapter/primary/http/v1/agent/controller.go
+++ b/pkg/apiserver/adapter/primary/http/v1/agent/controller.go
@@ -345,7 +345,7 @@ func (c *Controller) Update(ctx *gin.Context) {
 
 	var req v1.Agent
 
-	err = ctx.ShouldBindJSON(&req)
+	err = ginutil.BindJSON(ctx, &req)
 	if err != nil {
 		ginutil.HandleValidationError(ctx, "body", "", err, false)
 

--- a/pkg/apiserver/adapter/primary/http/v1/agent/controller_gaps_test.go
+++ b/pkg/apiserver/adapter/primary/http/v1/agent/controller_gaps_test.go
@@ -264,10 +264,9 @@ func TestAgentController_Update(t *testing.T) {
 		ctrlBase, _ := gapSetup(t)
 		uid := uuid.New()
 
-		// NOTE: unlike the other controllers (which wrap the bind error via ginutil.BindJSON and
-		// return 400), Update passes the raw ShouldBindJSON error to HandleValidationError, which
-		// maps unknown errors to 500. This asserts the current behavior; see PR description.
-		require.Equal(t, http.StatusInternalServerError,
+		// A malformed body is a client error: Update wraps the bind error via ginutil.BindJSON
+		// (like the other controllers) so HandleValidationError maps it to 400.
+		require.Equal(t, http.StatusBadRequest,
 			gapReq(t, ctrlBase.Router, http.MethodPut, gapBase+"/"+uid.String(), `{not-json`).Code)
 	})
 


### PR DESCRIPTION
## Problem
`agent.Update` bound the request body with `ctx.ShouldBindJSON` and passed the **raw** decode error to `ginutil.HandleValidationError`. That helper only maps its known sentinels (e.g. `ErrValidationFailed`, `ErrInvalidFormat`) to 4xx and falls through to **500** for anything else — so a malformed client body (e.g. `{not-json`) surfaced as `500 Internal Server Error` instead of `400 Bad Request`.

Every other controller (namespace, endpoint, certificate, …) wraps the bind error via `ginutil.BindJSON`, which returns `ErrValidationFailed` → 400. `Update` was the only inconsistent one.

## Fix
Switch `Update` to `ginutil.BindJSON(ctx, &req)`, matching the rest of the codebase. A malformed body now returns **400**.

## Test
Flips the `Update / invalid body` assertion (added in the agent test PR) from 500 to 400. Controller stays at **100%** coverage; `golangci-lint` clean.

## Note on base branch
This is **stacked on `test/agent-controller-tests`** (#527) because that branch introduced the test this fix updates. It will retarget to `main` automatically once #527 merges. Merge #527 first, then this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)