### PR TITLE
docs(opamp): refresh conformance doc for already-merged fixes

### DIFF
--- a/docs/content/en/docs/opamp-conformance.md
+++ b/docs/content/en/docs/opamp-conformance.md
@@ -11,7 +11,7 @@ handling changes.
 
 **Legend:** ✅ Implemented · 🟡 Partial · ⛔ Not implemented
 
-> Audited against `main` on 2026-07-19. Primary sources:
+> Audited against `main` on 2026-07-21. Primary sources:
 > `pkg/apiserver/application/service/opamp/{opamp,serverToAgent,protobufsToDomain,domainToProtobufs}.go`
 > and `pkg/apiserver/domain/agent/service/server.go`.
 
@@ -24,7 +24,7 @@ actually implemented.
 | ServerCapability | Advertised | Fulfilled | Notes |
 |---|:---:|:---:|---|
 | `AcceptsStatus` | ✅ | ✅ | Full `AgentToServer` ingestion via `report()`. |
-| `OffersRemoteConfig` | ✅ | ✅ | Delivered on the hot path; **omitted** on the cross-server push path (see [Known gaps](#known-gaps)). |
+| `OffersRemoteConfig` | ✅ | ✅ | Delivered by the shared `ServerToAgentBuilder` on both the hot path and the cross-server push path. |
 | `AcceptsEffectiveConfig` | ✅ | ✅ | Stored on the agent. |
 | `OffersConnectionSettings` | ✅ | ✅ | `opamp`, `own_metrics`, `own_logs`, `own_traces`, `other_connections`, each with headers + TLS certificate. |
 | `AcceptsConnectionSettingsRequest` | ✅ | ⛔ | Advertised, but `connection_settings_request` from the agent is **not processed**. |
@@ -58,7 +58,7 @@ actually implemented.
 |---|:---:|---|
 | `instance_uid` | ✅ | Incl. instance-UID conflict handling (`instanceuid_conflict.go`). |
 | `sequence_num` | ✅ | Recorded per report. |
-| `agent_description` | 🟡 | Ingested, but only string `AnyValue`s are kept — non-string attribute values are dropped (`protobufsToDomain.go`, `toMap`). |
+| `agent_description` | ✅ | Ingested; non-string `AnyValue`s are preserved in their string form (`protobufsToDomain.go`, `anyValueToString`). |
 | `capabilities` | ✅ | Stored. |
 | `health` (`ComponentHealth`) | ✅ | Incl. nested sub-component health. |
 | `effective_config` | ✅ | Stored. |
@@ -86,8 +86,9 @@ actually implemented.
 4. **Custom messages / custom capabilities** are unsupported end-to-end (server→agent always
    `nil`; agent→server `custom_message` dropped).
 5. **`error_response` is never sent**, so the agent gets no structured error signal from the server.
-6. **Non-string attribute values are dropped** in `toMap`, losing fidelity for identifying /
-   non-identifying attributes and component metadata.
+6. ~~**Non-string attribute values are dropped** in `toMap`.~~ *(Resolved in #504.)* Non-string
+   `AnyValue`s are now preserved in their string form for identifying / non-identifying
+   attributes and component metadata.
 
 ## Test coverage
 


### PR DESCRIPTION
## What

The OpAMP conformance matrix still described two gaps that `main` has already closed, so the doc understated conformance:

- **`OffersRemoteConfig`** was marked *"omitted on the cross-server push path"*, but #503 unified both delivery paths behind the shared `ServerToAgentBuilder` — remote config is delivered on both.
- **`agent_description`** was marked partial (*"only string `AnyValue`s kept"*), but #504 preserves non-string values in their string form via `anyValueToString`.

## Changes

- Update the `OffersRemoteConfig` and `agent_description` rows.
- Mark known gap #6 (non-string attributes dropped) as resolved in #504.
- Bump the audit date to 2026-07-21.

Docs-only; no code change.

## Related

Refs the OpAMP conformance tracking issue #501.

🤖 Generated with [Claude Code](https://claude.com/claude-code)