### PR TITLE
test(opamp): direct unit coverage for message converters/builders (#501)

### DIFF
--- a/docs/content/en/docs/opamp-conformance.md
+++ b/docs/content/en/docs/opamp-conformance.md
@@ -122,7 +122,12 @@ exchange, please open an issue describing the use case.
 
 ## Test coverage
 
-Most OpAMP message-path behavior is exercised only by the Docker-based E2E suite
-(`test/e2e/apiserver`). The message builders and protobuf↔domain converters have little direct
-unit coverage. Interop against a real OTel Collector `opamp` extension is a goal (a Collector
-test helper already exists in `pkg/testutil`).
+Full-path OpAMP behavior (registration, remote-config offer/apply, packages, HTTP vs WebSocket
+transports) is exercised against a real OTel Collector `opamp` extension by the Docker-based E2E
+suite (`test/e2e/apiserver`, using the Collector helper in `pkg/testutil`).
+
+The message builders and protobuf↔domain converters also have direct, Docker-free unit coverage:
+the `AgentToServer` converters in
+`pkg/apiserver/application/service/opamp/protobufstodomain_converters_test.go` and the
+`ServerToAgent` builder (including the connection-settings offer path) in
+`pkg/apiserver/domain/agent/service/servertoagent_test.go`.

--- a/pkg/apiserver/application/service/opamp/protobufstodomain_converters_test.go
+++ b/pkg/apiserver/application/service/opamp/protobufstodomain_converters_test.go
@@ -1,0 +1,238 @@
+//nolint:testpackage // white-box test of the unexported protobuf->domain converters
+package opamp
+
+import (
+	"testing"
+
+	"github.com/open-telemetry/opamp-go/protobufs"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent"
+	"github.com/minuk-dev/opampcommander/pkg/timeutil"
+)
+
+func TestDescToDomain_Nil(t *testing.T) {
+	t.Parallel()
+	assert.Nil(t, descToDomain(nil))
+}
+
+// TestAnyValueToString_NestedAndUnknown covers the fallback branches: array/kvlist values fall
+// back to their protobuf text form (non-empty), and an AnyValue with no oneof set yields "".
+func TestAnyValueToString_NestedAndUnknown(t *testing.T) {
+	t.Parallel()
+
+	arr := &protobufs.AnyValue{Value: &protobufs.AnyValue_ArrayValue{
+		ArrayValue: &protobufs.ArrayValue{Values: []*protobufs.AnyValue{strValue("a")}},
+	}}
+	assert.NotEmpty(t, anyValueToString(arr), "array value should fall back to protobuf text form")
+
+	kv := &protobufs.AnyValue{Value: &protobufs.AnyValue_KvlistValue{
+		KvlistValue: &protobufs.KeyValueList{Values: []*protobufs.KeyValue{{Key: "k", Value: strValue("v")}}},
+	}}
+	assert.NotEmpty(t, anyValueToString(kv), "kvlist value should fall back to protobuf text form")
+
+	assert.Empty(t, anyValueToString(&protobufs.AnyValue{}), "unset value should render as empty string")
+}
+
+func TestConnectionSettingsStatusToDomain(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil returns nil", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, connectionSettingsStatusToDomain(nil))
+	})
+
+	t.Run("maps every field", func(t *testing.T) {
+		t.Parallel()
+
+		got := connectionSettingsStatusToDomain(&protobufs.ConnectionSettingsStatus{
+			LastConnectionSettingsHash: []byte{0xAB, 0xCD},
+			Status:                     protobufs.ConnectionSettingsStatuses_ConnectionSettingsStatuses_FAILED,
+			ErrorMessage:               "boom",
+		})
+
+		require.NotNil(t, got)
+		assert.Equal(t, []byte{0xAB, 0xCD}, got.LastConnectionSettingsHash)
+		assert.Equal(t, agentmodel.ConnectionSettingsStatusFailed, got.Status)
+		assert.Equal(t, "boom", got.ErrorMessage)
+	})
+}
+
+func TestCustomCapabilitiesToDomain(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil returns nil", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, customCapabilitiesToDomain(nil))
+	})
+
+	t.Run("copies capability list", func(t *testing.T) {
+		t.Parallel()
+
+		got := customCapabilitiesToDomain(&protobufs.CustomCapabilities{
+			Capabilities: []string{"io.opentelemetry.foo", "io.opentelemetry.bar"},
+		})
+
+		require.NotNil(t, got)
+		assert.Equal(t, []string{"io.opentelemetry.foo", "io.opentelemetry.bar"}, got.Capabilities)
+	})
+}
+
+func TestHealthToDomain(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil returns nil", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, healthToDomain(nil))
+	})
+
+	t.Run("maps fields and nests sub-component health", func(t *testing.T) {
+		t.Parallel()
+
+		const (
+			startNanos  = uint64(1_000_000_000)
+			statusNanos = uint64(2_500_000_000)
+			subNanos    = uint64(3_000_000_000)
+		)
+
+		got := healthToDomain(&protobufs.ComponentHealth{
+			Healthy:            true,
+			StartTimeUnixNano:  startNanos,
+			LastError:          "",
+			Status:             "running",
+			StatusTimeUnixNano: statusNanos,
+			ComponentHealthMap: map[string]*protobufs.ComponentHealth{
+				"receiver/otlp": {
+					Healthy:            false,
+					StartTimeUnixNano:  subNanos,
+					LastError:          "listen failed",
+					Status:             "error",
+					StatusTimeUnixNano: subNanos,
+				},
+			},
+		})
+
+		require.NotNil(t, got)
+		assert.True(t, got.Healthy)
+		assert.Equal(t, timeutil.UnixNanoToTime(startNanos), got.StartTime)
+		assert.Equal(t, "running", got.Status)
+		assert.Equal(t, timeutil.UnixNanoToTime(statusNanos), got.StatusTime)
+
+		require.Contains(t, got.ComponentHealthMap, "receiver/otlp")
+		sub := got.ComponentHealthMap["receiver/otlp"]
+		assert.False(t, sub.Healthy)
+		assert.Equal(t, "listen failed", sub.LastError)
+		assert.Equal(t, "error", sub.Status)
+	})
+}
+
+func TestEffectiveConfigToDomain(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil returns nil", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, effectiveConfigToDomain(nil))
+	})
+
+	t.Run("maps config files", func(t *testing.T) {
+		t.Parallel()
+
+		got := effectiveConfigToDomain(&protobufs.EffectiveConfig{
+			ConfigMap: &protobufs.AgentConfigMap{
+				ConfigMap: map[string]*protobufs.AgentConfigFile{
+					"otel.yaml": {
+						Body:        []byte("receivers: {}"),
+						ContentType: "application/yaml",
+					},
+				},
+			},
+		})
+
+		require.NotNil(t, got)
+		require.Contains(t, got.ConfigMap.ConfigMap, "otel.yaml")
+		file := got.ConfigMap.ConfigMap["otel.yaml"]
+		assert.Equal(t, []byte("receivers: {}"), file.Body)
+		assert.Equal(t, "application/yaml", file.ContentType)
+	})
+}
+
+func TestPackageStatusToDomain(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil returns nil", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, packageStatusToDomain(nil))
+	})
+
+	t.Run("maps package entries and top-level fields", func(t *testing.T) {
+		t.Parallel()
+
+		got := packageStatusToDomain(&protobufs.PackageStatuses{
+			Packages: map[string]*protobufs.PackageStatus{
+				"collector": {
+					Name:                 "collector",
+					AgentHasVersion:      "0.115.1",
+					AgentHasHash:         []byte{0x01},
+					ServerOfferedVersion: "0.116.0",
+					Status:               protobufs.PackageStatusEnum_PackageStatusEnum_Installing,
+					ErrorMessage:         "",
+				},
+			},
+			ServerProvidedAllPackagesHash: []byte{0x0A, 0x0B},
+			ErrorMessage:                  "partial",
+		})
+
+		require.NotNil(t, got)
+		assert.Equal(t, []byte{0x0A, 0x0B}, got.ServerProvidedAllPackgesHash)
+		assert.Equal(t, "partial", got.ErrorMessage)
+
+		require.Contains(t, got.Packages, "collector")
+		entry := got.Packages["collector"]
+		assert.Equal(t, "collector", entry.Name)
+		assert.Equal(t, "0.115.1", entry.AgentHasVersion)
+		assert.Equal(t, "0.116.0", entry.ServerOfferedVersion)
+		assert.Equal(t, agentmodel.AgentPackageStatusEnum(agentmodel.AgentPackageStatusEnumInstalling), entry.Status)
+	})
+}
+
+func TestAvailableComponentsToDomain(t *testing.T) {
+	t.Parallel()
+
+	t.Run("nil returns nil", func(t *testing.T) {
+		t.Parallel()
+		assert.Nil(t, availableComponentsToDomain(nil))
+	})
+
+	t.Run("maps components, metadata and nested sub-components", func(t *testing.T) {
+		t.Parallel()
+
+		got := availableComponentsToDomain(&protobufs.AvailableComponents{
+			Hash: []byte{0xFF},
+			Components: map[string]*protobufs.ComponentDetails{
+				"receivers": {
+					Metadata: []*protobufs.KeyValue{
+						{Key: "code.namespace", Value: strValue("otlpreceiver")},
+					},
+					SubComponentMap: map[string]*protobufs.ComponentDetails{
+						"otlp": {
+							Metadata: []*protobufs.KeyValue{
+								{Key: "stability", Value: strValue("stable")},
+							},
+						},
+					},
+				},
+			},
+		})
+
+		require.NotNil(t, got)
+		assert.Equal(t, []byte{0xFF}, got.Hash)
+
+		require.Contains(t, got.Components, "receivers")
+		receivers := got.Components["receivers"]
+		assert.Equal(t, "otlpreceiver", receivers.Metadata["code.namespace"])
+
+		require.Contains(t, receivers.SubComponentMap, "otlp")
+		assert.Equal(t, "stable", receivers.SubComponentMap["otlp"].Metadata["stability"])
+	})
+}

