### PR TITLE
fix(opamp): derive package type from spec and surface package-offer failures

### DIFF
--- a/docs/content/en/docs/opamp-conformance.md
+++ b/docs/content/en/docs/opamp-conformance.md
@@ -28,7 +28,7 @@ actually implemented.
 | `AcceptsEffectiveConfig` | ✅ | ✅ | Stored on the agent. |
 | `OffersConnectionSettings` | ✅ | ✅ | `opamp`, `own_metrics`, `own_logs`, `own_traces`, `other_connections`, each with headers + TLS certificate. |
 | `AcceptsConnectionSettingsRequest` | ⛔ | ⛔ | Intentionally **not advertised**: `connection_settings_request` is not processed, so the capability is withheld rather than claimed-but-ignored. |
-| `OffersPackages` | ✅ | 🟡 | Only `TopLevel` package type; a package-fetch failure is silently dropped (see #496). |
+| `OffersPackages` | ✅ | ✅ | Package type derives from the package spec (`TopLevel`/`AddOn`); an unresolvable package is withheld from the offer and logged, not silently dropped (#496). |
 | `AcceptsPackagesStatus` | ✅ | ✅ | Stored on the agent. |
 
 ## Server → Agent message fields
@@ -40,7 +40,7 @@ actually implemented.
 | `instance_uid` | ✅ | |
 | `remote_config` | ✅ | Built from the agent's materialized `Spec.RemoteConfig.ConfigMap` with a content hash. |
 | `connection_settings` | ✅ | Full offer set incl. TLS certificates and headers. |
-| `packages_available` | 🟡 | `TopLevel` only; silent drop on fetch failure (#496). |
+| `packages_available` | ✅ | Package type derived from the spec; an unresolvable package is withheld and logged rather than silently dropped (#496). |
 | `agent_identification` | ✅ | Sent when the server assigns a new instance UID. |
 | `command` | ✅ | `Restart` — the only command the spec currently defines. |
 | `capabilities` | ✅ | |
@@ -84,7 +84,10 @@ actually implemented.
    no longer advertises the capability, so agents are not invited to send a
    `connection_settings_request` the server would silently ignore. Re-advertise once the request
    is processed.
-3. **Packages: `TopLevel`-only + silent-drop** on fetch failure (tracked in #496).
+3. ~~**Packages: `TopLevel`-only + silent-drop** on fetch failure.~~ *(Resolved in #496.)* The
+   advertised `PackageType` now derives from the package spec (`TopLevel`/`AddOn`), and a package
+   that cannot be resolved is withheld from the offer and logged (with the agent identity and the
+   affected package names) instead of being silently dropped.
 4. **Custom messages / custom capabilities** are [intentionally unsupported](#custom-messages)
    (documented decision, not an oversight).
 5. ~~**`error_response` is never sent.**~~ *(Resolved.)* When the server cannot process an

--- a/pkg/apiserver/domain/agent/service/servertoagent.go
+++ b/pkg/apiserver/domain/agent/service/servertoagent.go
@@ -2,7 +2,9 @@ package agentservice
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"strings"
 
 	"github.com/open-telemetry/opamp-go/protobufs"
 	"github.com/samber/lo"
@@ -130,6 +132,12 @@ func (b *ServerToAgentBuilder) Build(
 
 // buildPackagesAvailable resolves each package name advertised on the agent into a
 // protobuf PackageAvailable entry, or nil when the agent has no packages to offer.
+//
+// A package that cannot be resolved is omitted from the offer (an undescribable download
+// cannot be advertised) but never silently: the unresolved names are aggregated and logged
+// once at warn level with the agent identity, so "my collector never got its package" is
+// diagnosable instead of looking like the package was simply not assigned. A resolution
+// failure for one package does not drop the others, nor the rest of the ServerToAgent.
 func (b *ServerToAgentBuilder) buildPackagesAvailable(
 	ctx context.Context,
 	agentModel *agentmodel.Agent,
@@ -142,10 +150,25 @@ func (b *ServerToAgentBuilder) buildPackagesAvailable(
 
 	agentPackages := make(map[string]*protobufs.PackageAvailable)
 
+	var unresolved []string
+
 	for _, pkgName := range agentModel.Spec.PackagesAvailable.Packages {
-		if pkg := b.resolveAvailablePackage(ctx, agentModel.Metadata.Namespace, pkgName); pkg != nil {
-			agentPackages[pkgName] = pkg
+		pkg, err := b.resolveAvailablePackage(ctx, agentModel.Metadata.Namespace, pkgName)
+		if err != nil {
+			unresolved = append(unresolved, pkgName)
+
+			continue
 		}
+
+		agentPackages[pkgName] = pkg
+	}
+
+	if len(unresolved) > 0 {
+		b.logger.Warn("some agent packages could not be resolved and were withheld from the offer",
+			slog.String("instance_uid", instanceUID.String()),
+			slog.String("namespace", agentModel.Metadata.Namespace),
+			slog.Any("unresolved_packages", unresolved),
+		)
 	}
 
 	hash, err := vo.NewHashFromAny(agentPackages)
@@ -162,23 +185,19 @@ func (b *ServerToAgentBuilder) buildPackagesAvailable(
 }
 
 // resolveAvailablePackage looks up one advertised package by name and converts it into a
-// protobuf PackageAvailable, or nil if it cannot be resolved (which skips it, so the offer
-// omits packages that are momentarily unavailable rather than failing the whole message).
+// protobuf PackageAvailable. It returns the resolution error (rather than swallowing it) so
+// the caller can surface which packages were withheld.
 func (b *ServerToAgentBuilder) resolveAvailablePackage(
 	ctx context.Context,
 	namespace, pkgName string,
-) *protobufs.PackageAvailable {
+) (*protobufs.PackageAvailable, error) {
 	agentPackage, err := b.agentPackageUsecase.GetAgentPackage(ctx, namespace, pkgName, nil)
 	if err != nil {
-		b.logger.Error("failed to get agent package", "name", pkgName, "error", err)
-
-		return nil
+		return nil, fmt.Errorf("get agent package %q: %w", pkgName, err)
 	}
 
 	return &protobufs.PackageAvailable{
-		//nolint:godox // Tracked in issue tracker
-		// TODO: Support different package types in the future
-		Type:    protobufs.PackageType_PackageType_TopLevel,
+		Type:    b.packageType(agentPackage.Spec.PackageType, pkgName),
 		Version: agentPackage.Spec.Version,
 		File: &protobufs.DownloadableFile{
 			DownloadUrl: agentPackage.Spec.DownloadURL,
@@ -191,6 +210,25 @@ func (b *ServerToAgentBuilder) resolveAvailablePackage(
 			},
 		},
 		Hash: agentPackage.Spec.Hash,
+	}, nil
+}
+
+// packageType maps an AgentPackage's spec package type to the OpAMP protobuf enum. The match
+// is case-insensitive; an empty type defaults to TopLevel. An unrecognized value also falls
+// back to TopLevel but is logged, so a typo does not silently change the advertised type.
+func (b *ServerToAgentBuilder) packageType(specType, pkgName string) protobufs.PackageType {
+	switch strings.ToLower(strings.TrimSpace(specType)) {
+	case "", "toplevel":
+		return protobufs.PackageType_PackageType_TopLevel
+	case "addon":
+		return protobufs.PackageType_PackageType_Addon
+	default:
+		b.logger.Warn("unrecognized agent package type; defaulting to TopLevel",
+			slog.String("package", pkgName),
+			slog.String("package_type", specType),
+		)
+
+		return protobufs.PackageType_PackageType_TopLevel
 	}
 }
 

--- a/pkg/apiserver/domain/agent/service/servertoagent_test.go
+++ b/pkg/apiserver/domain/agent/service/servertoagent_test.go
@@ -1,8 +1,11 @@
 package agentservice_test
 
 import (
+	"context"
+	"errors"
 	"log/slog"
 	"testing"
+	"time"
 
 	"github.com/google/uuid"
 	"github.com/open-telemetry/opamp-go/protobufs"
@@ -12,12 +15,76 @@ import (
 	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent"
 	modelagent "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/agent"
 	agentservice "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/service"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
 )
 
 // newTestBuilder builds a ServerToAgentBuilder with no package usecase: the tests here do
 // not exercise packages, so it is never invoked.
 func newTestBuilder() *agentservice.ServerToAgentBuilder {
 	return agentservice.NewServerToAgentBuilder(nil, slog.Default())
+}
+
+var (
+	errPkgUsecaseNotImplemented = errors.New("not implemented")
+	errPackageNotFound          = errors.New("package not found")
+)
+
+// fakeAgentPackageUsecase is a hand-rolled AgentPackageUsecase for the package-offer tests:
+// GetAgentPackage returns the package registered under its name, or getErr when the name is
+// unknown. Only GetAgentPackage is exercised; the rest satisfy the interface.
+type fakeAgentPackageUsecase struct {
+	packages map[string]*agentmodel.AgentPackage
+	getErr   error
+}
+
+func (f *fakeAgentPackageUsecase) GetAgentPackage(
+	_ context.Context, _ string, name string, _ *model.GetOptions,
+) (*agentmodel.AgentPackage, error) {
+	if pkg, ok := f.packages[name]; ok {
+		return pkg, nil
+	}
+
+	return nil, f.getErr
+}
+
+func (f *fakeAgentPackageUsecase) ListAgentPackages(
+	_ context.Context, _ *model.ListOptions,
+) (*model.ListResponse[*agentmodel.AgentPackage], error) {
+	return nil, errPkgUsecaseNotImplemented
+}
+
+func (f *fakeAgentPackageUsecase) SaveAgentPackage(
+	_ context.Context, pkg *agentmodel.AgentPackage,
+) (*agentmodel.AgentPackage, error) {
+	return pkg, nil
+}
+
+func (f *fakeAgentPackageUsecase) CreateAgentPackage(
+	_ context.Context, pkg *agentmodel.AgentPackage, _ string,
+) (*agentmodel.AgentPackage, error) {
+	return pkg, nil
+}
+
+func (f *fakeAgentPackageUsecase) UpdateAgentPackage(
+	_ context.Context, _ string, _ string, pkg *agentmodel.AgentPackage,
+) (*agentmodel.AgentPackage, error) {
+	return pkg, nil
+}
+
+func (f *fakeAgentPackageUsecase) DeleteAgentPackage(
+	_ context.Context, _ string, _ string, _ time.Time, _ string,
+) error {
+	return nil
+}
+
+// agentWithPackages returns an agent advertising the given package names. It carries the
+// AcceptsPackages capability so HasNewPackages() (and thus the package offer) is enabled.
+func agentWithPackages(names ...string) *agentmodel.Agent {
+	capabilities := modelagent.Capabilities(modelagent.AgentCapabilityAcceptsPackages)
+	agent := agentmodel.NewAgent(uuid.New(), agentmodel.WithCapabilities(&capabilities))
+	agent.Spec.PackagesAvailable = &agentmodel.AgentSpecPackage{Packages: names}
+
+	return agent
 }
 
 // TestServerToAgentBuilder_Build_AdvertisesServerCapabilities guards the regression that
@@ -117,4 +184,64 @@ func TestServerToAgentBuilder_Build_IncludesRemoteConfig(t *testing.T) {
 	configFile, ok := msg.GetRemoteConfig().GetConfig().GetConfigMap()["collector.yaml"]
 	require.True(t, ok, "delivered config should contain the applied file")
 	assert.Equal(t, body, configFile.GetBody())
+}
+
+// TestServerToAgentBuilder_Build_PackageType pins that the advertised PackageType derives
+// from the package spec (case-insensitive), instead of the previously hardcoded TopLevel.
+func TestServerToAgentBuilder_Build_PackageType(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		specType string
+		want     protobufs.PackageType
+	}{
+		{"empty defaults to TopLevel", "", protobufs.PackageType_PackageType_TopLevel},
+		{"TopLevel", "TopLevel", protobufs.PackageType_PackageType_TopLevel},
+		{"AddOn is mapped", "AddOn", protobufs.PackageType_PackageType_Addon},
+		{"case-insensitive addon", "addon", protobufs.PackageType_PackageType_Addon},
+		{"unknown falls back to TopLevel", "nonsense", protobufs.PackageType_PackageType_TopLevel},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			fake := &fakeAgentPackageUsecase{
+				packages: map[string]*agentmodel.AgentPackage{
+					"pkg": {Spec: agentmodel.AgentPackageSpec{PackageType: tt.specType, Version: "1.0.0"}},
+				},
+			}
+			builder := agentservice.NewServerToAgentBuilder(fake, slog.Default())
+
+			msg := builder.Build(t.Context(), agentWithPackages("pkg"))
+
+			pkg, ok := msg.GetPackagesAvailable().GetPackages()["pkg"]
+			require.True(t, ok, "package should be offered")
+			assert.Equal(t, tt.want, pkg.GetType())
+		})
+	}
+}
+
+// TestServerToAgentBuilder_Build_UnresolvedPackage guards issue #496: a package that fails
+// to resolve is withheld from the offer, but the failure does not drop the packages that DID
+// resolve, nor the rest of the ServerToAgent message.
+func TestServerToAgentBuilder_Build_UnresolvedPackage(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeAgentPackageUsecase{
+		packages: map[string]*agentmodel.AgentPackage{
+			"good": {Spec: agentmodel.AgentPackageSpec{Version: "2.0.0"}},
+		},
+		getErr: errPackageNotFound,
+	}
+	builder := agentservice.NewServerToAgentBuilder(fake, slog.Default())
+
+	msg := builder.Build(t.Context(), agentWithPackages("good", "missing"))
+
+	packages := msg.GetPackagesAvailable().GetPackages()
+	assert.Contains(t, packages, "good", "resolvable package must still be offered")
+	assert.NotContains(t, packages, "missing", "unresolvable package must be withheld")
+	// The message itself is still well-formed (capabilities advertised) despite the failure.
+	assert.NotZero(t, msg.GetCapabilities())
 }


### PR DESCRIPTION
## Problem

Closes #496.

`serverToAgent` package delivery (now in the shared `ServerToAgentBuilder`, `pkg/apiserver/domain/agent/service/servertoagent.go`) had two robustness/limitation gaps:

1. **Package fetch failure silently degrades.** When resolving a package to advertise, a failed lookup was only logged per-package and then skipped — the agent got **no `PackageAvailable`** for it, but nothing distinguished this from "not assigned". Hard to diagnose "my collector never got its package".
2. **Only `TopLevel` package type supported.** The advertised `PackageType` was hardcoded, ignoring the spec's `PackageType` field.

## Fix

Both changes stay inside the builder, which is a **pure read/delivery-path** component (its callers — the OpAMP hot path and the cross-server push path — do not persist the agent afterward). So rather than record a persisted status condition (which would mean turning a high-volume read path into a writer, with write amplification and races), the fix makes the failure **observable** and keeps delivery robust:

1. `resolveAvailablePackage` now **returns** the resolution error instead of swallowing it. `buildPackagesAvailable` aggregates the unresolved package names and logs them **once at warn** with the agent instance UID + namespace, explicitly stating they were withheld. A single package's failure does **not** drop the packages that did resolve, nor the rest of the `ServerToAgent` (hard-erroring the whole message would be worse — the agent would get no config/connection either).
2. A new `packageType` mapping derives the advertised `PackageType` from `AgentPackage.Spec.PackageType` (case-insensitive `TopLevel`/`AddOn`), defaulting to `TopLevel` for an empty value and logging an unrecognized one so a typo doesn't silently change the type. Removes the hardcode and the `TODO`.

### Why not a persisted condition?

The issue proposed mirroring the AgentGroup `RemoteConfigApplied` condition. That pattern lives on a **write path** (group apply/reconcile, which saves the agent). Package resolution failure happens at **delivery/build time** on a pure read path with no save-after, and there is currently no write path that even assigns packages to an agent. Recording a persisted condition here would require injecting agent persistence into the builder and writing on the OpAMP hot path — disproportionate and racy. Structured, aggregated, per-agent logging is the right-sized observability primitive for this path; a metric/condition can follow once a package-assignment write path exists.

## Tests

- `TestServerToAgentBuilder_Build_PackageType` — table test: empty→TopLevel, `TopLevel`, `AddOn`, case-insensitive `addon`, unknown→TopLevel.
- `TestServerToAgentBuilder_Build_UnresolvedPackage` — a resolvable + an unresolvable package: the resolvable one is still offered, the unresolvable one is withheld, and the message stays well-formed.

`go test -short ./pkg/apiserver/...` and `golangci-lint run` on the changed package both pass. Also refreshes the OpAMP conformance doc to mark #496 resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)