### PR TITLE
fix(agentgroup): add agent-centric reconcile pass to heal identity-change orphans

### DIFF
--- a/pkg/apiserver/domain/agent/service/agentgroup.go
+++ b/pkg/apiserver/domain/agent/service/agentgroup.go
@@ -530,12 +530,30 @@ func (s *AgentGroupService) propagateAgentGroupChangesToAgents(
 	}
 }
 
-// reconcileAll re-scans every agent group and re-applies it to its matching agents.
+// reconcileAll repairs any drift between agent groups and agents. It runs two complementary
+// passes because neither alone is sufficient:
+//   - reconcileAllGroups (group-driven) iterates groups → their matching agents. It also
+//     records the per-group and per-agent RemoteConfigApplied conditions and re-drains
+//     recently-deleted groups.
+//   - reconcileAllAgents (agent-centric) iterates every agent → the union of its matching
+//     groups. This is the only pass that catches an agent that stopped matching a still-
+//     existing group because its own identity attributes changed: from that group's point
+//     of view the agent is simply no longer a member, so the group-driven pass never
+//     revisits it to drop the group's now-stale contribution.
+//
+// Both passes are idempotent (they only write when an agent's desired spec actually
+// changed), so running them back-to-back is cheap when nothing has drifted.
+func (s *AgentGroupService) reconcileAll(ctx context.Context) {
+	s.reconcileAllGroups(ctx)
+	s.reconcileAllAgents(ctx)
+}
+
+// reconcileAllGroups re-scans every agent group and re-applies it to its matching agents.
 // updateAgentsByAgentGroup is idempotent — it only writes when the agent's desired spec
 // actually changed — so this is cheap when nothing has drifted. Recently-deleted groups
 // are processed too (see shouldReconcileDeletedGroup) so a dropped delete event still
 // results in the deleted group's config being dropped from its former members.
-func (s *AgentGroupService) reconcileAll(ctx context.Context) {
+func (s *AgentGroupService) reconcileAllGroups(ctx context.Context) {
 	groups, err := s.persistencePort.ListAgentGroups(ctx, nil)
 	if err != nil {
 		s.logger.Error("reconcile loop: failed to list agent groups",
@@ -557,6 +575,68 @@ func (s *AgentGroupService) reconcileAll(ctx context.Context) {
 				slog.String("error", err.Error()),
 			)
 		}
+	}
+}
+
+// reconcileAllAgents re-applies the union of matching agent groups to every agent, dropping
+// any config contributed by a group that no longer selects it. This is the agent-centric
+// counterpart to reconcileAllGroups: because it starts from the agent (not the group), it
+// self-heals the identity-change orphan case the group-driven pass structurally cannot — an
+// agent whose attributes changed so a still-existing group's selector no longer matches it.
+// An empty selector lists every agent across all namespaces; ApplyMatchingAgentGroupsToAgent
+// re-scopes each agent to groups in its own namespace. Idempotent: an agent whose desired
+// spec is unchanged is not written.
+func (s *AgentGroupService) reconcileAllAgents(ctx context.Context) {
+	var continueToken string
+
+	// An empty selector (no attribute constraints) matches every agent.
+	//exhaustruct:ignore
+	allAgents := agentmodel.AgentSelector{}
+
+	for {
+		agentsResp, err := s.agentUsecase.ListAgentsBySelector(ctx, allAgents, &model.ListOptions{
+			Limit:          PropagationChunkSize,
+			Continue:       continueToken,
+			IncludeDeleted: false,
+		})
+		if err != nil {
+			s.logger.Error("reconcile loop: failed to list agents for agent-centric reconcile",
+				slog.String("error", err.Error()))
+
+			return
+		}
+
+		for _, agent := range agentsResp.Items {
+			before := agentSpecFingerprint(agent)
+
+			err := s.ApplyMatchingAgentGroupsToAgent(ctx, agent)
+			if err != nil {
+				s.logger.Warn("reconcile loop: failed to apply matching groups to agent",
+					slog.String("agent", agent.Metadata.InstanceUID.String()),
+					slog.String("error", err.Error()),
+				)
+
+				continue
+			}
+
+			if before == agentSpecFingerprint(agent) {
+				continue
+			}
+
+			err = s.agentUsecase.SaveAgent(ctx, agent)
+			if err != nil {
+				s.logger.Warn("reconcile loop: failed to save agent-centric reconciled agent",
+					slog.String("agent", agent.Metadata.InstanceUID.String()),
+					slog.String("error", err.Error()),
+				)
+			}
+		}
+
+		if agentsResp.Continue == "" {
+			break
+		}
+
+		continueToken = agentsResp.Continue
 	}
 }
 

--- a/pkg/apiserver/domain/agent/service/agentgroup_internal_test.go
+++ b/pkg/apiserver/domain/agent/service/agentgroup_internal_test.go
@@ -1099,6 +1099,87 @@ func TestUpdateAgentsByAgentGroup(t *testing.T) {
 	})
 }
 
