### PR TITLE
test(adapter): extend repository parity suite to agent and agentgroup (#495)

### DIFF
--- a/pkg/apiserver/adapter/secondary/persistence/parity/agent_parity_test.go
+++ b/pkg/apiserver/adapter/secondary/persistence/parity/agent_parity_test.go
@@ -1,0 +1,199 @@
+package parity_test
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/secondary/persistence/inmemory"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/secondary/persistence/mongodb"
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
+)
+
+// agentBackend reduces one Agent repository implementation to the operations the
+// agent parity contract needs. Agents are keyed by instance UID, are hard-deleted
+// (no soft delete), and carry optimistic-concurrency versions — so this is a
+// dedicated contract rather than the shared namespaced/soft-delete one.
+type agentBackend struct {
+	name          string
+	put           func(ctx context.Context, agent *agentmodel.Agent) error
+	get           func(ctx context.Context, uid uuid.UUID) (*agentmodel.Agent, error)
+	del           func(ctx context.Context, uid uuid.UUID) error
+	listNamespace func(ctx context.Context, ns string) ([]*agentmodel.Agent, error)
+}
+
+func makeAgent(ns, marker string) *agentmodel.Agent {
+	agent := agentmodel.NewAgent(uuid.New())
+	agent.Metadata.Namespace = ns
+	agent.Metadata.Description.IdentifyingAttributes = map[string]string{"marker": marker}
+
+	return agent
+}
+
+func agentMarker(agent *agentmodel.Agent) string {
+	return agent.Metadata.Description.IdentifyingAttributes["marker"]
+}
+
+func setAgentMarker(agent *agentmodel.Agent, marker string) {
+	agent.Metadata.Description.IdentifyingAttributes = map[string]string{"marker": marker}
+}
+
+// TestParity_Agent runs the agent-specific contract against both backends.
+func TestParity_Agent(t *testing.T) {
+	t.Parallel()
+
+	runAgentContract(t, inmemoryAgentBackend())
+
+	if testing.Short() {
+		return
+	}
+
+	testcontainers.SkipIfProviderIsNotHealthy(t)
+	runAgentContract(t, mongoAgentBackend(startMongoDatabase(t)))
+}
+
+func inmemoryAgentBackend() agentBackend {
+	repo := inmemory.NewAgentRepository()
+
+	return agentBackend{
+		name: "inmemory",
+		put:  repo.PutAgent,
+		get:  repo.GetAgent,
+		del:  repo.DeleteAgent,
+		listNamespace: func(ctx context.Context, ns string) ([]*agentmodel.Agent, error) {
+			resp, err := repo.ListAgents(ctx, ns, nil)
+			if err != nil {
+				return nil, fmt.Errorf("parity list: %w", err)
+			}
+
+			return resp.Items, nil
+		},
+	}
+}
+
+func mongoAgentBackend(db *mongo.Database) agentBackend {
+	repo := mongodb.NewAgentRepository(db, slog.Default())
+
+	return agentBackend{
+		name: "mongodb",
+		put:  repo.PutAgent,
+		get:  repo.GetAgent,
+		del:  repo.DeleteAgent,
+		listNamespace: func(ctx context.Context, ns string) ([]*agentmodel.Agent, error) {
+			resp, err := repo.ListAgents(ctx, ns, nil)
+			if err != nil {
+				return nil, fmt.Errorf("parity list: %w", err)
+			}
+
+			return resp.Items, nil
+		},
+	}
+}
+
+//nolint:thelper // subtest bodies are the assertions themselves, not helpers
+func runAgentContract(t *testing.T, b agentBackend) {
+	ctx := context.Background()
+
+	t.Run("agent/"+b.name+"/put_get_roundtrip", func(t *testing.T) {
+		t.Parallel()
+
+		agent := makeAgent(uniqueNamespace("rt"), "v1")
+		require.NoError(t, b.put(ctx, agent))
+
+		got, err := b.get(ctx, agent.Metadata.InstanceUID)
+		require.NoError(t, err)
+		assert.Equal(t, "v1", agentMarker(got), "stored marker must round-trip")
+	})
+
+	t.Run("agent/"+b.name+"/get_missing_is_not_found", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := b.get(ctx, uuid.New())
+		require.ErrorIs(t, err, model.ErrResourceNotExist)
+	})
+
+	t.Run("agent/"+b.name+"/delete_removes_then_not_found", func(t *testing.T) {
+		t.Parallel()
+
+		agent := makeAgent(uniqueNamespace("del"), "v1")
+		require.NoError(t, b.put(ctx, agent))
+
+		require.NoError(t, b.del(ctx, agent.Metadata.InstanceUID))
+
+		_, err := b.get(ctx, agent.Metadata.InstanceUID)
+		require.ErrorIs(t, err, model.ErrResourceNotExist)
+
+		// Deleting a missing agent reports not-found.
+		require.ErrorIs(t, b.del(ctx, agent.Metadata.InstanceUID), model.ErrResourceNotExist)
+	})
+
+	t.Run("agent/"+b.name+"/namespace_isolation", func(t *testing.T) {
+		t.Parallel()
+
+		nsA, nsB := uniqueNamespace("iso-a"), uniqueNamespace("iso-b")
+
+		inA := makeAgent(nsA, "from-a")
+		require.NoError(t, b.put(ctx, inA))
+		require.NoError(t, b.put(ctx, makeAgent(nsB, "from-b")))
+
+		listA, err := b.listNamespace(ctx, nsA)
+		require.NoError(t, err)
+		require.Len(t, listA, 1)
+		assert.Equal(t, inA.Metadata.InstanceUID, listA[0].Metadata.InstanceUID)
+	})
+
+	t.Run("agent/"+b.name+"/get_returns_isolated_copy", func(t *testing.T) {
+		t.Parallel()
+
+		agent := makeAgent(uniqueNamespace("copy"), "original")
+		require.NoError(t, b.put(ctx, agent))
+
+		got, err := b.get(ctx, agent.Metadata.InstanceUID)
+		require.NoError(t, err)
+
+		// Mutating a Get result must not leak into the store.
+		setAgentMarker(got, "mutated")
+		got.Status.Connected = true
+
+		reread, err := b.get(ctx, agent.Metadata.InstanceUID)
+		require.NoError(t, err)
+		assert.Equal(t, "original", agentMarker(reread), "mutation must not leak into the store")
+		assert.False(t, reread.Status.Connected)
+	})
+
+	t.Run("agent/"+b.name+"/optimistic_concurrency", func(t *testing.T) {
+		t.Parallel()
+
+		agent := makeAgent(uniqueNamespace("occ"), "v1")
+		require.Equal(t, int64(0), agent.Metadata.ResourceVersion)
+
+		require.NoError(t, b.put(ctx, agent))
+		assert.Equal(t, int64(1), agent.Metadata.ResourceVersion, "first put inserts at v1 and bumps the caller")
+
+		loadA, err := b.get(ctx, agent.Metadata.InstanceUID)
+		require.NoError(t, err)
+		loadB, err := b.get(ctx, agent.Metadata.InstanceUID)
+		require.NoError(t, err)
+
+		// Writer A wins, advancing the stored version to v2.
+		setAgentMarker(loadA, "from-a")
+		require.NoError(t, b.put(ctx, loadA))
+
+		// Writer B still holds v1, so its write is rejected rather than clobbering A.
+		setAgentMarker(loadB, "from-b")
+		require.ErrorIs(t, b.put(ctx, loadB), model.ErrConflict)
+
+		stored, err := b.get(ctx, agent.Metadata.InstanceUID)
+		require.NoError(t, err)
+		assert.Equal(t, "from-a", agentMarker(stored), "the losing writer must not overwrite the winner")
+		assert.Equal(t, int64(2), stored.Metadata.ResourceVersion)
+	})
+}

