### PR TITLE
fix(opamp): stop advertising AcceptsConnectionSettingsRequest

### DIFF
--- a/docs/content/en/docs/opamp-conformance.md
+++ b/docs/content/en/docs/opamp-conformance.md
@@ -27,7 +27,7 @@ actually implemented.
 | `OffersRemoteConfig` | ✅ | ✅ | Delivered on the hot path; **omitted** on the cross-server push path (see [Known gaps](#known-gaps)). |
 | `AcceptsEffectiveConfig` | ✅ | ✅ | Stored on the agent. |
 | `OffersConnectionSettings` | ✅ | ✅ | `opamp`, `own_metrics`, `own_logs`, `own_traces`, `other_connections`, each with headers + TLS certificate. |
-| `AcceptsConnectionSettingsRequest` | ✅ | ⛔ | Advertised, but `connection_settings_request` from the agent is **not processed**. |
+| `AcceptsConnectionSettingsRequest` | ⛔ | ⛔ | Intentionally **not advertised**: `connection_settings_request` is not processed, so the capability is withheld rather than claimed-but-ignored. |
 | `OffersPackages` | ✅ | 🟡 | Only `TopLevel` package type; a package-fetch failure is silently dropped (see #496). |
 | `AcceptsPackagesStatus` | ✅ | ✅ | Stored on the agent. |
 
@@ -68,7 +68,7 @@ actually implemented.
 | `available_components` | ✅ | Incl. nested sub-components. |
 | `custom_capabilities` | ✅ | Stored. |
 | `agent_disconnect` | 🟡 | Detected; disconnect is handled via connection-close, not an explicit report. |
-| `connection_settings_request` | ⛔ | Not processed despite `AcceptsConnectionSettingsRequest` being advertised. |
+| `connection_settings_request` | ⛔ | Not processed; the server withholds `AcceptsConnectionSettingsRequest` rather than advertising it. |
 | `custom_message` | ⛔ | Not processed. |
 
 ## Known gaps
@@ -80,8 +80,10 @@ actually implemented.
    (`buildServerToAgentMessage`) omitted those fields and, for a fully-described agent, left
    `ReportFullState` unset — making the immediate push effectively a no-op until the agent's
    next heartbeat.
-2. **`AcceptsConnectionSettingsRequest` advertised but unhandled** — the server claims the
-   capability but ignores `connection_settings_request`.
+2. ~~**`AcceptsConnectionSettingsRequest` advertised but unhandled.**~~ *(Resolved.)* The server
+   no longer advertises the capability, so agents are not invited to send a
+   `connection_settings_request` the server would silently ignore. Re-advertise once the request
+   is processed.
 3. **Packages: `TopLevel`-only + silent-drop** on fetch failure (tracked in #496).
 4. **Custom messages / custom capabilities** are unsupported end-to-end (server→agent always
    `nil`; agent→server `custom_message` dropped).

--- a/pkg/apiserver/domain/agent/service/servertoagent.go
+++ b/pkg/apiserver/domain/agent/service/servertoagent.go
@@ -98,7 +98,9 @@ func (b *ServerToAgentBuilder) Build(
 	capabilities |= int32(protobufs.ServerCapabilities_ServerCapabilities_AcceptsStatus)
 	capabilities |= int32(protobufs.ServerCapabilities_ServerCapabilities_OffersRemoteConfig)
 	capabilities |= int32(protobufs.ServerCapabilities_ServerCapabilities_AcceptsEffectiveConfig)
-	capabilities |= int32(protobufs.ServerCapabilities_ServerCapabilities_AcceptsConnectionSettingsRequest)
+	// AcceptsConnectionSettingsRequest is intentionally not advertised: the server does not
+	// yet process the agent's connection_settings_request, so claiming the capability would
+	// invite requests it silently ignores. Re-add it once the request is handled.
 	capabilities |= int32(protobufs.ServerCapabilities_ServerCapabilities_OffersConnectionSettings)
 	capabilities |= int32(protobufs.ServerCapabilities_ServerCapabilities_OffersPackages)
 	capabilities |= int32(protobufs.ServerCapabilities_ServerCapabilities_AcceptsPackagesStatus)

--- a/pkg/apiserver/domain/agent/service/servertoagent_test.go
+++ b/pkg/apiserver/domain/agent/service/servertoagent_test.go
@@ -38,13 +38,18 @@ func TestServerToAgentBuilder_Build_AdvertisesServerCapabilities(t *testing.T) {
 		protobufs.ServerCapabilities_ServerCapabilities_OffersRemoteConfig,
 		protobufs.ServerCapabilities_ServerCapabilities_AcceptsEffectiveConfig,
 		protobufs.ServerCapabilities_ServerCapabilities_OffersConnectionSettings,
-		protobufs.ServerCapabilities_ServerCapabilities_AcceptsConnectionSettingsRequest,
 		protobufs.ServerCapabilities_ServerCapabilities_OffersPackages,
 		protobufs.ServerCapabilities_ServerCapabilities_AcceptsPackagesStatus,
 	} {
 		assert.NotZero(t, msg.GetCapabilities()&uint64(capability),
 			"server capability %v should be advertised", capability)
 	}
+
+	// AcceptsConnectionSettingsRequest must NOT be advertised while the server does not
+	// process connection_settings_request — advertising it would invite ignored requests.
+	assert.Zero(t,
+		msg.GetCapabilities()&uint64(protobufs.ServerCapabilities_ServerCapabilities_AcceptsConnectionSettingsRequest),
+		"AcceptsConnectionSettingsRequest must not be advertised until it is handled")
 }
 
 // completeAgent returns an agent that has reported a description and capabilities, so


### PR DESCRIPTION
## What

The server advertised the `AcceptsConnectionSettingsRequest` server capability but never processed the agent's `connection_settings_request` message, so agents were invited to send a request the server silently ignored.

This withholds the capability until the request is actually handled — the spec-conformant choice (a server must not advertise a capability it does not implement).

## Changes

- `servertoagent.go`: drop the `AcceptsConnectionSettingsRequest` bit from the advertised server capabilities, with a comment explaining why and when to re-add it.
- `servertoagent_test.go`: assert the capability is **not** advertised (regression guard).
- `opamp-conformance.md`: update the capability/field rows and mark the gap resolved.

## Related

Closes one gap from the OpAMP conformance tracking issue #501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)