### PR TITLE
feat(domain): extend optimistic concurrency to agentpackage/host/endpoint (#487)

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -182,6 +182,7 @@ linters:
             - github.com/testcontainers/testcontainers-go/wait
             - github.com/google/go-github/v72/github
             - github.com/golang-jwt/jwt/v5
+            - k8s.io/utils/clock
 formatters:
   enable:
     - gci

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/agentpackage.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/agentpackage.go
@@ -1,4 +1,3 @@
-//nolint:dupl // namespaced CRUD repositories intentionally share this shape.
 package inmemory
 
 import (
@@ -35,13 +34,32 @@ func (r *AgentPackageRepository) GetAgentPackage(
 }
 
 // PutAgentPackage implements agentport.AgentPackagePersistencePort.
+//
+// Like the MongoDB adapter, this is an optimistic-concurrency write: an update
+// (ResourceVersion > 0) succeeds only if the stored version still matches, else it
+// returns [model.ErrConflict]. On success the version is incremented and written
+// back onto the passed agent package.
 func (r *AgentPackageRepository) PutAgentPackage(
 	_ context.Context, agentPackage *agentmodel.AgentPackage,
 ) (*agentmodel.AgentPackage, error) {
-	r.store.put(namespacedName{
+	key := namespacedName{
 		Namespace: agentPackage.Metadata.Namespace,
 		Name:      agentPackage.Metadata.Name,
-	}, agentPackage)
+	}
+	expected := agentPackage.Metadata.ResourceVersion
+	next := expected + 1
+
+	toStore := cloneAgentPackage(agentPackage)
+	toStore.Metadata.ResourceVersion = next
+
+	err := r.store.casPutOrCreate(key, toStore, expected, func(ap *agentmodel.AgentPackage) int64 {
+		return ap.Metadata.ResourceVersion
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	agentPackage.Metadata.ResourceVersion = next
 
 	return agentPackage, nil
 }

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/agentremoteconfig.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/agentremoteconfig.go
@@ -1,4 +1,3 @@
-//nolint:dupl // namespaced CRUD repositories intentionally share this shape.
 package inmemory
 
 import (

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/container.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/container.go
@@ -30,10 +30,28 @@ func (r *ContainerRepository) GetContainer(_ context.Context, id string) (*agent
 }
 
 // PutContainer implements agentport.ContainerPersistencePort.
+//
+// Like the MongoDB adapter, this is an optimistic-concurrency write: an update
+// (ResourceVersion > 0) succeeds only if the stored version still matches, else it
+// returns [model.ErrConflict]. On success the version is incremented and written
+// back onto the passed container.
 func (r *ContainerRepository) PutContainer(
 	_ context.Context, container *agentmodel.Container,
 ) (*agentmodel.Container, error) {
-	r.store.put(container.Metadata.ID, container)
+	expected := container.Metadata.ResourceVersion
+	next := expected + 1
+
+	toStore := cloneContainer(container)
+	toStore.Metadata.ResourceVersion = next
+
+	err := r.store.casPutOrCreate(container.Metadata.ID, toStore, expected, func(c *agentmodel.Container) int64 {
+		return c.Metadata.ResourceVersion
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	container.Metadata.ResourceVersion = next
 
 	return container, nil
 }

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/endpoint.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/endpoint.go
@@ -34,13 +34,32 @@ func (r *EndpointRepository) GetEndpoint(
 }
 
 // PutEndpoint implements agentport.EndpointPersistencePort.
+//
+// Like the MongoDB adapter, this is an optimistic-concurrency write: an update
+// (ResourceVersion > 0) succeeds only if the stored version still matches, else it
+// returns [model.ErrConflict]. On success the version is incremented and written
+// back onto the passed endpoint.
 func (r *EndpointRepository) PutEndpoint(
 	_ context.Context, endpoint *agentmodel.Endpoint,
 ) (*agentmodel.Endpoint, error) {
-	r.store.put(namespacedName{
+	key := namespacedName{
 		Namespace: endpoint.Metadata.Namespace,
 		Name:      endpoint.Metadata.Name,
-	}, endpoint)
+	}
+	expected := endpoint.Metadata.ResourceVersion
+	next := expected + 1
+
+	toStore := cloneEndpoint(endpoint)
+	toStore.Metadata.ResourceVersion = next
+
+	err := r.store.casPutOrCreate(key, toStore, expected, func(e *agentmodel.Endpoint) int64 {
+		return e.Metadata.ResourceVersion
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	endpoint.Metadata.ResourceVersion = next
 
 	return endpoint, nil
 }

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/host.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/host.go
@@ -30,8 +30,26 @@ func (r *HostRepository) GetHost(_ context.Context, id string) (*agentmodel.Host
 }
 
 // PutHost implements agentport.HostPersistencePort.
+//
+// Like the MongoDB adapter, this is an optimistic-concurrency write: an update
+// (ResourceVersion > 0) succeeds only if the stored version still matches, else it
+// returns [model.ErrConflict]. On success the version is incremented and written
+// back onto the passed host.
 func (r *HostRepository) PutHost(_ context.Context, host *agentmodel.Host) (*agentmodel.Host, error) {
-	r.store.put(host.Metadata.ID, host)
+	expected := host.Metadata.ResourceVersion
+	next := expected + 1
+
+	toStore := cloneHost(host)
+	toStore.Metadata.ResourceVersion = next
+
+	err := r.store.casPutOrCreate(host.Metadata.ID, toStore, expected, func(h *agentmodel.Host) int64 {
+		return h.Metadata.ResourceVersion
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	host.Metadata.ResourceVersion = next
 
 	return host, nil
 }

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/inmemory_test.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/inmemory_test.go
@@ -602,3 +602,146 @@ func TestServerConnectionRepository_ListFiltersByServerID(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, all.Items, 2)
 }
+
+func newTestAgentPackage(namespace, name string) *agentmodel.AgentPackage {
+	return &agentmodel.AgentPackage{
+		Metadata: agentmodel.AgentPackageMetadata{Name: name, Namespace: namespace},
+		Spec:     agentmodel.AgentPackageSpec{PackageType: "top", Version: "1.0.0"},
+		Status:   agentmodel.AgentPackageStatus{},
+	}
+}
+
+func TestAgentPackageRepository_PutOptimisticConcurrency(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo := inmemory.NewAgentPackageRepository()
+
+	// A freshly created package starts at version 0; the first write inserts it as v1.
+	pkg := newTestAgentPackage("default", "otelcol")
+	assert.Equal(t, int64(0), pkg.Metadata.ResourceVersion)
+
+	saved, err := repo.PutAgentPackage(ctx, pkg)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), saved.Metadata.ResourceVersion, "PutAgentPackage must bump the caller's version")
+
+	// Two writers load the same v1 snapshot.
+	loadA, err := repo.GetAgentPackage(ctx, "default", "otelcol", nil)
+	require.NoError(t, err)
+	loadB, err := repo.GetAgentPackage(ctx, "default", "otelcol", nil)
+	require.NoError(t, err)
+
+	// Writer A wins, advancing the stored version to v2.
+	loadA.Spec.Version = "2.0.0"
+	_, err = repo.PutAgentPackage(ctx, loadA)
+	require.NoError(t, err)
+
+	// Writer B still holds v1, so its write is rejected instead of clobbering A.
+	loadB.Spec.Version = "3.0.0"
+	_, err = repo.PutAgentPackage(ctx, loadB)
+	require.ErrorIs(t, err, model.ErrConflict)
+
+	stored, err := repo.GetAgentPackage(ctx, "default", "otelcol", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "2.0.0", stored.Spec.Version, "the losing writer must not overwrite the winner")
+	assert.Equal(t, int64(2), stored.Metadata.ResourceVersion)
+}
+
+func TestHostRepository_PutOptimisticConcurrency(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo := inmemory.NewHostRepository()
+	now := time.Date(2026, 6, 19, 0, 0, 0, 0, time.UTC)
+
+	host := agentmodel.NewHost("host-1", now)
+	assert.Equal(t, int64(0), host.Metadata.ResourceVersion)
+
+	saved, err := repo.PutHost(ctx, host)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), saved.Metadata.ResourceVersion, "PutHost must bump the caller's version")
+
+	loadA, err := repo.GetHost(ctx, "host-1")
+	require.NoError(t, err)
+	loadB, err := repo.GetHost(ctx, "host-1")
+	require.NoError(t, err)
+
+	loadA.Metadata.Name = "host-a"
+	_, err = repo.PutHost(ctx, loadA)
+	require.NoError(t, err)
+
+	loadB.Metadata.Name = "host-b"
+	_, err = repo.PutHost(ctx, loadB)
+	require.ErrorIs(t, err, model.ErrConflict)
+
+	stored, err := repo.GetHost(ctx, "host-1")
+	require.NoError(t, err)
+	assert.Equal(t, "host-a", stored.Metadata.Name, "the losing writer must not overwrite the winner")
+	assert.Equal(t, int64(2), stored.Metadata.ResourceVersion)
+}
+
+func TestContainerRepository_PutOptimisticConcurrency(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo := inmemory.NewContainerRepository()
+	now := time.Date(2026, 6, 19, 0, 0, 0, 0, time.UTC)
+
+	container := agentmodel.NewContainer("container-1", now)
+	assert.Equal(t, int64(0), container.Metadata.ResourceVersion)
+
+	saved, err := repo.PutContainer(ctx, container)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), saved.Metadata.ResourceVersion, "PutContainer must bump the caller's version")
+
+	loadA, err := repo.GetContainer(ctx, "container-1")
+	require.NoError(t, err)
+	loadB, err := repo.GetContainer(ctx, "container-1")
+	require.NoError(t, err)
+
+	loadA.Metadata.Name = "cont-a"
+	_, err = repo.PutContainer(ctx, loadA)
+	require.NoError(t, err)
+
+	loadB.Metadata.Name = "cont-b"
+	_, err = repo.PutContainer(ctx, loadB)
+	require.ErrorIs(t, err, model.ErrConflict)
+
+	stored, err := repo.GetContainer(ctx, "container-1")
+	require.NoError(t, err)
+	assert.Equal(t, "cont-a", stored.Metadata.Name, "the losing writer must not overwrite the winner")
+	assert.Equal(t, int64(2), stored.Metadata.ResourceVersion)
+}
+
+func TestEndpointRepository_PutOptimisticConcurrency(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo := inmemory.NewEndpointRepository()
+	now := time.Date(2026, 6, 19, 0, 0, 0, 0, time.UTC)
+
+	endpoint := agentmodel.NewEndpoint("default", "tempo", nil, now, "tester")
+	assert.Equal(t, int64(0), endpoint.Metadata.ResourceVersion)
+
+	saved, err := repo.PutEndpoint(ctx, endpoint)
+	require.NoError(t, err)
+	assert.Equal(t, int64(1), saved.Metadata.ResourceVersion, "PutEndpoint must bump the caller's version")
+
+	loadA, err := repo.GetEndpoint(ctx, "default", "tempo", nil)
+	require.NoError(t, err)
+	loadB, err := repo.GetEndpoint(ctx, "default", "tempo", nil)
+	require.NoError(t, err)
+
+	loadA.Spec.URL = "https://a.example.com"
+	_, err = repo.PutEndpoint(ctx, loadA)
+	require.NoError(t, err)
+
+	loadB.Spec.URL = "https://b.example.com"
+	_, err = repo.PutEndpoint(ctx, loadB)
+	require.ErrorIs(t, err, model.ErrConflict)
+
+	stored, err := repo.GetEndpoint(ctx, "default", "tempo", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "https://a.example.com", stored.Spec.URL, "the losing writer must not overwrite the winner")
+	assert.Equal(t, int64(2), stored.Metadata.ResourceVersion)
+}

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/inmemory_test.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/inmemory_test.go
@@ -680,6 +680,39 @@ func TestHostRepository_PutOptimisticConcurrency(t *testing.T) {
 	assert.Equal(t, int64(2), stored.Metadata.ResourceVersion)
 }
 
+func TestAgentRemoteConfigRepository_PutGetListSoftDelete(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	repo := inmemory.NewAgentRemoteConfigRepository()
+
+	config := &agentmodel.AgentRemoteConfig{
+		Metadata: agentmodel.AgentRemoteConfigMetadata{Name: "cfg", Namespace: "default"},
+		Spec:     agentmodel.AgentRemoteConfigSpec{Value: []byte("body"), ContentType: "text/yaml"},
+	}
+
+	_, err := repo.PutAgentRemoteConfig(ctx, config)
+	require.NoError(t, err)
+
+	got, err := repo.GetAgentRemoteConfig(ctx, "default", "cfg", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "cfg", got.Metadata.Name)
+	assert.Equal(t, []byte("body"), got.Spec.Value)
+
+	list, err := repo.ListAgentRemoteConfigs(ctx, nil)
+	require.NoError(t, err)
+	require.Len(t, list.Items, 1)
+
+	// Soft delete hides it from the default read.
+	deletedAt := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	config.Metadata.DeletedAt = &deletedAt
+	_, err = repo.PutAgentRemoteConfig(ctx, config)
+	require.NoError(t, err)
+
+	_, err = repo.GetAgentRemoteConfig(ctx, "default", "cfg", nil)
+	require.ErrorIs(t, err, model.ErrResourceNotExist)
+}
+
 func TestContainerRepository_PutOptimisticConcurrency(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/store.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/store.go
@@ -149,6 +149,22 @@ func (s *store[K, V]) casPut(key K, value V, expected int64, versionOf func(V) i
 	return nil
 }
 
+// casPutOrCreate applies the optimistic-concurrency write semantics shared by the
+// MongoDB adapter. expected 0 is a create or the first write of a
+// pre-optimistic-concurrency value that has no version yet: it upserts by key,
+// migrating that value rather than conflicting. A positive expected must match the
+// stored version or the write is rejected with [model.ErrConflict]. The value's
+// version must already be set to the next version by the caller.
+func (s *store[K, V]) casPutOrCreate(key K, value V, expected int64, versionOf func(V) int64) error {
+	if expected == 0 {
+		s.put(key, value)
+
+		return nil
+	}
+
+	return s.casPut(key, value, expected, versionOf)
+}
+
 // delete permanently removes key (hard delete). It returns
 // [port.ErrResourceNotExist] when the key is absent.
 func (s *store[K, V]) delete(key K) error {

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/agentpackage.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/agentpackage.go
@@ -1,5 +1,3 @@
-//nolint:dupl // MongoDB adapter pattern - similar structure is intentional
-//nolint:dupl // MongoDB adapter pattern - similar structure is intentional
 package mongodb
 
 import (
@@ -10,7 +8,6 @@ import (
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
-	"go.mongodb.org/mongo-driver/v2/mongo/options"
 
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/secondary/persistence/mongodb/entity"
 	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent"
@@ -114,21 +111,29 @@ func (a *AgentPackageMongoAdapter) ListAgentPackages(
 }
 
 // PutAgentPackage implements agentport.AgentPackagePersistencePort.
+//
+// PutAgentPackage is an optimistic-concurrency write: an update only succeeds when
+// the stored document's resourceVersion still equals the version the in-memory
+// agent package was loaded with, otherwise it returns [model.ErrConflict] rather
+// than silently clobbering a concurrent writer. On success the version is
+// incremented and written back onto the passed agent package.
 func (a *AgentPackageMongoAdapter) PutAgentPackage(
 	ctx context.Context, agentPackage *agentmodel.AgentPackage,
 ) (*agentmodel.AgentPackage, error) {
-	agentPackageEntity := entity.AgentPackageFromDomain(agentPackage)
 	namespace := agentPackage.Metadata.Namespace
 	name := agentPackage.Metadata.Name
+	expected := agentPackage.Metadata.ResourceVersion
+	next := expected + 1
 
-	_, err := a.collection.ReplaceOne(ctx,
-		a.filterByNamespaceAndName(namespace, name),
-		agentPackageEntity,
-		options.Replace().SetUpsert(true),
-	)
+	agentPackageEntity := entity.AgentPackageFromDomain(agentPackage)
+	agentPackageEntity.Metadata.ResourceVersion = next
+
+	err := casReplace(ctx, a.collection, a.filterByNamespaceAndName(namespace, name), agentPackageEntity, expected)
 	if err != nil {
 		return nil, fmt.Errorf("put agent package: %w", err)
 	}
+
+	agentPackage.Metadata.ResourceVersion = next
 
 	// Return the domain model directly instead of querying again
 	// This avoids issues with soft-deleted documents not being found

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/common.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/common.go
@@ -202,6 +202,48 @@ func (a *commonEntityAdapter[Entity, KeyType]) put(ctx context.Context, entity *
 	return nil
 }
 
+// casReplace performs an optimistic-concurrency upsert of doc, identified by
+// keyFilter, whose resourceVersion field has already been set to the next version.
+//
+// expected is the version the caller loaded doc at. When it is greater than 0 the
+// write matches only a stored document still at that version, so a concurrent
+// writer that advanced it makes casReplace return [model.ErrConflict] instead of
+// silently clobbering the change. expected 0 is a create (or the first write of a
+// pre-optimistic-concurrency document that has no resourceVersion field yet): it
+// upserts by key alone, so a legacy document is migrated rather than duplicated.
+//
+// If the collection carries a unique index on the logical key, a racing create is
+// rejected as a duplicate key, which casReplace also surfaces as [model.ErrConflict].
+func casReplace(
+	ctx context.Context,
+	collection *mongo.Collection,
+	keyFilter bson.M,
+	doc any,
+	expected int64,
+) error {
+	filter := maps.Clone(keyFilter)
+	if expected != 0 {
+		filter[resourceVersionFieldName] = expected
+	}
+
+	result, err := collection.ReplaceOne(ctx, filter, doc, options.Replace().SetUpsert(expected == 0))
+	if err != nil {
+		if mongo.IsDuplicateKeyError(err) {
+			return fmt.Errorf("%w: resource was created concurrently", model.ErrConflict)
+		}
+
+		return fmt.Errorf("failed to put resource to mongodb: %w", err)
+	}
+
+	// No matched (and not freshly upserted) document means the version filter did not
+	// find the expected version — another writer advanced it (or deleted the resource).
+	if result.MatchedCount == 0 && result.UpsertedCount == 0 {
+		return fmt.Errorf("%w: resource was modified concurrently", model.ErrConflict)
+	}
+
+	return nil
+}
+
 // deleteOne permanently removes the document identified by key. It returns
 // model.ErrResourceNotExist when no matching document is found.
 //

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/container.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/container.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/secondary/persistence/mongodb/entity"
@@ -22,7 +23,8 @@ const (
 
 // ContainerMongoAdapter implements the ContainerPersistencePort interface.
 type ContainerMongoAdapter struct {
-	common commonEntityAdapter[entity.Container, string]
+	collection *mongo.Collection
+	common     commonEntityAdapter[entity.Container, string]
 }
 
 // NewContainerRepository creates a new instance of ContainerMongoAdapter.
@@ -39,6 +41,7 @@ func NewContainerRepository(
 	}
 
 	return &ContainerMongoAdapter{
+		collection: collection,
 		common: newCommonAdapter(
 			logger,
 			collection,
@@ -81,15 +84,30 @@ func (a *ContainerMongoAdapter) ListContainers(
 }
 
 // PutContainer implements agentport.ContainerPersistencePort.
+//
+// PutContainer is an optimistic-concurrency write: an update only succeeds when the
+// stored document's resourceVersion still equals the version the in-memory
+// container was loaded with, otherwise it returns [model.ErrConflict] rather than
+// clobbering a concurrent writer (another HA node that discovered the same
+// container). On success the version is incremented and written back onto the
+// passed container.
 func (a *ContainerMongoAdapter) PutContainer(
 	ctx context.Context, container *agentmodel.Container,
 ) (*agentmodel.Container, error) {
-	containerEntity := entity.ContainerFromDomain(container)
+	expected := container.Metadata.ResourceVersion
+	next := expected + 1
 
-	err := a.common.put(ctx, containerEntity)
+	containerEntity := entity.ContainerFromDomain(container)
+	containerEntity.Metadata.ResourceVersion = next
+
+	filter := bson.M{entity.ContainerKeyFieldName: container.Metadata.ID}
+
+	err := casReplace(ctx, a.collection, filter, containerEntity, expected)
 	if err != nil {
 		return nil, fmt.Errorf("put container: %w", err)
 	}
+
+	container.Metadata.ResourceVersion = next
 
 	return container, nil
 }

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/endpoint.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/endpoint.go
@@ -8,7 +8,6 @@ import (
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
-	"go.mongodb.org/mongo-driver/v2/mongo/options"
 
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/secondary/persistence/mongodb/entity"
 	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent"
@@ -114,21 +113,29 @@ func (a *EndpointMongoAdapter) ListEndpoints(
 }
 
 // PutEndpoint implements agentport.EndpointPersistencePort.
+//
+// PutEndpoint is an optimistic-concurrency write: an update only succeeds when the
+// stored document's resourceVersion still equals the version the in-memory endpoint
+// was loaded with, otherwise it returns [model.ErrConflict] rather than silently
+// clobbering a concurrent writer. On success the version is incremented and written
+// back onto the passed endpoint.
 func (a *EndpointMongoAdapter) PutEndpoint(
 	ctx context.Context, endpoint *agentmodel.Endpoint,
 ) (*agentmodel.Endpoint, error) {
-	endpointEntity := entity.EndpointResourceEntityFromDomain(endpoint)
 	namespace := endpoint.Metadata.Namespace
 	name := endpoint.Metadata.Name
+	expected := endpoint.Metadata.ResourceVersion
+	next := expected + 1
 
-	_, err := a.collection.ReplaceOne(ctx,
-		a.filterByNamespaceAndName(namespace, name),
-		endpointEntity,
-		options.Replace().SetUpsert(true),
-	)
+	endpointEntity := entity.EndpointResourceEntityFromDomain(endpoint)
+	endpointEntity.Metadata.ResourceVersion = next
+
+	err := casReplace(ctx, a.collection, a.filterByNamespaceAndName(namespace, name), endpointEntity, expected)
 	if err != nil {
 		return nil, fmt.Errorf("put endpoint: %w", err)
 	}
+
+	endpoint.Metadata.ResourceVersion = next
 
 	// Return the domain model directly instead of querying again
 	// This avoids issues with soft-deleted documents not being found

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/entity/agentpackage.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/entity/agentpackage.go
@@ -28,11 +28,12 @@ type AgentPackage struct {
 
 // AgentPackageMetadata represents the metadata of an agent package.
 type AgentPackageMetadata struct {
-	Name       string            `bson:"name"`
-	Namespace  string            `bson:"namespace"`
-	Attributes map[string]string `bson:"attributes,omitempty"`
-	CreatedAt  time.Time         `bson:"createdAt"`
-	DeletedAt  *time.Time        `bson:"deletedAt,omitempty"`
+	Name            string            `bson:"name"`
+	Namespace       string            `bson:"namespace"`
+	Attributes      map[string]string `bson:"attributes,omitempty"`
+	ResourceVersion int64             `bson:"resourceVersion"` // Optimistic-concurrency token
+	CreatedAt       time.Time         `bson:"createdAt"`
+	DeletedAt       *time.Time        `bson:"deletedAt,omitempty"`
 }
 
 // AgentPackageSpec represents the specification of an agent package.
@@ -62,11 +63,12 @@ func (ap *AgentPackage) ToDomain() *agentmodel.AgentPackage {
 
 func (m *AgentPackageMetadata) toDomain() agentmodel.AgentPackageMetadata {
 	return agentmodel.AgentPackageMetadata{
-		Name:       m.Name,
-		Namespace:  m.Namespace,
-		Attributes: m.Attributes,
-		CreatedAt:  m.CreatedAt,
-		DeletedAt:  m.DeletedAt,
+		Name:            m.Name,
+		Namespace:       m.Namespace,
+		Attributes:      m.Attributes,
+		ResourceVersion: m.ResourceVersion,
+		CreatedAt:       m.CreatedAt,
+		DeletedAt:       m.DeletedAt,
 	}
 }
 
@@ -105,11 +107,12 @@ func AgentPackageFromDomain(domain *agentmodel.AgentPackage) *AgentPackage {
 
 func agentPackageMetadataFromDomain(metadata agentmodel.AgentPackageMetadata) AgentPackageMetadata {
 	return AgentPackageMetadata{
-		Name:       metadata.Name,
-		Namespace:  metadata.Namespace,
-		Attributes: metadata.Attributes,
-		CreatedAt:  metadata.CreatedAt,
-		DeletedAt:  metadata.DeletedAt,
+		Name:            metadata.Name,
+		Namespace:       metadata.Namespace,
+		Attributes:      metadata.Attributes,
+		ResourceVersion: metadata.ResourceVersion,
+		CreatedAt:       metadata.CreatedAt,
+		DeletedAt:       metadata.DeletedAt,
 	}
 }
 

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/entity/container.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/entity/container.go
@@ -26,12 +26,13 @@ type Container struct {
 
 // ContainerMetadata represents the metadata of a container.
 type ContainerMetadata struct {
-	ID          string            `bson:"id"`
-	Name        string            `bson:"name,omitempty"`
-	Labels      map[string]string `bson:"labels,omitempty"`
-	Annotations map[string]string `bson:"annotations,omitempty"`
-	FirstSeenAt time.Time         `bson:"firstSeenAt"`
-	LastSeenAt  time.Time         `bson:"lastSeenAt"`
+	ID              string            `bson:"id"`
+	Name            string            `bson:"name,omitempty"`
+	Labels          map[string]string `bson:"labels,omitempty"`
+	Annotations     map[string]string `bson:"annotations,omitempty"`
+	ResourceVersion int64             `bson:"resourceVersion"` // Optimistic-concurrency token
+	FirstSeenAt     time.Time         `bson:"firstSeenAt"`
+	LastSeenAt      time.Time         `bson:"lastSeenAt"`
 }
 
 // ContainerSpec represents the spec of a container.
@@ -57,12 +58,13 @@ type ContainerResourceStatus struct {
 func (c *Container) ToDomain() *agentmodel.Container {
 	return &agentmodel.Container{
 		Metadata: agentmodel.ContainerMetadata{
-			ID:          c.Metadata.ID,
-			Name:        c.Metadata.Name,
-			Labels:      c.Metadata.Labels,
-			Annotations: c.Metadata.Annotations,
-			FirstSeenAt: c.Metadata.FirstSeenAt,
-			LastSeenAt:  c.Metadata.LastSeenAt,
+			ID:              c.Metadata.ID,
+			Name:            c.Metadata.Name,
+			Labels:          c.Metadata.Labels,
+			Annotations:     c.Metadata.Annotations,
+			ResourceVersion: c.Metadata.ResourceVersion,
+			FirstSeenAt:     c.Metadata.FirstSeenAt,
+			LastSeenAt:      c.Metadata.LastSeenAt,
 		},
 		Spec: agentmodel.ContainerSpec{
 			Platform:  agent.Platform(c.Spec.Platform),
@@ -94,12 +96,13 @@ func ContainerFromDomain(domain *agentmodel.Container) *Container {
 			ID:      nil,
 		},
 		Metadata: ContainerMetadata{
-			ID:          domain.Metadata.ID,
-			Name:        domain.Metadata.Name,
-			Labels:      domain.Metadata.Labels,
-			Annotations: domain.Metadata.Annotations,
-			FirstSeenAt: domain.Metadata.FirstSeenAt,
-			LastSeenAt:  domain.Metadata.LastSeenAt,
+			ID:              domain.Metadata.ID,
+			Name:            domain.Metadata.Name,
+			Labels:          domain.Metadata.Labels,
+			Annotations:     domain.Metadata.Annotations,
+			ResourceVersion: domain.Metadata.ResourceVersion,
+			FirstSeenAt:     domain.Metadata.FirstSeenAt,
+			LastSeenAt:      domain.Metadata.LastSeenAt,
 		},
 		Spec: ContainerSpec{
 			Platform:         string(domain.Spec.Platform),

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/entity/endpoint.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/entity/endpoint.go
@@ -23,11 +23,12 @@ type EndpointResourceEntity struct {
 
 // EndpointResourceMetadata represents the metadata of an endpoint resource.
 type EndpointResourceMetadata struct {
-	Name       string            `bson:"name"`
-	Namespace  string            `bson:"namespace"`
-	Attributes map[string]string `bson:"attributes,omitempty"`
-	CreatedAt  time.Time         `bson:"createdAt"`
-	DeletedAt  *time.Time        `bson:"deletedAt,omitempty"`
+	Name            string            `bson:"name"`
+	Namespace       string            `bson:"namespace"`
+	Attributes      map[string]string `bson:"attributes,omitempty"`
+	ResourceVersion int64             `bson:"resourceVersion"` // Optimistic-concurrency token
+	CreatedAt       time.Time         `bson:"createdAt"`
+	DeletedAt       *time.Time        `bson:"deletedAt,omitempty"`
 }
 
 // EndpointResourceSpec represents the specification of an endpoint resource.
@@ -71,11 +72,12 @@ type EndpointResourceEntityStatus struct {
 func (e *EndpointResourceEntity) ToDomain() *agentmodel.Endpoint {
 	return &agentmodel.Endpoint{
 		Metadata: agentmodel.EndpointMetadata{
-			Name:       e.Metadata.Name,
-			Namespace:  e.Metadata.Namespace,
-			Attributes: e.Metadata.Attributes,
-			CreatedAt:  e.Metadata.CreatedAt,
-			DeletedAt:  e.Metadata.DeletedAt,
+			Name:            e.Metadata.Name,
+			Namespace:       e.Metadata.Namespace,
+			Attributes:      e.Metadata.Attributes,
+			ResourceVersion: e.Metadata.ResourceVersion,
+			CreatedAt:       e.Metadata.CreatedAt,
+			DeletedAt:       e.Metadata.DeletedAt,
 		},
 		Spec: agentmodel.EndpointSpec{
 			URL:      e.Spec.URL,
@@ -137,11 +139,12 @@ func EndpointResourceEntityFromDomain(
 	//nolint:exhaustruct // ID is set by MongoDB
 	return &EndpointResourceEntity{
 		Metadata: EndpointResourceMetadata{
-			Name:       endpoint.Metadata.Name,
-			Namespace:  endpoint.Metadata.Namespace,
-			Attributes: endpoint.Metadata.Attributes,
-			CreatedAt:  endpoint.Metadata.CreatedAt,
-			DeletedAt:  endpoint.Metadata.DeletedAt,
+			Name:            endpoint.Metadata.Name,
+			Namespace:       endpoint.Metadata.Namespace,
+			Attributes:      endpoint.Metadata.Attributes,
+			ResourceVersion: endpoint.Metadata.ResourceVersion,
+			CreatedAt:       endpoint.Metadata.CreatedAt,
+			DeletedAt:       endpoint.Metadata.DeletedAt,
 		},
 		Spec: EndpointResourceSpec{
 			URL:      endpoint.Spec.URL,

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/entity/entity_test.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/entity/entity_test.go
@@ -1,0 +1,188 @@
+package entity_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/secondary/persistence/mongodb/entity"
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/agent"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model/vo"
+)
+
+func TestAgentPackageEntity_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	deletedAt := createdAt.Add(time.Hour)
+	domainPkg := &agentmodel.AgentPackage{
+		Metadata: agentmodel.AgentPackageMetadata{
+			Name:            "otelcol",
+			Namespace:       "default",
+			Attributes:      agentmodel.Attributes{"team": "obs"},
+			ResourceVersion: 7,
+			CreatedAt:       createdAt,
+			DeletedAt:       &deletedAt,
+		},
+		Spec: agentmodel.AgentPackageSpec{
+			PackageType: "top",
+			Version:     "1.2.3",
+			DownloadURL: "https://example.com/pkg.tar.gz",
+			ContentHash: []byte{0x01, 0x02},
+			Signature:   []byte{0x03},
+			Headers:     map[string]string{"Authorization": "Bearer x"},
+			Hash:        []byte{0x04},
+		},
+		Status: agentmodel.AgentPackageStatus{
+			Conditions: []model.Condition{{Type: model.ConditionTypeCreated, Status: model.ConditionStatusTrue}},
+		},
+	}
+
+	got := entity.AgentPackageFromDomain(domainPkg).ToDomain()
+
+	assert.Equal(t, int64(7), got.Metadata.ResourceVersion, "ResourceVersion must survive the round trip")
+	assert.Equal(t, "otelcol", got.Metadata.Name)
+	assert.Equal(t, "default", got.Metadata.Namespace)
+	assert.Equal(t, agentmodel.Attributes{"team": "obs"}, got.Metadata.Attributes)
+	assert.Equal(t, createdAt, got.Metadata.CreatedAt)
+	require.NotNil(t, got.Metadata.DeletedAt)
+	assert.Equal(t, deletedAt, *got.Metadata.DeletedAt)
+	assert.Equal(t, domainPkg.Spec, got.Spec)
+	require.Len(t, got.Status.Conditions, 1)
+	assert.Equal(t, model.ConditionTypeCreated, got.Status.Conditions[0].Type)
+}
+
+func TestHostEntity_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	uid := uuid.New()
+	domainHost := &agentmodel.Host{
+		Metadata: agentmodel.HostMetadata{
+			ID:              "h-1",
+			Name:            "node-1",
+			Labels:          map[string]string{"env": "prod"},
+			Annotations:     map[string]string{"note": "x"},
+			ResourceVersion: 4,
+			FirstSeenAt:     now,
+			LastSeenAt:      now.Add(time.Minute),
+		},
+		Spec: agentmodel.HostSpec{
+			Platform: agent.PlatformVM,
+			Arch:     "amd64",
+			Type:     "m5.large",
+			OS:       vo.OS{Type: "linux", Version: "5.15"},
+			Cloud:    agent.Cloud{Provider: "aws", Platform: "aws_ec2", Region: "us-east-1"},
+		},
+		Status: agentmodel.HostStatus{
+			AgentInstanceUIDs: []uuid.UUID{uid},
+			Conditions:        []model.Condition{{Type: model.ConditionTypeCreated, Status: model.ConditionStatusTrue}},
+		},
+	}
+
+	got := entity.HostFromDomain(domainHost).ToDomain()
+
+	assert.Equal(t, int64(4), got.Metadata.ResourceVersion, "ResourceVersion must survive the round trip")
+	assert.Equal(t, "h-1", got.Metadata.ID)
+	assert.Equal(t, "node-1", got.Metadata.Name)
+	assert.Equal(t, domainHost.Spec, got.Spec)
+	require.Len(t, got.Status.AgentInstanceUIDs, 1)
+	assert.Equal(t, uid, got.Status.AgentInstanceUIDs[0])
+}
+
+func TestContainerEntity_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	uid := uuid.New()
+	domainContainer := &agentmodel.Container{
+		Metadata: agentmodel.ContainerMetadata{
+			ID:              "pod-uid",
+			Name:            "otelcol-0",
+			Labels:          map[string]string{"app": "otel"},
+			Annotations:     map[string]string{"note": "y"},
+			ResourceVersion: 9,
+			FirstSeenAt:     now,
+			LastSeenAt:      now.Add(time.Minute),
+		},
+		Spec: agentmodel.ContainerSpec{
+			Platform:  agent.PlatformKubernetes,
+			ImageName: "otel/opentelemetry-collector",
+			Runtime:   "containerd",
+			HostID:    "node-1",
+			K8s: agent.K8s{
+				PodName:       "otelcol-0",
+				PodUID:        "pod-uid",
+				NamespaceName: "monitoring",
+				NodeName:      "node-1",
+				ContainerName: "otelcol",
+			},
+		},
+		Status: agentmodel.ContainerStatus{
+			AgentInstanceUIDs: []uuid.UUID{uid},
+			Conditions:        []model.Condition{{Type: model.ConditionTypeCreated, Status: model.ConditionStatusTrue}},
+		},
+	}
+
+	got := entity.ContainerFromDomain(domainContainer).ToDomain()
+
+	assert.Equal(t, int64(9), got.Metadata.ResourceVersion, "ResourceVersion must survive the round trip")
+	assert.Equal(t, "pod-uid", got.Metadata.ID)
+	assert.Equal(t, domainContainer.Spec, got.Spec)
+	require.Len(t, got.Status.AgentInstanceUIDs, 1)
+	assert.Equal(t, uid, got.Status.AgentInstanceUIDs[0])
+}
+
+func TestEndpointEntity_RoundTrip(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	tenantSignals := &agentmodel.EndpointSignals{Metrics: true, Logs: false, Traces: false}
+	domainEndpoint := &agentmodel.Endpoint{
+		Metadata: agentmodel.EndpointMetadata{
+			Name:            "tempo",
+			Namespace:       "default",
+			Attributes:      agentmodel.Attributes{"team": "obs"},
+			ResourceVersion: 3,
+			CreatedAt:       createdAt,
+			DeletedAt:       nil,
+		},
+		Spec: agentmodel.EndpointSpec{
+			URL:      "https://tempo.example.com",
+			Protocol: "otlp",
+			Signals:  agentmodel.EndpointSignals{Metrics: false, Logs: false, Traces: true},
+			Tenants: []agentmodel.EndpointTenant{
+				{
+					Name:    "team-a",
+					Headers: map[string]string{"X-Scope-OrgID": "team-a"},
+					Tags:    map[string]string{"tier": "gold"},
+					Signals: tenantSignals,
+				},
+			},
+			MetricsQuery: &agentmodel.EndpointMetricsQuery{
+				Metrics: "sum(rate(m[5m]))",
+				Logs:    "",
+				Traces:  "",
+			},
+		},
+		Status: agentmodel.EndpointStatus{
+			Conditions: []model.Condition{{Type: model.ConditionTypeCreated, Status: model.ConditionStatusTrue}},
+		},
+	}
+
+	got := entity.EndpointResourceEntityFromDomain(domainEndpoint).ToDomain()
+
+	assert.Equal(t, int64(3), got.Metadata.ResourceVersion, "ResourceVersion must survive the round trip")
+	assert.Equal(t, "tempo", got.Metadata.Name)
+	assert.Equal(t, domainEndpoint.Spec, got.Spec)
+	require.Len(t, got.Spec.Tenants, 1)
+	require.NotNil(t, got.Spec.Tenants[0].Signals)
+	assert.True(t, got.Spec.Tenants[0].Signals.Metrics)
+	require.NotNil(t, got.Spec.MetricsQuery)
+	assert.Equal(t, "sum(rate(m[5m]))", got.Spec.MetricsQuery.Metrics)
+}

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/entity/host.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/entity/host.go
@@ -28,12 +28,13 @@ type Host struct {
 
 // HostMetadata represents the metadata of a host.
 type HostMetadata struct {
-	ID          string            `bson:"id"`
-	Name        string            `bson:"name,omitempty"`
-	Labels      map[string]string `bson:"labels,omitempty"`
-	Annotations map[string]string `bson:"annotations,omitempty"`
-	FirstSeenAt time.Time         `bson:"firstSeenAt"`
-	LastSeenAt  time.Time         `bson:"lastSeenAt"`
+	ID              string            `bson:"id"`
+	Name            string            `bson:"name,omitempty"`
+	Labels          map[string]string `bson:"labels,omitempty"`
+	Annotations     map[string]string `bson:"annotations,omitempty"`
+	ResourceVersion int64             `bson:"resourceVersion"` // Optimistic-concurrency token
+	FirstSeenAt     time.Time         `bson:"firstSeenAt"`
+	LastSeenAt      time.Time         `bson:"lastSeenAt"`
 }
 
 // HostSpec represents the spec of a host.
@@ -58,12 +59,13 @@ type HostResourceStatus struct {
 func (h *Host) ToDomain() *agentmodel.Host {
 	return &agentmodel.Host{
 		Metadata: agentmodel.HostMetadata{
-			ID:          h.Metadata.ID,
-			Name:        h.Metadata.Name,
-			Labels:      h.Metadata.Labels,
-			Annotations: h.Metadata.Annotations,
-			FirstSeenAt: h.Metadata.FirstSeenAt,
-			LastSeenAt:  h.Metadata.LastSeenAt,
+			ID:              h.Metadata.ID,
+			Name:            h.Metadata.Name,
+			Labels:          h.Metadata.Labels,
+			Annotations:     h.Metadata.Annotations,
+			ResourceVersion: h.Metadata.ResourceVersion,
+			FirstSeenAt:     h.Metadata.FirstSeenAt,
+			LastSeenAt:      h.Metadata.LastSeenAt,
 		},
 		Spec: agentmodel.HostSpec{
 			Platform: agent.Platform(h.Spec.Platform),
@@ -93,12 +95,13 @@ func HostFromDomain(domain *agentmodel.Host) *Host {
 			ID:      nil,
 		},
 		Metadata: HostMetadata{
-			ID:          domain.Metadata.ID,
-			Name:        domain.Metadata.Name,
-			Labels:      domain.Metadata.Labels,
-			Annotations: domain.Metadata.Annotations,
-			FirstSeenAt: domain.Metadata.FirstSeenAt,
-			LastSeenAt:  domain.Metadata.LastSeenAt,
+			ID:              domain.Metadata.ID,
+			Name:            domain.Metadata.Name,
+			Labels:          domain.Metadata.Labels,
+			Annotations:     domain.Metadata.Annotations,
+			ResourceVersion: domain.Metadata.ResourceVersion,
+			FirstSeenAt:     domain.Metadata.FirstSeenAt,
+			LastSeenAt:      domain.Metadata.LastSeenAt,
 		},
 		Spec: HostSpec{
 			Platform:      string(domain.Spec.Platform),

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/host.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/host.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 
+	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/secondary/persistence/mongodb/entity"
@@ -22,7 +23,8 @@ const (
 
 // HostMongoAdapter implements the HostPersistencePort interface.
 type HostMongoAdapter struct {
-	common commonEntityAdapter[entity.Host, string]
+	collection *mongo.Collection
+	common     commonEntityAdapter[entity.Host, string]
 }
 
 // NewHostRepository creates a new instance of HostMongoAdapter.
@@ -39,6 +41,7 @@ func NewHostRepository(
 	}
 
 	return &HostMongoAdapter{
+		collection: collection,
 		common: newCommonAdapter(
 			logger,
 			collection,
@@ -81,15 +84,29 @@ func (a *HostMongoAdapter) ListHosts(
 }
 
 // PutHost implements agentport.HostPersistencePort.
+//
+// PutHost is an optimistic-concurrency write: an update only succeeds when the
+// stored document's resourceVersion still equals the version the in-memory host
+// was loaded with, otherwise it returns [model.ErrConflict] rather than clobbering
+// a concurrent writer (another HA node that discovered the same host). On success
+// the version is incremented and written back onto the passed host.
 func (a *HostMongoAdapter) PutHost(
 	ctx context.Context, host *agentmodel.Host,
 ) (*agentmodel.Host, error) {
-	hostEntity := entity.HostFromDomain(host)
+	expected := host.Metadata.ResourceVersion
+	next := expected + 1
 
-	err := a.common.put(ctx, hostEntity)
+	hostEntity := entity.HostFromDomain(host)
+	hostEntity.Metadata.ResourceVersion = next
+
+	filter := bson.M{entity.HostKeyFieldName: host.Metadata.ID}
+
+	err := casReplace(ctx, a.collection, filter, hostEntity, expected)
 	if err != nil {
 		return nil, fmt.Errorf("put host: %w", err)
 	}
+
+	host.Metadata.ResourceVersion = next
 
 	return host, nil
 }

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/optimisticconcurrency_test.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/optimisticconcurrency_test.go
@@ -1,0 +1,173 @@
+package mongodb_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	mongoTestContainer "github.com/testcontainers/testcontainers-go/modules/mongodb"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/secondary/persistence/mongodb"
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+	"github.com/minuk-dev/opampcommander/pkg/testutil"
+)
+
+// TestOptimisticConcurrency verifies that the agentpackage, host, and endpoint
+// adapters reject a stale write with model.ErrConflict instead of silently
+// clobbering a concurrent writer, and bump the caller's version on success —
+// consistent with the agent adapter's optimistic-concurrency test.
+func TestOptimisticConcurrency(t *testing.T) {
+	testcontainers.SkipIfProviderIsNotHealthy(t)
+	t.Parallel()
+	base := testutil.NewBase(t)
+	ctx := t.Context()
+	mongoDBContainer, err := mongoTestContainer.Run(ctx, testMongoDBImage)
+	require.NoError(t, err)
+
+	mongoDBURI, err := mongoDBContainer.ConnectionString(ctx)
+	require.NoError(t, err)
+
+	client, err := mongo.Connect(options.Client().ApplyURI(mongoDBURI))
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, client.Disconnect(ctx))
+	})
+
+	database := client.Database("testdb")
+
+	t.Run("agent package", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		repo := mongodb.NewAgentPackageRepository(database, base.Logger)
+
+		pkg := &agentmodel.AgentPackage{
+			Metadata: agentmodel.AgentPackageMetadata{Name: "otelcol", Namespace: "default"},
+			Spec:     agentmodel.AgentPackageSpec{PackageType: "top", Version: "1.0.0"},
+			Status:   agentmodel.AgentPackageStatus{},
+		}
+		require.Equal(t, int64(0), pkg.Metadata.ResourceVersion)
+
+		saved, err := repo.PutAgentPackage(ctx, pkg)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), saved.Metadata.ResourceVersion)
+
+		loadA, err := repo.GetAgentPackage(ctx, "default", "otelcol", nil)
+		require.NoError(t, err)
+		loadB, err := repo.GetAgentPackage(ctx, "default", "otelcol", nil)
+		require.NoError(t, err)
+
+		loadA.Spec.Version = "2.0.0"
+		_, err = repo.PutAgentPackage(ctx, loadA)
+		require.NoError(t, err)
+
+		loadB.Spec.Version = "3.0.0"
+		_, err = repo.PutAgentPackage(ctx, loadB)
+		require.ErrorIs(t, err, model.ErrConflict)
+
+		stored, err := repo.GetAgentPackage(ctx, "default", "otelcol", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "2.0.0", stored.Spec.Version)
+		assert.Equal(t, int64(2), stored.Metadata.ResourceVersion)
+	})
+
+	t.Run("host", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		repo := mongodb.NewHostRepository(database, base.Logger)
+		now := time.Date(2026, 6, 19, 0, 0, 0, 0, time.UTC)
+
+		host := agentmodel.NewHost("host-1", now)
+		require.Equal(t, int64(0), host.Metadata.ResourceVersion)
+
+		saved, err := repo.PutHost(ctx, host)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), saved.Metadata.ResourceVersion)
+
+		loadA, err := repo.GetHost(ctx, "host-1")
+		require.NoError(t, err)
+		loadB, err := repo.GetHost(ctx, "host-1")
+		require.NoError(t, err)
+
+		loadA.Metadata.Name = "host-a"
+		_, err = repo.PutHost(ctx, loadA)
+		require.NoError(t, err)
+
+		loadB.Metadata.Name = "host-b"
+		_, err = repo.PutHost(ctx, loadB)
+		require.ErrorIs(t, err, model.ErrConflict)
+
+		stored, err := repo.GetHost(ctx, "host-1")
+		require.NoError(t, err)
+		assert.Equal(t, "host-a", stored.Metadata.Name)
+		assert.Equal(t, int64(2), stored.Metadata.ResourceVersion)
+	})
+
+	t.Run("container", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		repo := mongodb.NewContainerRepository(database, base.Logger)
+		now := time.Date(2026, 6, 19, 0, 0, 0, 0, time.UTC)
+
+		container := agentmodel.NewContainer("container-1", now)
+		require.Equal(t, int64(0), container.Metadata.ResourceVersion)
+
+		saved, err := repo.PutContainer(ctx, container)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), saved.Metadata.ResourceVersion)
+
+		loadA, err := repo.GetContainer(ctx, "container-1")
+		require.NoError(t, err)
+		loadB, err := repo.GetContainer(ctx, "container-1")
+		require.NoError(t, err)
+
+		loadA.Metadata.Name = "cont-a"
+		_, err = repo.PutContainer(ctx, loadA)
+		require.NoError(t, err)
+
+		loadB.Metadata.Name = "cont-b"
+		_, err = repo.PutContainer(ctx, loadB)
+		require.ErrorIs(t, err, model.ErrConflict)
+
+		stored, err := repo.GetContainer(ctx, "container-1")
+		require.NoError(t, err)
+		assert.Equal(t, "cont-a", stored.Metadata.Name)
+		assert.Equal(t, int64(2), stored.Metadata.ResourceVersion)
+	})
+
+	t.Run("endpoint", func(t *testing.T) {
+		t.Parallel()
+		ctx := t.Context()
+		repo := mongodb.NewEndpointRepository(database, base.Logger)
+		now := time.Date(2026, 6, 19, 0, 0, 0, 0, time.UTC)
+
+		endpoint := agentmodel.NewEndpoint("default", "tempo", nil, now, "tester")
+		require.Equal(t, int64(0), endpoint.Metadata.ResourceVersion)
+
+		saved, err := repo.PutEndpoint(ctx, endpoint)
+		require.NoError(t, err)
+		assert.Equal(t, int64(1), saved.Metadata.ResourceVersion)
+
+		loadA, err := repo.GetEndpoint(ctx, "default", "tempo", nil)
+		require.NoError(t, err)
+		loadB, err := repo.GetEndpoint(ctx, "default", "tempo", nil)
+		require.NoError(t, err)
+
+		loadA.Spec.URL = "https://a.example.com"
+		_, err = repo.PutEndpoint(ctx, loadA)
+		require.NoError(t, err)
+
+		loadB.Spec.URL = "https://b.example.com"
+		_, err = repo.PutEndpoint(ctx, loadB)
+		require.ErrorIs(t, err, model.ErrConflict)
+
+		stored, err := repo.GetEndpoint(ctx, "default", "tempo", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "https://a.example.com", stored.Spec.URL)
+		assert.Equal(t, int64(2), stored.Metadata.ResourceVersion)
+	})
+}

--- a/pkg/apiserver/application/helper/mapper.go
+++ b/pkg/apiserver/application/helper/mapper.go
@@ -253,8 +253,11 @@ func (mapper *Mapper) MapAPIToAgentPackage(apiModel *v1.AgentPackage) *agentmode
 			Name:       apiModel.Metadata.Name,
 			Namespace:  apiModel.Metadata.Namespace,
 			Attributes: agentmodel.OfAttributes(apiModel.Metadata.Attributes),
-			CreatedAt:  apiModel.Metadata.CreatedAt.Time,
-			DeletedAt:  nil,
+			// ResourceVersion is server-managed; a client-supplied model does not carry
+			// it. The service layer loads the stored version before writing.
+			ResourceVersion: 0,
+			CreatedAt:       apiModel.Metadata.CreatedAt.Time,
+			DeletedAt:       nil,
 		},
 		Spec: agentmodel.AgentPackageSpec{
 			PackageType: apiModel.Spec.PackageType,
@@ -490,8 +493,11 @@ func (mapper *Mapper) MapAPIToEndpoint(
 			Name:       api.Metadata.Name,
 			Namespace:  api.Metadata.Namespace,
 			Attributes: agentmodel.OfAttributes(api.Metadata.Attributes),
-			CreatedAt:  api.Metadata.CreatedAt.Time,
-			DeletedAt:  nil,
+			// ResourceVersion is server-managed; a client-supplied model does not carry
+			// it. The service layer loads the stored version before writing.
+			ResourceVersion: 0,
+			CreatedAt:       api.Metadata.CreatedAt.Time,
+			DeletedAt:       nil,
 		},
 		Spec: agentmodel.EndpointSpec{
 			URL:      api.Spec.URL,

--- a/pkg/apiserver/application/helper/mapper_test.go
+++ b/pkg/apiserver/application/helper/mapper_test.go
@@ -1,0 +1,96 @@
+package helper_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/utils/clock"
+
+	v1 "github.com/minuk-dev/opampcommander/api/v1"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/application/helper"
+)
+
+func TestMapAPIToAgentPackage(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	mapper := helper.NewMapper(clock.RealClock{}, 0)
+
+	//exhaustruct:ignore
+	apiPkg := &v1.AgentPackage{
+		Metadata: v1.AgentPackageMetadata{
+			Name:       "otelcol",
+			Namespace:  "default",
+			Attributes: v1.Attributes{"team": "obs"},
+			CreatedAt:  v1.NewTime(createdAt),
+		},
+		Spec: v1.AgentPackageSpec{
+			PackageType: "top",
+			Version:     "1.2.3",
+			DownloadURL: "https://example.com/pkg.tar.gz",
+			Headers:     map[string]string{"Authorization": "Bearer x"},
+		},
+	}
+
+	got := mapper.MapAPIToAgentPackage(apiPkg)
+
+	assert.Equal(t, "otelcol", got.Metadata.Name)
+	assert.Equal(t, "default", got.Metadata.Namespace)
+	assert.Equal(t, createdAt, got.Metadata.CreatedAt)
+	assert.Equal(t, "1.2.3", got.Spec.Version)
+	// A client-supplied model never carries the server-managed version.
+	assert.Equal(t, int64(0), got.Metadata.ResourceVersion)
+}
+
+func TestMapAPIToEndpoint(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC)
+	mapper := helper.NewMapper(clock.RealClock{}, 0)
+
+	//exhaustruct:ignore
+	apiEndpoint := &v1.Endpoint{
+		Metadata: v1.EndpointMetadata{
+			Name:       "tempo",
+			Namespace:  "default",
+			Attributes: v1.Attributes{"team": "obs"},
+			CreatedAt:  v1.NewTime(createdAt),
+		},
+		Spec: v1.EndpointSpec{
+			URL:      "https://tempo.example.com",
+			Protocol: "otlp",
+			Signals:  v1.EndpointSignals{Metrics: false, Logs: false, Traces: true},
+			Tenants: []v1.EndpointTenant{
+				{
+					Name:    "team-a",
+					Headers: map[string]string{"X-Scope-OrgID": "team-a"},
+					Signals: &v1.EndpointSignals{Metrics: true, Logs: false, Traces: false},
+				},
+			},
+			MetricsQuery: &v1.EndpointMetricsQuery{Metrics: "sum(rate(m[5m]))"},
+		},
+	}
+
+	got := mapper.MapAPIToEndpoint(apiEndpoint)
+
+	require.NotNil(t, got)
+	assert.Equal(t, "tempo", got.Metadata.Name)
+	assert.Equal(t, "https://tempo.example.com", got.Spec.URL)
+	assert.True(t, got.Spec.Signals.Traces)
+	require.Len(t, got.Spec.Tenants, 1)
+	require.NotNil(t, got.Spec.Tenants[0].Signals)
+	assert.True(t, got.Spec.Tenants[0].Signals.Metrics)
+	require.NotNil(t, got.Spec.MetricsQuery)
+	assert.Equal(t, "sum(rate(m[5m]))", got.Spec.MetricsQuery.Metrics)
+	// A client-supplied model never carries the server-managed version.
+	assert.Equal(t, int64(0), got.Metadata.ResourceVersion)
+}
+
+func TestMapAPIToEndpoint_Nil(t *testing.T) {
+	t.Parallel()
+
+	mapper := helper.NewMapper(clock.RealClock{}, 0)
+	assert.Nil(t, mapper.MapAPIToEndpoint(nil))
+}

--- a/pkg/apiserver/domain/agent/agentpackage.go
+++ b/pkg/apiserver/domain/agent/agentpackage.go
@@ -56,6 +56,13 @@ type AgentPackageMetadata struct {
 	Name       string
 	Namespace  string
 	Attributes Attributes
+	// ResourceVersion is an optimistic-concurrency token. It is 0 for an agent
+	// package that has never been persisted and is incremented by the persistence
+	// layer on every successful write. An update only succeeds if the stored version
+	// still equals the version this in-memory copy was loaded with; otherwise the
+	// persistence layer returns model.ErrConflict so a concurrent writer cannot be
+	// silently clobbered. Callers must not set this by hand — load, mutate, save.
+	ResourceVersion int64
 	// CreatedAt is the timestamp when the agent package was created.
 	CreatedAt time.Time
 	// DeletedAt is the timestamp when the agent package was soft deleted.

--- a/pkg/apiserver/domain/agent/agentpackage_test.go
+++ b/pkg/apiserver/domain/agent/agentpackage_test.go
@@ -1,0 +1,90 @@
+package agentmodel_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+)
+
+func TestAgentPackage_MarkAsCreated(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 19, 0, 0, 0, 0, time.UTC)
+	pkg := &agentmodel.AgentPackage{
+		Metadata: agentmodel.AgentPackageMetadata{Name: "pkg", Namespace: "default"},
+		Spec:     agentmodel.AgentPackageSpec{Version: "1.0.0"},
+		Status:   agentmodel.AgentPackageStatus{},
+	}
+
+	pkg.MarkAsCreated(now, "tester")
+
+	assert.Equal(t, now, pkg.Metadata.CreatedAt)
+	require.Len(t, pkg.Status.Conditions, 1)
+	assert.Equal(t, model.ConditionTypeCreated, pkg.Status.Conditions[0].Type)
+	assert.Equal(t, "tester", pkg.Status.Conditions[0].Reason)
+}
+
+func TestAgentPackage_ApplyUpdate_PreservesIdentityAndLifecycle(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2020, 1, 1, 0, 0, 0, 0, time.UTC)
+	stored := &agentmodel.AgentPackage{
+		Metadata: agentmodel.AgentPackageMetadata{
+			Name:            "pkg",
+			Namespace:       "default",
+			ResourceVersion: 5,
+			CreatedAt:       createdAt,
+			Attributes:      agentmodel.Attributes{"team": "old"},
+		},
+		Spec:   agentmodel.AgentPackageSpec{Version: "1.0.0"},
+		Status: agentmodel.AgentPackageStatus{Conditions: []model.Condition{{Type: model.ConditionTypeCreated}}},
+	}
+
+	incoming := &agentmodel.AgentPackage{
+		Metadata: agentmodel.AgentPackageMetadata{
+			Name:            "hacker",
+			Namespace:       "other",
+			ResourceVersion: 999,
+			CreatedAt:       time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC),
+			Attributes:      agentmodel.Attributes{"team": "new"},
+		},
+		Spec: agentmodel.AgentPackageSpec{Version: "2.0.0"},
+	}
+
+	stored.ApplyUpdate(incoming)
+
+	// Mutable fields are applied.
+	assert.Equal(t, "2.0.0", stored.Spec.Version)
+	assert.Equal(t, agentmodel.Attributes{"team": "new"}, stored.Metadata.Attributes)
+
+	// Immutable identity, lifecycle, and the optimistic-concurrency token are preserved.
+	assert.Equal(t, "pkg", stored.Metadata.Name)
+	assert.Equal(t, "default", stored.Metadata.Namespace)
+	assert.Equal(t, createdAt, stored.Metadata.CreatedAt)
+	assert.Equal(t, int64(5), stored.Metadata.ResourceVersion,
+		"ApplyUpdate must not let a client-supplied model rewind the version")
+	assert.Len(t, stored.Status.Conditions, 1)
+}
+
+func TestAgentPackage_MarkAsDeleted(t *testing.T) {
+	t.Parallel()
+
+	deletedAt := time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC)
+	pkg := &agentmodel.AgentPackage{
+		Metadata: agentmodel.AgentPackageMetadata{Name: "pkg", Namespace: "default"},
+		Spec:     agentmodel.AgentPackageSpec{Version: "1.0.0"},
+		Status:   agentmodel.AgentPackageStatus{},
+	}
+
+	pkg.MarkAsDeleted(deletedAt, "tester")
+
+	require.NotNil(t, pkg.Metadata.DeletedAt)
+	assert.Equal(t, deletedAt, *pkg.Metadata.DeletedAt)
+	require.Len(t, pkg.Status.Conditions, 1)
+	assert.Equal(t, model.ConditionTypeDeleted, pkg.Status.Conditions[0].Type)
+}

--- a/pkg/apiserver/domain/agent/container.go
+++ b/pkg/apiserver/domain/agent/container.go
@@ -30,6 +30,13 @@ type ContainerMetadata struct {
 	// Labels and Annotations are reserved for user-supplied metadata.
 	Labels      map[string]string
 	Annotations map[string]string
+	// ResourceVersion is an optimistic-concurrency token. It is 0 for a container
+	// that has never been persisted and is incremented by the persistence layer on
+	// every successful write. An update only succeeds if the stored version still
+	// equals the version this in-memory copy was loaded with; otherwise the
+	// persistence layer returns model.ErrConflict so a concurrent writer (another
+	// HA node discovering the same container) cannot be silently clobbered.
+	ResourceVersion int64
 	// FirstSeenAt is when the container was first discovered.
 	FirstSeenAt time.Time
 	// LastSeenAt is the most recent time an agent in this container reported.
@@ -76,12 +83,13 @@ func ContainerIDOf(desc agent.Description) string {
 func NewContainer(id string, now time.Time) *Container {
 	return &Container{
 		Metadata: ContainerMetadata{
-			ID:          id,
-			Name:        "",
-			Labels:      make(map[string]string),
-			Annotations: make(map[string]string),
-			FirstSeenAt: now,
-			LastSeenAt:  now,
+			ID:              id,
+			Name:            "",
+			Labels:          make(map[string]string),
+			Annotations:     make(map[string]string),
+			ResourceVersion: 0,
+			FirstSeenAt:     now,
+			LastSeenAt:      now,
 		},
 		Spec: ContainerSpec{
 			Platform:  agent.PlatformUnknown,

--- a/pkg/apiserver/domain/agent/endpoint.go
+++ b/pkg/apiserver/domain/agent/endpoint.go
@@ -31,6 +31,13 @@ type EndpointMetadata struct {
 	Namespace string
 	// Attributes is a map of user-supplied attributes for the endpoint.
 	Attributes Attributes
+	// ResourceVersion is an optimistic-concurrency token. It is 0 for an endpoint
+	// that has never been persisted and is incremented by the persistence layer on
+	// every successful write. An update only succeeds if the stored version still
+	// equals the version this in-memory copy was loaded with; otherwise the
+	// persistence layer returns model.ErrConflict so a concurrent writer cannot be
+	// silently clobbered. Callers must not set this by hand — load, mutate, save.
+	ResourceVersion int64
 	// CreatedAt is the timestamp when the endpoint was created.
 	CreatedAt time.Time
 	// DeletedAt is the timestamp when the endpoint was soft deleted.
@@ -121,11 +128,12 @@ func NewEndpoint(
 ) *Endpoint {
 	return &Endpoint{
 		Metadata: EndpointMetadata{
-			Name:       name,
-			Namespace:  namespace,
-			Attributes: attributes,
-			CreatedAt:  createdAt,
-			DeletedAt:  nil,
+			Name:            name,
+			Namespace:       namespace,
+			Attributes:      attributes,
+			ResourceVersion: 0,
+			CreatedAt:       createdAt,
+			DeletedAt:       nil,
 		},
 		Spec: EndpointSpec{
 			URL:          "",

--- a/pkg/apiserver/domain/agent/host.go
+++ b/pkg/apiserver/domain/agent/host.go
@@ -31,6 +31,13 @@ type HostMetadata struct {
 	// Labels and Annotations are reserved for user-supplied metadata.
 	Labels      map[string]string
 	Annotations map[string]string
+	// ResourceVersion is an optimistic-concurrency token. It is 0 for a host that
+	// has never been persisted and is incremented by the persistence layer on every
+	// successful write. An update only succeeds if the stored version still equals
+	// the version this in-memory copy was loaded with; otherwise the persistence
+	// layer returns model.ErrConflict so a concurrent writer (another HA node
+	// discovering the same host) cannot be silently clobbered.
+	ResourceVersion int64
 	// FirstSeenAt is when the host was first discovered.
 	FirstSeenAt time.Time
 	// LastSeenAt is the most recent time an agent on this host reported.
@@ -76,12 +83,13 @@ func HostIDOf(desc agent.Description) string {
 func NewHost(id string, now time.Time) *Host {
 	return &Host{
 		Metadata: HostMetadata{
-			ID:          id,
-			Name:        "",
-			Labels:      make(map[string]string),
-			Annotations: make(map[string]string),
-			FirstSeenAt: now,
-			LastSeenAt:  now,
+			ID:              id,
+			Name:            "",
+			Labels:          make(map[string]string),
+			Annotations:     make(map[string]string),
+			ResourceVersion: 0,
+			FirstSeenAt:     now,
+			LastSeenAt:      now,
 		},
 		Spec: HostSpec{
 			Platform: agent.PlatformUnknown,

--- a/pkg/apiserver/domain/agent/service/agentpackage.go
+++ b/pkg/apiserver/domain/agent/service/agentpackage.go
@@ -2,6 +2,7 @@ package agentservice
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -80,6 +81,17 @@ func (s *AgentPackageService) CreateAgentPackage(
 	agentPackage *agentmodel.AgentPackage,
 	actor string,
 ) (*agentmodel.AgentPackage, error) {
+	// Reject creating over an existing package instead of silently upserting it,
+	// which would overwrite it and rewind its optimistic-concurrency version.
+	_, err := s.persistence.GetAgentPackage(ctx, agentPackage.Metadata.Namespace, agentPackage.Metadata.Name, nil)
+	switch {
+	case err == nil:
+		return nil, fmt.Errorf("%w: agent package %q in namespace %q",
+			model.ErrResourceAlreadyExist, agentPackage.Metadata.Name, agentPackage.Metadata.Namespace)
+	case !errors.Is(err, model.ErrResourceNotExist):
+		return nil, fmt.Errorf("check existing agent package: %w", err)
+	}
+
 	agentPackage.MarkAsCreated(s.clock.Now(), actor)
 
 	created, err := s.persistence.PutAgentPackage(ctx, agentPackage)

--- a/pkg/apiserver/domain/agent/service/agentpackage_test.go
+++ b/pkg/apiserver/domain/agent/service/agentpackage_test.go
@@ -99,6 +99,74 @@ func TestAgentPackageService_CreateAgentPackage_RejectsExisting(t *testing.T) {
 	assert.Equal(t, 0, persistence.putCalls, "no write may happen when the package already exists")
 }
 
+func TestAgentPackageService_GetListSaveDelete(t *testing.T) {
+	t.Parallel()
+
+	t.Run("get delegates to persistence", func(t *testing.T) {
+		t.Parallel()
+
+		stored := &agentmodel.AgentPackage{
+			Metadata: agentmodel.AgentPackageMetadata{Name: "pkg", Namespace: "default"},
+		}
+		svc := agentservice.NewAgentPackageService(&apFakePersistence{stored: stored})
+
+		got, err := svc.GetAgentPackage(t.Context(), "default", "pkg", nil)
+		require.NoError(t, err)
+		assert.Equal(t, "pkg", got.Metadata.Name)
+	})
+
+	t.Run("get propagates not-found", func(t *testing.T) {
+		t.Parallel()
+
+		svc := agentservice.NewAgentPackageService(&apFakePersistence{})
+
+		_, err := svc.GetAgentPackage(t.Context(), "default", "missing", nil)
+		require.ErrorIs(t, err, model.ErrResourceNotExist)
+	})
+
+	t.Run("list delegates to persistence", func(t *testing.T) {
+		t.Parallel()
+
+		svc := agentservice.NewAgentPackageService(&apFakePersistence{})
+
+		resp, err := svc.ListAgentPackages(t.Context(), nil)
+		require.NoError(t, err)
+		assert.Empty(t, resp.Items)
+	})
+
+	t.Run("save writes as-is", func(t *testing.T) {
+		t.Parallel()
+
+		persistence := &apFakePersistence{}
+		svc := agentservice.NewAgentPackageService(persistence)
+		pkg := &agentmodel.AgentPackage{
+			Metadata: agentmodel.AgentPackageMetadata{Name: "pkg", Namespace: "default", ResourceVersion: 2},
+		}
+
+		_, err := svc.SaveAgentPackage(t.Context(), pkg)
+		require.NoError(t, err)
+		assert.Equal(t, 1, persistence.putCalls)
+		assert.Equal(t, int64(2), persistence.lastPut.Metadata.ResourceVersion)
+	})
+
+	t.Run("delete stamps a deletion and persists it", func(t *testing.T) {
+		t.Parallel()
+
+		stored := &agentmodel.AgentPackage{
+			Metadata: agentmodel.AgentPackageMetadata{Name: "pkg", Namespace: "default"},
+		}
+		persistence := &apFakePersistence{stored: stored}
+		svc := agentservice.NewAgentPackageService(persistence)
+
+		deletedAt := time.Date(2026, 6, 20, 0, 0, 0, 0, time.UTC)
+		require.NoError(t, svc.DeleteAgentPackage(t.Context(), "default", "pkg", deletedAt, "tester"))
+
+		require.Equal(t, 1, persistence.putCalls)
+		require.NotNil(t, persistence.lastPut.Metadata.DeletedAt)
+		assert.Equal(t, deletedAt, *persistence.lastPut.Metadata.DeletedAt)
+	})
+}
+
 func TestAgentPackageService_UpdateAgentPackage_PreservesImmutableFields(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/apiserver/domain/agent/service/agentpackage_test.go
+++ b/pkg/apiserver/domain/agent/service/agentpackage_test.go
@@ -30,6 +30,10 @@ func (f *apFakePersistence) GetAgentPackage(
 		return nil, f.getErr
 	}
 
+	if f.stored == nil {
+		return nil, model.ErrResourceNotExist
+	}
+
 	return f.stored, nil
 }
 
@@ -70,6 +74,29 @@ func TestAgentPackageService_CreateAgentPackage_Stamps(t *testing.T) {
 	cond := created.Status.Conditions[0]
 	assert.Equal(t, model.ConditionTypeCreated, cond.Type)
 	assert.Equal(t, "tester", cond.Reason, "the acting user must be stamped as the condition reason")
+}
+
+func TestAgentPackageService_CreateAgentPackage_RejectsExisting(t *testing.T) {
+	t.Parallel()
+
+	stored := &agentmodel.AgentPackage{
+		Metadata: agentmodel.AgentPackageMetadata{Name: "pkg", Namespace: "default", ResourceVersion: 5},
+		Spec:     agentmodel.AgentPackageSpec{Version: "1.0.0"},
+	}
+	persistence := &apFakePersistence{stored: stored}
+	svc := agentservice.NewAgentPackageService(persistence)
+
+	input := &agentmodel.AgentPackage{
+		Metadata: agentmodel.AgentPackageMetadata{Name: "pkg", Namespace: "default"},
+		Spec:     agentmodel.AgentPackageSpec{Version: "2.0.0"},
+	}
+
+	_, err := svc.CreateAgentPackage(t.Context(), input, "tester")
+
+	// Creating over an existing package must be rejected, not silently upsert it
+	// (which would overwrite the package and rewind its ResourceVersion).
+	require.ErrorIs(t, err, model.ErrResourceAlreadyExist)
+	assert.Equal(t, 0, persistence.putCalls, "no write may happen when the package already exists")
 }
 
 func TestAgentPackageService_UpdateAgentPackage_PreservesImmutableFields(t *testing.T) {

--- a/pkg/apiserver/domain/agent/service/container.go
+++ b/pkg/apiserver/domain/agent/service/container.go
@@ -1,4 +1,3 @@
-//nolint:dupl // Host and Container discovery services intentionally share this shape.
 package agentservice
 
 import (
@@ -56,6 +55,10 @@ func (s *ContainerService) ListContainers(
 }
 
 // ObserveAgent implements [agentport.ContainerUsecase].
+//
+// Like host discovery, this is a read-modify-write retried on
+// [model.ErrConflict] so a concurrent writer (another HA node discovering the same
+// container) does not drop this agent's association.
 func (s *ContainerService) ObserveAgent(ctx context.Context, agent *agentmodel.Agent) error {
 	id := agentmodel.ContainerIDOf(agent.Metadata.Description)
 	if id == "" {
@@ -65,21 +68,27 @@ func (s *ContainerService) ObserveAgent(ctx context.Context, agent *agentmodel.A
 
 	now := s.clock.Now()
 
-	container, err := s.persistence.GetContainer(ctx, id)
-	if err != nil {
-		if !errors.Is(err, model.ErrResourceNotExist) {
-			return fmt.Errorf("failed to get container for discovery: %w", err)
+	for attempt := 0; ; attempt++ {
+		container, err := s.persistence.GetContainer(ctx, id)
+		if err != nil {
+			if !errors.Is(err, model.ErrResourceNotExist) {
+				return fmt.Errorf("failed to get container for discovery: %w", err)
+			}
+
+			container = agentmodel.NewContainer(id, now)
 		}
 
-		container = agentmodel.NewContainer(id, now)
-	}
+		container.ObserveAgent(agent.Metadata.InstanceUID, agent.Metadata.Description, now)
 
-	container.ObserveAgent(agent.Metadata.InstanceUID, agent.Metadata.Description, now)
+		_, err = s.persistence.PutContainer(ctx, container)
+		if err == nil {
+			return nil
+		}
 
-	_, err = s.persistence.PutContainer(ctx, container)
-	if err != nil {
+		if errors.Is(err, model.ErrConflict) && attempt < discoveryObserveConflictRetries {
+			continue
+		}
+
 		return fmt.Errorf("failed to save discovered container: %w", err)
 	}
-
-	return nil
 }

--- a/pkg/apiserver/domain/agent/service/container_test.go
+++ b/pkg/apiserver/domain/agent/service/container_test.go
@@ -119,4 +119,21 @@ func TestContainerServiceObserveAgent(t *testing.T) {
 		persistence.AssertNotCalled(t, "GetContainer")
 		persistence.AssertNotCalled(t, "PutContainer")
 	})
+
+	t.Run("retries the read-modify-write when a concurrent writer wins", func(t *testing.T) {
+		t.Parallel()
+
+		persistence := &MockContainerPersistencePort{}
+		svc := agentservice.NewContainerService(persistence, fixedClock{now: now})
+		a := containerAgent(t)
+		existing := agentmodel.NewContainer("pod-uid", now.Add(-time.Hour))
+
+		persistence.On("GetContainer", mock.Anything, "pod-uid").Return(existing, nil)
+		persistence.On("PutContainer", mock.Anything, mock.Anything).Return(nil, model.ErrConflict).Once()
+		persistence.On("PutContainer", mock.Anything, mock.Anything).Return(&agentmodel.Container{}, nil).Once()
+
+		require.NoError(t, svc.ObserveAgent(context.Background(), a))
+		persistence.AssertNumberOfCalls(t, "PutContainer", 2)
+		persistence.AssertExpectations(t)
+	})
 }

--- a/pkg/apiserver/domain/agent/service/host.go
+++ b/pkg/apiserver/domain/agent/service/host.go
@@ -1,4 +1,3 @@
-//nolint:dupl // Host and Container discovery services intentionally share this shape.
 package agentservice
 
 import (
@@ -56,6 +55,12 @@ func (s *HostService) ListHosts(
 }
 
 // ObserveAgent implements [agentport.HostUsecase].
+//
+// Discovery is a read-modify-write, so a concurrent writer (another HA node
+// discovering the same host) can make PutHost return [model.ErrConflict]. Rather
+// than dropping this agent's association until its next report, the whole cycle is
+// retried on conflict so the losing write re-reads the winner's version and merges
+// onto it.
 func (s *HostService) ObserveAgent(ctx context.Context, agent *agentmodel.Agent) error {
 	id := agentmodel.HostIDOf(agent.Metadata.Description)
 	if id == "" {
@@ -65,21 +70,33 @@ func (s *HostService) ObserveAgent(ctx context.Context, agent *agentmodel.Agent)
 
 	now := s.clock.Now()
 
-	host, err := s.persistence.GetHost(ctx, id)
-	if err != nil {
-		if !errors.Is(err, model.ErrResourceNotExist) {
-			return fmt.Errorf("failed to get host for discovery: %w", err)
+	for attempt := 0; ; attempt++ {
+		host, err := s.persistence.GetHost(ctx, id)
+		if err != nil {
+			if !errors.Is(err, model.ErrResourceNotExist) {
+				return fmt.Errorf("failed to get host for discovery: %w", err)
+			}
+
+			host = agentmodel.NewHost(id, now)
 		}
 
-		host = agentmodel.NewHost(id, now)
-	}
+		host.ObserveAgent(agent.Metadata.InstanceUID, agent.Metadata.Description, now)
 
-	host.ObserveAgent(agent.Metadata.InstanceUID, agent.Metadata.Description, now)
+		_, err = s.persistence.PutHost(ctx, host)
+		if err == nil {
+			return nil
+		}
 
-	_, err = s.persistence.PutHost(ctx, host)
-	if err != nil {
+		if errors.Is(err, model.ErrConflict) && attempt < discoveryObserveConflictRetries {
+			continue
+		}
+
 		return fmt.Errorf("failed to save discovered host: %w", err)
 	}
-
-	return nil
 }
+
+// discoveryObserveConflictRetries bounds how many times a host/container discovery
+// read-modify-write is retried when a concurrent writer wins the optimistic-
+// concurrency race. A small bound is enough: contention is between the few agents
+// on one machine, and any residual loss self-heals on the next agent report.
+const discoveryObserveConflictRetries = 3

--- a/pkg/apiserver/domain/agent/service/host_test.go
+++ b/pkg/apiserver/domain/agent/service/host_test.go
@@ -137,4 +137,37 @@ func TestHostServiceObserveAgent(t *testing.T) {
 		assert.Equal(t, now, existing.Metadata.LastSeenAt)
 		persistence.AssertExpectations(t)
 	})
+
+	t.Run("retries the read-modify-write when a concurrent writer wins", func(t *testing.T) {
+		t.Parallel()
+
+		persistence := &MockHostPersistencePort{}
+		svc := agentservice.NewHostService(persistence, fixedClock{now: now})
+		a := hostAgent(t)
+		existing := agentmodel.NewHost("h-1", now.Add(-time.Hour))
+
+		persistence.On("GetHost", mock.Anything, "h-1").Return(existing, nil)
+		// The first write loses the optimistic-concurrency race; the retry re-reads
+		// and succeeds instead of dropping this agent's observation.
+		persistence.On("PutHost", mock.Anything, mock.Anything).Return(nil, model.ErrConflict).Once()
+		persistence.On("PutHost", mock.Anything, mock.Anything).Return(&agentmodel.Host{}, nil).Once()
+
+		require.NoError(t, svc.ObserveAgent(context.Background(), a))
+		persistence.AssertNumberOfCalls(t, "PutHost", 2)
+		persistence.AssertExpectations(t)
+	})
+
+	t.Run("gives up and surfaces the conflict after exhausting retries", func(t *testing.T) {
+		t.Parallel()
+
+		persistence := &MockHostPersistencePort{}
+		svc := agentservice.NewHostService(persistence, fixedClock{now: now})
+		a := hostAgent(t)
+		existing := agentmodel.NewHost("h-1", now.Add(-time.Hour))
+
+		persistence.On("GetHost", mock.Anything, "h-1").Return(existing, nil)
+		persistence.On("PutHost", mock.Anything, mock.Anything).Return(nil, model.ErrConflict)
+
+		require.ErrorIs(t, svc.ObserveAgent(context.Background(), a), model.ErrConflict)
+	})
 }

--- a/pkg/apiserver/internal/module/infrastructure/bootstrap.go
+++ b/pkg/apiserver/internal/module/infrastructure/bootstrap.go
@@ -309,6 +309,31 @@ func applyEndpoint(ctx context.Context, doc manifestDoc, deps bootstrapDeps) err
 
 	desired := helper.NewMapper(deps.clk, 0).MapAPIToEndpoint(&apiEndpoint)
 
+	// The endpoint is versioned (optimistic concurrency), so a concurrent apiserver
+	// startup applying the same manifest can lose the compare-and-swap and get
+	// model.ErrConflict. Retry by re-reading: the winner has already written the
+	// desired spec, so the next pass converges (equal -> skip) instead of failing
+	// startup. Bootstrap must stay idempotent across concurrent HA processes.
+	for attempt := 0; ; attempt++ {
+		err = reconcileBootstrapEndpoint(ctx, deps, namespace, name, desired)
+		if err == nil || !errors.Is(err, model.ErrConflict) || attempt >= bootstrapConflictRetries {
+			return err
+		}
+	}
+}
+
+// bootstrapConflictRetries bounds how many times a bootstrap endpoint write is
+// re-read and retried after losing an optimistic-concurrency race to another
+// apiserver applying the same manifest.
+const bootstrapConflictRetries = 3
+
+// reconcileBootstrapEndpoint creates the endpoint when absent, or updates it in
+// place when the manifest changes its spec/attributes, leaving it untouched when
+// already in the desired state. It may return a wrapped model.ErrConflict, which
+// applyEndpoint retries.
+func reconcileBootstrapEndpoint(
+	ctx context.Context, deps bootstrapDeps, namespace, name string, desired *agentmodel.Endpoint,
+) error {
 	existing, err := deps.endpointUsecase.GetEndpoint(ctx, namespace, name, nil)
 	if err != nil && !errors.Is(err, model.ErrResourceNotExist) {
 		return fmt.Errorf("check endpoint %q/%q: %w", namespace, name, err)

--- a/pkg/apiserver/internal/module/infrastructure/bootstrap_internal_test.go
+++ b/pkg/apiserver/internal/module/infrastructure/bootstrap_internal_test.go
@@ -1,6 +1,7 @@
 package infrastructure
 
 import (
+	"context"
 	"log/slog"
 	"path/filepath"
 	"testing"
@@ -12,7 +13,9 @@ import (
 
 	inmemory "github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/secondary/persistence/inmemory"
 	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent"
+	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
 	agentservice "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/service"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
 	usermodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/user"
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/security"
 	"github.com/minuk-dev/opampcommander/pkg/utils/clock"
@@ -368,6 +371,70 @@ spec:
 
 	// Reconciliation is idempotent: a second apply must not error.
 	require.NoError(t, applyManifests(t.Context(), docs, deps))
+}
+
+// conflictOnceEndpointUsecase wraps an EndpointUsecase and returns model.ErrConflict
+// on the first SaveEndpoint call, simulating losing a bootstrap optimistic-
+// concurrency race to a concurrent apiserver before succeeding on retry.
+type conflictOnceEndpointUsecase struct {
+	agentport.EndpointUsecase
+
+	saveCalls int
+}
+
+func (w *conflictOnceEndpointUsecase) SaveEndpoint(
+	ctx context.Context, endpoint *agentmodel.Endpoint,
+) (*agentmodel.Endpoint, error) {
+	w.saveCalls++
+	if w.saveCalls == 1 {
+		return nil, model.ErrConflict
+	}
+
+	return w.EndpointUsecase.SaveEndpoint(ctx, endpoint) //nolint:wrapcheck // test delegate
+}
+
+func TestApplyManifests_EndpointUpdateRetriesOnConflict(t *testing.T) {
+	t.Parallel()
+
+	deps, _, _ := newTestDeps()
+	endpointRepo := inmemory.NewEndpointRepository()
+	delegate := agentservice.NewEndpointService(endpointRepo)
+
+	// Seed an existing endpoint whose spec differs from the manifest, so bootstrap
+	// takes the update path (the only one that can hit a version conflict).
+	seeded := agentmodel.NewEndpoint("default", "vm", nil, deps.clk.Now(), "system")
+	seeded.Spec.URL = "http://old/insert"
+	_, err := delegate.SaveEndpoint(t.Context(), seeded)
+	require.NoError(t, err)
+
+	wrapper := &conflictOnceEndpointUsecase{EndpointUsecase: delegate}
+	deps.endpointUsecase = wrapper
+
+	dir := writeManifests(t, deps.fs, map[string]string{
+		"30-endpoint.yaml": `kind: Endpoint
+apiVersion: v1
+metadata:
+  name: vm
+  namespace: default
+spec:
+  url: http://vm/insert
+  protocol: prometheusremotewrite
+  signals:
+    metrics: true
+`,
+	})
+
+	docs, err := loadManifestDocs(deps.fs, dir)
+	require.NoError(t, err)
+
+	// The first write loses the race; applyEndpoint must re-read and retry rather
+	// than fail startup, so the manifest still converges.
+	require.NoError(t, applyManifests(t.Context(), docs, deps))
+	assert.GreaterOrEqual(t, wrapper.saveCalls, 2, "the conflicting write must be retried")
+
+	got, err := endpointRepo.GetEndpoint(t.Context(), "default", "vm", nil)
+	require.NoError(t, err)
+	assert.Equal(t, "http://vm/insert", got.Spec.URL, "the desired spec must win after the retry")
 }
 
 func TestApplyManifests_EndpointRequiresNamespace(t *testing.T) {


### PR DESCRIPTION
Closes #487.

## Problem

PR #465/#471 gave the `agent` aggregate version-based optimistic concurrency so concurrent writers can't silently overwrite each other. The remaining aggregates persisted with a full-document upsert and **no version guard**, so concurrent read-modify-write cycles (another HA node's discovery pass, a racing API update) clobbered each other via last-writer-wins.

This applies the same pattern to `agentpackage`, `host`, and `endpoint` — plus `container`, which is the structurally identical discovery aggregate to `host` and shared the same exposure.

## Change

- **`ResourceVersion int64`** added to each domain metadata + MongoDB entity. It is `0` for an unpersisted resource and is incremented by the persistence layer on every successful write, then written back onto the caller's copy.
- **MongoDB** (`casReplace`, shared helper): a version-filtered `ReplaceOne`. On an update (`expected > 0`) a stale write matches no document → `model.ErrConflict` instead of overwriting the winner. A create (`expected == 0`) upserts by key alone, which also **migrates a legacy document** that predates the field rather than failing on it.
- **In-memory** (`store.casPutOrCreate`): mirrors the same semantics for standalone mode.

Conflict plumbing is reused from the agent work: `model.ErrConflict` already maps to **HTTP 409** in `ginutil.HandleDomainError`, and the in-memory store already returns it. So API callers (agentpackage/endpoint CRUD) now get a `409`-and-retry instead of a silent lost update, and the host/container discovery upserts self-heal on the next agent report.

### Deliberately out of scope
- No new unique indexes: a unique index on a soft-deletable `namespace+name` resource would permanently burn a name via its tombstone, and one on the existing `hosts` collection could fail `EnsureSchema` at startup if legacy duplicates exist. The create path stays permissive/migration-safe; the fix targets the **lost-update-on-update** the issue describes.
- The public API DTOs are unchanged — `ResourceVersion` is server-managed and not yet exposed for client-driven OCC.

## Tests
- In-memory: version-bump + stale-write-conflict for agentpackage, host, endpoint, container (`inmemory_test.go`) — run without Docker.
- MongoDB: equivalent testcontainer suite (`optimisticconcurrency_test.go`), consistent with the existing agent adapter test; Docker-gated (runs in CI / `make test`).
- `golangci-lint run ./...` clean; `go test -short ./...` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)