+func TestReconcileAllAgents(t *testing.T) {
+	t.Parallel()
+
+	newSvc := func() (*AgentGroupService, *mockAgentGroupPersistence, *mockAgentUsecase) {
+		mockPersistence := new(mockAgentGroupPersistence)
+		mockAgentUC := new(mockAgentUsecase)
+		svc := NewAgentGroupService(
+			mockPersistence, new(mockRemoteConfigPersistence), new(mockCertPersistence),
+			mockAgentUC, alwaysLeaderElector{}, slog.Default())
+
+		return svc, mockPersistence, mockAgentUC
+	}
+
+	// agentWithStaleConfig is an agent that still carries a group's remote config in its spec.
+	agentWithStaleConfig := func() *agentmodel.Agent {
+		a := agentmodel.NewAgent(uuid.New(), agentmodel.WithDescription(&agent.Description{
+			IdentifyingAttributes: map[string]string{"service.name": "changed"},
+		}))
+		a.Spec.RemoteConfig = &agentmodel.AgentSpecRemoteConfig{
+			ConfigMap: agentmodel.AgentConfigMap{
+				ConfigMap: map[string]agentmodel.AgentConfigFile{"prod/cfg": {Body: []byte("stale")}},
+			},
+		}
+
+		return a
+	}
+
+	t.Run("clears config from an agent no longer selected by any group (identity-change orphan)", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		svc, mockPersistence, mockAgentUC := newSvc()
+
+		orphan := agentWithStaleConfig()
+
+		// A group still exists but its selector no longer matches the agent (its identity changed).
+		group := &agentmodel.AgentGroup{
+			Metadata: agentmodel.AgentGroupMetadata{Namespace: "default", Name: "prod"},
+			Spec: agentmodel.AgentGroupSpec{
+				Selector: agentmodel.AgentSelector{
+					IdentifyingAttributes: map[string]string{"service.name": "was-matching"},
+				},
+			},
+		}
+
+		mockAgentUC.On("ListAgentsBySelector", ctx, agentmodel.AgentSelector{}, mock.Anything).
+			Return(&model.ListResponse[*agentmodel.Agent]{Items: []*agentmodel.Agent{orphan}}, nil)
+		mockPersistence.On("ListAgentGroups", mock.Anything, (*model.ListOptions)(nil)).
+			Return(&model.ListResponse[*agentmodel.AgentGroup]{Items: []*agentmodel.AgentGroup{group}}, nil)
+		// The agent drifted (config -> none), so it must be persisted with the config dropped.
+		mockAgentUC.On("SaveAgent", ctx, mock.MatchedBy(func(a *agentmodel.Agent) bool {
+			return a.Spec.RemoteConfig == nil
+		})).Return(nil)
+
+		svc.reconcileAllAgents(ctx)
+
+		mockAgentUC.AssertExpectations(t)
+	})
+
+	t.Run("does not re-save an agent whose desired spec is unchanged", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := t.Context()
+		svc, mockPersistence, mockAgentUC := newSvc()
+
+		// Agent with no config and no matching group -> desired state already matches -> no write.
+		a := agentmodel.NewAgent(uuid.New(), agentmodel.WithDescription(&agent.Description{
+			IdentifyingAttributes: map[string]string{"service.name": "changed"},
+		}))
+
+		mockAgentUC.On("ListAgentsBySelector", ctx, agentmodel.AgentSelector{}, mock.Anything).
+			Return(&model.ListResponse[*agentmodel.Agent]{Items: []*agentmodel.Agent{a}}, nil)
+		mockPersistence.On("ListAgentGroups", mock.Anything, (*model.ListOptions)(nil)).
+			Return(&model.ListResponse[*agentmodel.AgentGroup]{Items: nil}, nil)
+
+		svc.reconcileAllAgents(ctx)
+
+		mockAgentUC.AssertNotCalled(t, "SaveAgent", mock.Anything, mock.Anything)
+	})
+}
+
 // alwaysLeaderElector is a test double that always reports leadership, so the
 // reconcile loop behaves as it did before leader election was introduced.
 type alwaysLeaderElector struct{}