--- a/pkg/apiserver/adapter/secondary/persistence/parity/agentgroup_parity_test.go
+++ b/pkg/apiserver/adapter/secondary/persistence/parity/agentgroup_parity_test.go
@@ -1,0 +1,197 @@
+package parity_test
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/testcontainers/testcontainers-go"
+	"go.mongodb.org/mongo-driver/v2/mongo"
+
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/secondary/persistence/inmemory"
+	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/secondary/persistence/mongodb"
+	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent"
+)
+
+// TestParity_AgentGroup reuses the shared namespaced/soft-delete contract for the
+// agent-group port. PutAgentGroup takes namespace and name separately, so the put
+// closure forwards them from the group's own metadata.
+func TestParity_AgentGroup(t *testing.T) {
+	t.Parallel()
+	runAggregateParity(t, agentGroupAggregate())
+}
+
+func agentGroupAggregate() aggregate[*agentmodel.AgentGroup] {
+	// ListAgentGroups is not namespace-scoped, so filter client-side to keep the
+	// shared contract's namespace assertions uniform across aggregates.
+	filterNS := func(items []*agentmodel.AgentGroup, ns string) []*agentmodel.AgentGroup {
+		out := make([]*agentmodel.AgentGroup, 0, len(items))
+		for _, it := range items {
+			if it.Metadata.Namespace == ns {
+				out = append(out, it)
+			}
+		}
+
+		return out
+	}
+
+	putVia := func(
+		put func(ctx context.Context, ns, name string, g *agentmodel.AgentGroup) (*agentmodel.AgentGroup, error),
+	) func(ctx context.Context, g *agentmodel.AgentGroup) (*agentmodel.AgentGroup, error) {
+		return func(ctx context.Context, g *agentmodel.AgentGroup) (*agentmodel.AgentGroup, error) {
+			return put(ctx, g.Metadata.Namespace, g.Metadata.Name, g)
+		}
+	}
+
+	return aggregate[*agentmodel.AgentGroup]{
+		label: "agentgroup",
+		makeObj: func(ns, name string) *agentmodel.AgentGroup {
+			return agentmodel.NewAgentGroup(ns, name, nil, contractTime(), "tester")
+		},
+		setMarker:   func(g *agentmodel.AgentGroup, m string) { g.Metadata.Attributes = agentmodel.Attributes{"marker": m} },
+		getMarker:   func(g *agentmodel.AgentGroup) string { return g.Metadata.Attributes["marker"] },
+		markDeleted: func(g *agentmodel.AgentGroup) { g.MarkDeleted(contractTime().Add(time.Hour), "tester") },
+		inmemory: func() backend[*agentmodel.AgentGroup] {
+			repo := inmemory.NewAgentGroupRepository(inmemory.NewAgentRepository())
+
+			return backend[*agentmodel.AgentGroup]{
+				name: "inmemory",
+				put:  putVia(repo.PutAgentGroup),
+				get: func(ctx context.Context, ns, name string, incl bool) (*agentmodel.AgentGroup, error) {
+					return repo.GetAgentGroup(ctx, ns, name, getOptions(incl))
+				},
+				listNamespace: func(ctx context.Context, ns string) ([]*agentmodel.AgentGroup, error) {
+					resp, err := repo.ListAgentGroups(ctx, nil)
+					if err != nil {
+						return nil, fmt.Errorf("parity list: %w", err)
+					}
+
+					return filterNS(resp.Items, ns), nil
+				},
+			}
+		},
+		mongo: func(db *mongo.Database) backend[*agentmodel.AgentGroup] {
+			repo := mongodb.NewAgentGroupRepository(db, slog.Default())
+
+			return backend[*agentmodel.AgentGroup]{
+				name: "mongodb",
+				put:  putVia(repo.PutAgentGroup),
+				get: func(ctx context.Context, ns, name string, incl bool) (*agentmodel.AgentGroup, error) {
+					return repo.GetAgentGroup(ctx, ns, name, getOptions(incl))
+				},
+				listNamespace: func(ctx context.Context, ns string) ([]*agentmodel.AgentGroup, error) {
+					resp, err := repo.ListAgentGroups(ctx, nil)
+					if err != nil {
+						return nil, fmt.Errorf("parity list: %w", err)
+					}
+
+					return filterNS(resp.Items, ns), nil
+				},
+			}
+		},
+	}
+}
+
+// groupStatsBackend is one backend wiring for the statistics-parity test: an
+// agent repository feeding an agent-group repository over the same store.
+type groupStatsBackend struct {
+	name     string
+	putAgent func(ctx context.Context, agent *agentmodel.Agent) error
+	putGroup func(ctx context.Context, group *agentmodel.AgentGroup) (*agentmodel.AgentGroup, error)
+}
+
+// TestParity_AgentGroup_Statistics pins that both backends aggregate the same
+// group membership statistics from the agent store on write. Statistics are
+// computed at PutAgentGroup time by scanning agents that match the selector, so
+// a divergence here would surface as wrong connected/healthy counts in the UI.
+func TestParity_AgentGroup_Statistics(t *testing.T) {
+	t.Parallel()
+
+	runGroupStatistics(t, inmemoryGroupStatsBackend())
+
+	if testing.Short() {
+		return
+	}
+
+	testcontainers.SkipIfProviderIsNotHealthy(t)
+	runGroupStatistics(t, mongoGroupStatsBackend(startMongoDatabase(t)))
+}
+
+func inmemoryGroupStatsBackend() groupStatsBackend {
+	agentRepo := inmemory.NewAgentRepository()
+	groupRepo := inmemory.NewAgentGroupRepository(agentRepo)
+
+	return groupStatsBackend{
+		name:     "inmemory",
+		putAgent: agentRepo.PutAgent,
+		putGroup: func(ctx context.Context, group *agentmodel.AgentGroup) (*agentmodel.AgentGroup, error) {
+			return groupRepo.PutAgentGroup(ctx, group.Metadata.Namespace, group.Metadata.Name, group)
+		},
+	}
+}
+
+func mongoGroupStatsBackend(db *mongo.Database) groupStatsBackend {
+	agentRepo := mongodb.NewAgentRepository(db, slog.Default())
+	groupRepo := mongodb.NewAgentGroupRepository(db, slog.Default())
+
+	return groupStatsBackend{
+		name:     "mongodb",
+		putAgent: agentRepo.PutAgent,
+		putGroup: func(ctx context.Context, group *agentmodel.AgentGroup) (*agentmodel.AgentGroup, error) {
+			return groupRepo.PutAgentGroup(ctx, group.Metadata.Namespace, group.Metadata.Name, group)
+		},
+	}
+}
+
+func runGroupStatistics(t *testing.T, b groupStatsBackend) {
+	t.Helper()
+
+	t.Run(b.name, func(t *testing.T) {
+		t.Parallel()
+
+		ctx := context.Background()
+		ns := uniqueNamespace("stats")
+		// A per-run selector value keeps matches isolated within a shared store.
+		serviceName := "otelcol-" + uuid.NewString()[:8]
+		selector := map[string]string{"service.name": serviceName}
+
+		// Connected + healthy, matching the selector.
+		connected := agentmodel.NewAgent(uuid.New())
+		connected.Metadata.Namespace = ns
+		connected.Metadata.Description.IdentifyingAttributes = selector
+		connected.Status.Connected = true
+		connected.Status.LastReportedAt = time.Now()
+		connected.Status.ComponentHealth.Healthy = true
+		require.NoError(t, b.putAgent(ctx, connected))
+
+		// Matching but disconnected.
+		disconnected := agentmodel.NewAgent(uuid.New())
+		disconnected.Metadata.Namespace = ns
+		disconnected.Metadata.Description.IdentifyingAttributes = selector
+		require.NoError(t, b.putAgent(ctx, disconnected))
+
+		// Non-matching agent must not be counted.
+		other := agentmodel.NewAgent(uuid.New())
+		other.Metadata.Namespace = ns
+		other.Metadata.Description.IdentifyingAttributes = map[string]string{"service.name": "nginx"}
+		other.Status.Connected = true
+		other.Status.LastReportedAt = time.Now()
+		require.NoError(t, b.putAgent(ctx, other))
+
+		group := agentmodel.NewAgentGroup(ns, "grp", nil, contractTime(), "tester")
+		group.Spec.Selector = agentmodel.AgentSelector{IdentifyingAttributes: selector}
+
+		stored, err := b.putGroup(ctx, group)
+		require.NoError(t, err)
+
+		assert.Equal(t, 2, stored.Status.NumAgents, "both matching agents counted")
+		assert.Equal(t, 1, stored.Status.NumConnectedAgents)
+		assert.Equal(t, 1, stored.Status.NumHealthyAgents)
+		assert.Equal(t, 1, stored.Status.NumNotConnectedAgents)
+	})
+}


