### PR TITLE
fix(opamp): stamp remote-config status from the injected clock

### DIFF
--- a/docs/content/en/docs/opamp-conformance.md
+++ b/docs/content/en/docs/opamp-conformance.md
@@ -62,7 +62,7 @@ actually implemented.
 | `capabilities` | ✅ | Stored. |
 | `health` (`ComponentHealth`) | ✅ | Incl. nested sub-component health. |
 | `effective_config` | ✅ | Stored. |
-| `remote_config_status` | ✅ | Stored (uses `time.Now()` rather than the injected clock — hygiene nit). |
+| `remote_config_status` | ✅ | Stored; `LastUpdatedAt` is stamped from the injected clock. |
 | `connection_settings_status` | ✅ | Stored. |
 | `package_statuses` | ✅ | Stored. |
 | `available_components` | ✅ | Incl. nested sub-components. |

--- a/pkg/apiserver/application/service/opamp/opamp.go
+++ b/pkg/apiserver/application/service/opamp/opamp.go
@@ -354,8 +354,10 @@ func (s *Service) report(
 	agentToServer *protobufs.AgentToServer,
 	by *agentmodel.Server,
 ) error {
+	now := s.clock.Now()
+
 	// Update communication info
-	agent.RecordLastReported(by, s.clock.Now(), agentToServer.GetSequenceNum())
+	agent.RecordLastReported(by, now, agentToServer.GetSequenceNum())
 
 	err := agent.ReportDescription(descToDomain(agentToServer.GetAgentDescription()))
 	if err != nil {
@@ -379,7 +381,7 @@ func (s *Service) report(
 		return fmt.Errorf("failed to report effective config: %w", err)
 	}
 
-	err = agent.ReportRemoteConfigStatus(remoteConfigStatusToDomain(agentToServer.GetRemoteConfigStatus()))
+	err = agent.ReportRemoteConfigStatus(remoteConfigStatusToDomain(agentToServer.GetRemoteConfigStatus(), now))
 	if err != nil {
 		return fmt.Errorf("failed to report remote config status: %w", err)
 	}

--- a/pkg/apiserver/application/service/opamp/protobufsToDomain.go
+++ b/pkg/apiserver/application/service/opamp/protobufsToDomain.go
@@ -23,7 +23,13 @@ func descToDomain(desc *protobufs.AgentDescription) *modelagent.Description {
 	}
 }
 
-func remoteConfigStatusToDomain(remoteConfigStatus *protobufs.RemoteConfigStatus) *agentmodel.AgentRemoteConfigStatus {
+// remoteConfigStatusToDomain converts the agent's reported remote-config status. lastUpdatedAt
+// is supplied by the caller (the injected clock) rather than read from time.Now() here, so the
+// timestamp is deterministic and testable.
+func remoteConfigStatusToDomain(
+	remoteConfigStatus *protobufs.RemoteConfigStatus,
+	lastUpdatedAt time.Time,
+) *agentmodel.AgentRemoteConfigStatus {
 	if remoteConfigStatus == nil {
 		return nil
 	}
@@ -32,7 +38,7 @@ func remoteConfigStatusToDomain(remoteConfigStatus *protobufs.RemoteConfigStatus
 		LastRemoteConfigHash: remoteConfigStatus.GetLastRemoteConfigHash(),
 		Status:               agentmodel.RemoteConfigStatus(remoteConfigStatus.GetStatus()),
 		ErrorMessage:         remoteConfigStatus.GetErrorMessage(),
-		LastUpdatedAt:        time.Now(),
+		LastUpdatedAt:        lastUpdatedAt,
 	}
 }
 

--- a/pkg/apiserver/application/service/opamp/protobufstodomain_test.go
+++ b/pkg/apiserver/application/service/opamp/protobufstodomain_test.go
@@ -3,6 +3,7 @@ package opamp
 
 import (
 	"testing"
+	"time"
 
 	"github.com/open-telemetry/opamp-go/protobufs"
 	"github.com/stretchr/testify/assert"
@@ -67,4 +68,29 @@ func TestAnyValueToString(t *testing.T) {
 			assert.Equal(t, tt.want, anyValueToString(tt.in))
 		})
 	}
+}
+
+// TestRemoteConfigStatusToDomain_UsesSuppliedTimestamp pins that the converter stamps the
+// caller-supplied time (the injected clock) rather than reading time.Now() itself, so the
+// LastUpdatedAt is deterministic.
+func TestRemoteConfigStatusToDomain_UsesSuppliedTimestamp(t *testing.T) {
+	t.Parallel()
+
+	lastUpdatedAt := time.Date(2026, time.July, 21, 10, 0, 0, 0, time.UTC)
+
+	got := remoteConfigStatusToDomain(&protobufs.RemoteConfigStatus{
+		LastRemoteConfigHash: []byte{0x01},
+		Status:               protobufs.RemoteConfigStatuses_RemoteConfigStatuses_APPLIED,
+		ErrorMessage:         "",
+	}, lastUpdatedAt)
+
+	require.NotNil(t, got)
+	assert.Equal(t, lastUpdatedAt, got.LastUpdatedAt)
+}
+
+// TestRemoteConfigStatusToDomain_NilReturnsNil keeps the nil short-circuit intact.
+func TestRemoteConfigStatusToDomain_NilReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	assert.Nil(t, remoteConfigStatusToDomain(nil, time.Now()))
 }


### PR DESCRIPTION
## What

`remoteConfigStatusToDomain` read `time.Now()` directly when converting the agent's reported `remote_config_status`, making the stored `LastUpdatedAt` non-deterministic and untestable — and violating the project convention of never calling `time.Now()` in production code.

The timestamp is now supplied by the caller from `report()`'s single clock read (the same `s.clock.Now()` already used for `RecordLastReported`).

## Changes

- `protobufsToDomain.go`: `remoteConfigStatusToDomain` takes a `lastUpdatedAt time.Time` instead of calling `time.Now()`.
- `opamp.go`: `report()` captures `now := s.clock.Now()` once and passes it through.
- `protobufstodomain_test.go`: add white-box tests asserting the supplied timestamp is used and the nil short-circuit holds.
- `opamp-conformance.md`: update the `remote_config_status` row.

## Related

Closes the "hygiene" gap from the OpAMP conformance tracking issue #501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)