@@ -1120,17 +1201,28 @@ func TestAgentGroupService_reconcileAllIfLeader(t *testing.T) {
 
 	listOpts := (*model.ListOptions)(nil)
 
+	// noAgents lets the agent-centric reconcile pass (reconcileAllAgents) run to a clean
+	// no-op: it lists agents once with an empty selector and gets nothing back.
+	noAgents := func(m *mockAgentUsecase) *mockAgentUsecase {
+		m.On("ListAgentsBySelector", mock.Anything, agentmodel.AgentSelector{}, mock.Anything).
+			Return(&model.ListResponse[*agentmodel.Agent]{Items: nil}, nil)
+
+		return m
+	}
+
 	t.Run("skips the reconcile scan when not leader", func(t *testing.T) {
 		t.Parallel()
 		ctx := t.Context()
 		mockPersistence := new(mockAgentGroupPersistence)
+		mockAgentUC := new(mockAgentUsecase)
 		svc := NewAgentGroupService(
 			mockPersistence, new(mockRemoteConfigPersistence), new(mockCertPersistence),
-			new(mockAgentUsecase), fakeLeaderElector{leader: false, err: nil}, slog.Default())
+			mockAgentUC, fakeLeaderElector{leader: false, err: nil}, slog.Default())
 
 		svc.reconcileAllIfLeader(ctx)
 
 		mockPersistence.AssertNotCalled(t, "ListAgentGroups", mock.Anything, mock.Anything)
+		mockAgentUC.AssertNotCalled(t, "ListAgentsBySelector", mock.Anything, mock.Anything, mock.Anything)
 	})
 
 	t.Run("runs the reconcile scan when leader", func(t *testing.T) {
@@ -1139,13 +1231,16 @@ func TestAgentGroupService_reconcileAllIfLeader(t *testing.T) {
 		mockPersistence := new(mockAgentGroupPersistence)
 		mockPersistence.On("ListAgentGroups", mock.Anything, listOpts).
 			Return(&model.ListResponse[*agentmodel.AgentGroup]{Items: nil}, nil)
+
+		mockAgentUC := noAgents(new(mockAgentUsecase))
 		svc := NewAgentGroupService(
 			mockPersistence, new(mockRemoteConfigPersistence), new(mockCertPersistence),
-			new(mockAgentUsecase), fakeLeaderElector{leader: true, err: nil}, slog.Default())
+			mockAgentUC, fakeLeaderElector{leader: true, err: nil}, slog.Default())
 
 		svc.reconcileAllIfLeader(ctx)
 
 		mockPersistence.AssertCalled(t, "ListAgentGroups", mock.Anything, listOpts)
+		mockAgentUC.AssertCalled(t, "ListAgentsBySelector", mock.Anything, agentmodel.AgentSelector{}, mock.Anything)
 	})
 
 	t.Run("fails open and reconciles when leader election errors", func(t *testing.T) {
@@ -1154,12 +1249,15 @@ func TestAgentGroupService_reconcileAllIfLeader(t *testing.T) {
 		mockPersistence := new(mockAgentGroupPersistence)
 		mockPersistence.On("ListAgentGroups", mock.Anything, listOpts).
 			Return(&model.ListResponse[*agentmodel.AgentGroup]{Items: nil}, nil)
+
+		mockAgentUC := noAgents(new(mockAgentUsecase))
 		svc := NewAgentGroupService(
 			mockPersistence, new(mockRemoteConfigPersistence), new(mockCertPersistence),
-			new(mockAgentUsecase), fakeLeaderElector{leader: false, err: errBoomLeader}, slog.Default())
+			mockAgentUC, fakeLeaderElector{leader: false, err: errBoomLeader}, slog.Default())
 
 		svc.reconcileAllIfLeader(ctx)
 
 		mockPersistence.AssertCalled(t, "ListAgentGroups", mock.Anything, listOpts)
+		mockAgentUC.AssertCalled(t, "ListAgentsBySelector", mock.Anything, agentmodel.AgentSelector{}, mock.Anything)
 	})
 }


### PR DESCRIPTION
## Problem

Closes #497.

AgentGroup → agent remote-config reconcile was **group-driven**: the periodic loop iterated groups → their currently-matching agents. This left one orphan case the reconcile could never self-heal:

> An agent that stops matching a still-existing group because **its own identity attributes changed** (so the group's selector no longer selects it) keeps the group's contributed remote config until the OnMessage identity-change path happens to re-clear it. The 5-min reconcile loop never revisits that agent for that group, because from the group's point of view the agent is simply "not a member" anymore.

Deletion-driven orphans were already handled (`DeleteAgentGroup` propagates the tombstone's selector; `DeletedGroupReconcileWindow` re-processes recently-deleted groups). This is specifically the **identity-change** case. A disconnected agent whose attributes changed while offline could retain stale config with no reconcile safety net.

## Fix

Add an **agent-centric** reconcile pass (`reconcileAllAgents`) alongside the existing group-driven pass (`reconcileAllGroups`), both run from `reconcileAll`:

- `reconcileAllGroups` (unchanged behavior) — iterates groups → matching agents; still records the per-group / per-agent `RemoteConfigApplied` conditions and re-drains recently-deleted groups.
- `reconcileAllAgents` (new) — iterates **every** agent (empty selector) and re-applies the union of its matching groups via the existing `ApplyMatchingAgentGroupsToAgent`, dropping config from any group that no longer selects it. `ApplyMatchingAgentGroupsToAgent` re-scopes each agent to groups in its own namespace, so cross-namespace groups are not applied.

Both passes are idempotent — they only `SaveAgent` when the agent's desired spec actually drifted (via `agentSpecFingerprint`) — so running them back-to-back is cheap when nothing changed. The new pass is still gated behind the leader election and only runs on the elected node.

## Tests

- `TestReconcileAllAgents` — verifies an orphan whose identity changed has its stale config cleared and persisted, and that an already-correct agent is not re-saved.
- Updated `TestAgentGroupService_reconcileAllIfLeader` to reflect that a leader reconcile now also lists agents for the agent-centric pass (and a non-leader still does neither scan).

`go test -short ./pkg/apiserver/...` and `golangci-lint run` on the changed package both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)