### PR DESCRIPTION
## Summary

Follow-up to #541 (now merged). Extends the cross-implementation parity harness to the two aggregates #495 prioritizes that did not fit the shared namespaced/soft-delete contract.

### `agent` — dedicated contract
Agents are keyed by instance UID, hard-deleted (no soft delete), and carry optimistic-concurrency versions, so they get their own `runAgentContract`:
- put → get round-trip
- get of a missing UID → `ErrResourceNotExist`
- delete removes, and deleting a missing agent → `ErrResourceNotExist`
- namespace isolation via `ListAgents(ns)`
- Get returns an isolated copy (mutation must not leak into the store)
- **optimistic concurrency**: first put inserts at v1 and bumps the caller; a stale writer loses with `ErrConflict` while the winner's value and v2 survive

### `agentgroup` — reuses the shared contract + statistics parity
- Reuses the generic namespaced/soft-delete `runContract` (the put closure forwards `namespace`+`name` into `PutAgentGroup`), exercising round-trip, namespace isolation, isolated copy, and soft delete.
- Adds a **statistics-parity** test: seed connected/disconnected/non-matching agents, put a group whose selector matches, and assert both backends compute identical `NumAgents` / `NumConnectedAgents` / `NumHealthyAgents` / `NumNotConnectedAgents`. Statistics are computed at `PutAgentGroup` time by scanning the agent store, so a divergence would surface as wrong counts in the UI.

Both run the in-memory backend always and MongoDB via testcontainers (skipped without a healthy provider or under `-short`), same as the base suite.

### Verification
- `go test -short -race ./pkg/apiserver/adapter/secondary/persistence/parity/` passes (in-memory; MongoDB skipped locally without Docker — runs in CI)
- `go build ./...` clean, `golangci-lint run` — 0 issues

With this, the five aggregates named in #495 (agent, agentgroup, agentremoteconfig, endpoint, certificate) are all covered by cross-implementation parity tests.

Refs #495

🤖 Generated with [Claude Code](https://claude.com/claude-code)