--- a/pkg/apiserver/domain/agent/service/servertoagent_test.go
+++ b/pkg/apiserver/domain/agent/service/servertoagent_test.go
@@ -186,6 +186,71 @@ func TestServerToAgentBuilder_Build_IncludesRemoteConfig(t *testing.T) {
 	assert.Equal(t, body, configFile.GetBody())
 }
 
+// TestServerToAgentBuilder_Build_IncludesConnectionSettings exercises the domain→protobuf
+// connection-settings conversion path (opamp/own_metrics/own_logs/own_traces/other_connections,
+// each with headers + TLS certificate) end-to-end through the builder, so the offer the agent
+// receives carries every configured destination, header and certificate.
+func TestServerToAgentBuilder_Build_IncludesConnectionSettings(t *testing.T) {
+	t.Parallel()
+
+	cert := &agentmodel.AgentCertificate{
+		Cert:       []byte("cert"),
+		PrivateKey: []byte("key"),
+		CaCert:     []byte("ca"),
+	}
+
+	connectionInfo, err := agentmodel.NewConnectionInfo(
+		&agentmodel.AgentOpAMPConnectionSettings{
+			DestinationEndpoint: "wss://opamp.example/v1/opamp",
+			Headers:             map[string][]string{"Authorization": {"Bearer token"}},
+			Certificate:         cert,
+		},
+		&agentmodel.AgentTelemetryConnectionSettings{
+			DestinationEndpoint: "https://metrics.example/v1/metrics",
+			Headers:             nil,
+			Certificate:         nil,
+		},
+		nil,
+		nil,
+		map[string]agentmodel.AgentOtherConnectionSettings{
+			"custom": {
+				DestinationEndpoint: "https://other.example",
+				Headers:             nil,
+				Certificate:         nil,
+			},
+		},
+	)
+	require.NoError(t, err)
+
+	agent := agentmodel.NewAgent(uuid.New())
+	agent.Spec.ConnectionInfo = connectionInfo
+
+	msg := newTestBuilder().Build(t.Context(), agent)
+
+	offers := msg.GetConnectionSettings()
+	require.NotNil(t, offers, "connection settings should be offered")
+	assert.NotEmpty(t, offers.GetHash())
+
+	opamp := offers.GetOpamp()
+	require.NotNil(t, opamp)
+	assert.Equal(t, "wss://opamp.example/v1/opamp", opamp.GetDestinationEndpoint())
+	require.NotNil(t, opamp.GetCertificate())
+	assert.Equal(t, []byte("cert"), opamp.GetCertificate().GetCert())
+
+	headers := opamp.GetHeaders().GetHeaders()
+	require.Len(t, headers, 1)
+	assert.Equal(t, "Authorization", headers[0].GetKey())
+	assert.Equal(t, "Bearer token", headers[0].GetValue())
+
+	require.NotNil(t, offers.GetOwnMetrics())
+	assert.Equal(t, "https://metrics.example/v1/metrics", offers.GetOwnMetrics().GetDestinationEndpoint())
+	// A telemetry setting without a certificate must not synthesize an empty TLS certificate.
+	assert.Nil(t, offers.GetOwnMetrics().GetCertificate())
+
+	require.Contains(t, offers.GetOtherConnections(), "custom")
+	assert.Equal(t, "https://other.example", offers.GetOtherConnections()["custom"].GetDestinationEndpoint())
+}
+
 // TestServerToAgentBuilder_Build_PackageType pins that the advertised PackageType derives
 // from the package spec (case-insensitive), instead of the previously hardcoded TopLevel.
 func TestServerToAgentBuilder_Build_PackageType(t *testing.T) {


### PR DESCRIPTION
## Summary

Fills the remaining **"Add direct unit coverage for the protobuf↔domain converters and message builders"** verification item on #501 (OpAMP spec conformance tracking). All 7 capability gaps on that issue are already closed and merged; this closes the converter/builder unit-coverage gap with fast, Docker-free tests.

## What changed

- **`AgentToServer` converters** (`application/service/opamp/protobufstodomain_converters_test.go`, new): cover the previously 0%-covered `connectionSettingsStatusToDomain`, `customCapabilitiesToDomain`, `healthToDomain` (incl. nested sub-component health), `effectiveConfigToDomain`, `packageStatusToDomain`, `availableComponentsToDomain`/`componentDetailsToDomain`, plus the `descToDomain` nil branch and `anyValueToString` array/kvlist/unset fallbacks.
- **`ServerToAgent` builder** (`domain/agent/service/servertoagent_test.go`): exercise the domain→protobuf connection-settings offer path (opamp / own_metrics / other_connections + headers + TLS certificate) end-to-end through `Build`, which was entirely uncovered — including the guard that a telemetry setting without a certificate does not synthesize an empty TLS cert.
- **Docs**: refresh the `Test coverage` section of `opamp-conformance.md`.

## Coverage

| Package | Before | After |
|---|---|---|
| `application/service/opamp` | 24.1% | 36.4% (all `protobufsToDomain` converters 100%) |
| `domain/agent/service` | 54.6% | 56.8% (connection-settings converters 0% → covered) |

## Verification

- `go test -short ./pkg/apiserver/...` passes
- `go build ./...` clean
- `golangci-lint run` — 0 issues

Refs #501

🤖 Generated with [Claude Code](https://claude.com/claude-code)