### PR TITLE
feat(opamp): send error_response when a message cannot be processed

### DIFF
--- a/docs/content/en/docs/opamp-conformance.md
+++ b/docs/content/en/docs/opamp-conformance.md
@@ -45,7 +45,7 @@ actually implemented.
 | `command` | ✅ | `Restart` — the only command the spec currently defines. |
 | `capabilities` | ✅ | |
 | `flags` (`ReportFullState`) | ✅ | Requested only while the agent's reported info is incomplete (its description or capabilities are still missing); not once it is complete. |
-| `error_response` | ⛔ | Never populated. |
+| `error_response` | ✅ | Sent when the server cannot process an `AgentToServer`: `Unavailable` if the agent state cannot be loaded, `BadRequest` if the reported fields cannot be absorbed. Error-only message (no desired-state fields). |
 | `custom_capabilities` | ⛔ | Always `nil` (server advertises no custom capabilities). |
 | `custom_message` | ⛔ | Always `nil`. |
 
@@ -85,7 +85,10 @@ actually implemented.
 3. **Packages: `TopLevel`-only + silent-drop** on fetch failure (tracked in #496).
 4. **Custom messages / custom capabilities** are unsupported end-to-end (server→agent always
    `nil`; agent→server `custom_message` dropped).
-5. **`error_response` is never sent**, so the agent gets no structured error signal from the server.
+5. ~~**`error_response` is never sent.**~~ *(Resolved.)* When the server cannot process an
+   incoming `AgentToServer` it now replies with an error-only `ServerToAgent`: `Unavailable`
+   when the agent's state cannot be loaded, `BadRequest` when the reported fields cannot be
+   absorbed. Processing short-circuits so no partially-applied state is persisted.
 6. **Non-string attribute values are dropped** in `toMap`, losing fidelity for identifying /
    non-identifying attributes and component metadata.
 

--- a/pkg/apiserver/application/service/opamp/opamp.go
+++ b/pkg/apiserver/application/service/opamp/opamp.go
@@ -226,8 +226,11 @@ func (s *Service) OnMessage(
 	if err != nil {
 		logger.Error("failed to get agent", slog.String("error", err.Error()))
 
-		// whan the agent cannot be retrieved, return a fallback ServerToAgent message
-		return s.createFallbackServerToAgent(instanceUID)
+		// The server could not load the agent's state, so it cannot process this message.
+		// Signal it as Unavailable (a transient server-side failure) so the agent retries.
+		return s.createErrorServerToAgent(instanceUID,
+			protobufs.ServerErrorResponseType_ServerErrorResponseType_Unavailable,
+			"failed to load agent state")
 	}
 
 	s.syncConnectionNamespace(ctx, logger, connection, agent)
@@ -240,7 +243,15 @@ func (s *Service) OnMessage(
 	// Update agent connection status
 	agent.UpdateLastCommunicationInfo(receivedAt, connection)
 
-	s.reportAndReconcileGroups(ctx, logger, message, agent, currentServer)
+	reportErr := s.reportAndReconcileGroups(ctx, logger, message, agent, currentServer)
+	if reportErr != nil {
+		// The agent's report could not be absorbed into its state. Return an error-only
+		// response (BadRequest) rather than a desired-state message the agent would ignore,
+		// and skip persistence so partially-applied state is not written.
+		return s.createErrorServerToAgent(instanceUID,
+			protobufs.ServerErrorResponseType_ServerErrorResponseType_BadRequest,
+			reportErr.Error())
+	}
 
 	s.maybePersistAgent(ctx, logger, instanceUID, message, agent, receivedAt)
 
@@ -597,13 +608,17 @@ func identityChanged(prev identitySnapshot, agent *agentmodel.Agent) bool {
 // that is the only report() input that can affect AgentGroup selectors, and skipping
 // the snapshot avoids two map allocations on every heartbeat plus a full ListAgentGroups
 // scan when agents put monotonic counters under NonIdentifyingAttributes.
+//
+// It returns the report error (if any) so the caller can surface it to the agent as an
+// error_response; on error the group reconcile is skipped because the agent's state may be
+// inconsistent.
 func (s *Service) reportAndReconcileGroups(
 	ctx context.Context,
 	logger *slog.Logger,
 	message *protobufs.AgentToServer,
 	agent *agentmodel.Agent,
 	currentServer *agentmodel.Server,
-) {
+) error {
 	hasDescription := message.GetAgentDescription() != nil
 
 	var prevIdentity identitySnapshot
@@ -614,11 +629,15 @@ func (s *Service) reportAndReconcileGroups(
 	err := s.report(agent, message, currentServer)
 	if err != nil {
 		logger.Error("failed to report agent", slog.String("error", err.Error()))
+
+		return err
 	}
 
 	if hasDescription {
 		s.maybeApplyMatchingAgentGroups(ctx, logger, agent, prevIdentity)
 	}
+
+	return nil
 }
 
 // maybePersistAgent writes the agent through the throttle if the message warrants it,

--- a/pkg/apiserver/application/service/opamp/serverToAgent.go
+++ b/pkg/apiserver/application/service/opamp/serverToAgent.go
@@ -16,13 +16,20 @@ func (s *Service) fetchServerToAgent(ctx context.Context, agentModel *agentmodel
 	return s.serverToAgentBuilder.Build(ctx, agentModel)
 }
 
-// createFallbackServerToAgent creates a fallback ServerToAgent message.
-// This is used when the agent is not found or when there is an error in creating
-// the ServerToAgent message.
-func (s *Service) createFallbackServerToAgent(
+// createErrorServerToAgent builds a ServerToAgent that carries only an error_response, giving
+// the agent a structured signal that the server could not process its message. Per the OpAMP
+// spec the agent ignores every other ServerToAgent field when error_response is set, so no
+// desired-state fields are populated here — sending them would be wasted work the agent discards.
+func (s *Service) createErrorServerToAgent(
 	instanceUID uuid.UUID,
+	errorType protobufs.ServerErrorResponseType,
+	message string,
 ) *protobufs.ServerToAgent {
 	return &protobufs.ServerToAgent{
 		InstanceUid: instanceUID[:],
+		ErrorResponse: &protobufs.ServerErrorResponse{
+			Type:         errorType,
+			ErrorMessage: message,
+		},
 	}
 }

--- a/pkg/apiserver/application/service/opamp/servertoagent_test.go
+++ b/pkg/apiserver/application/service/opamp/servertoagent_test.go
@@ -1,0 +1,41 @@
+//nolint:testpackage // white-box test of the unexported error-response builder
+package opamp
+
+import (
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/open-telemetry/opamp-go/protobufs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestCreateErrorServerToAgent pins the shape of the error-only ServerToAgent: it carries the
+// instance UID and a structured error_response, and — per the OpAMP spec, where the agent
+// ignores every other field when error_response is set — no desired-state fields.
+func TestCreateErrorServerToAgent(t *testing.T) {
+	t.Parallel()
+
+	instanceUID := uuid.New()
+	svc := &Service{}
+
+	msg := svc.createErrorServerToAgent(instanceUID,
+		protobufs.ServerErrorResponseType_ServerErrorResponseType_BadRequest,
+		"boom")
+
+	require.NotNil(t, msg)
+	assert.Equal(t, instanceUID[:], msg.GetInstanceUid())
+
+	require.NotNil(t, msg.GetErrorResponse())
+	assert.Equal(t,
+		protobufs.ServerErrorResponseType_ServerErrorResponseType_BadRequest,
+		msg.GetErrorResponse().GetType())
+	assert.Equal(t, "boom", msg.GetErrorResponse().GetErrorMessage())
+
+	// No desired-state fields must be set alongside the error.
+	assert.Nil(t, msg.GetRemoteConfig())
+	assert.Nil(t, msg.GetConnectionSettings())
+	assert.Nil(t, msg.GetPackagesAvailable())
+	assert.Nil(t, msg.GetCommand())
+	assert.Zero(t, msg.GetCapabilities())
+}


### PR DESCRIPTION
## What

The server previously always replied with a normal (or empty fallback) `ServerToAgent` even when it failed to process the agent's `AgentToServer`, so the agent got **no structured error signal** — the `error_response` field was never populated.

`OnMessage` now returns an error-only `ServerToAgent` carrying `error_response`:

- **`Unavailable`** — the agent's state could not be loaded (transient server-side failure; the agent should retry).
- **`BadRequest`** — the reported fields could not be absorbed into the agent's state. Processing short-circuits so no partially-applied state is persisted, and group reconcile is skipped.

Per the OpAMP spec the agent ignores every other `ServerToAgent` field when `error_response` is set, so the reply is error-only by design (no wasted desired-state fields).

## Changes

- `serverToAgent.go`: add `createErrorServerToAgent` helper; remove the now-unused `createFallbackServerToAgent`.
- `opamp.go`: `reportAndReconcileGroups` now returns the report error; `OnMessage` maps the agent-load and report failures to `error_response` replies.
- `servertoagent_test.go`: white-box test pinning the error-only message shape.
- `opamp-conformance.md`: mark the gap resolved.

## Related

Closes the `error_response` gap from the OpAMP conformance tracking issue #501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)