### PR TITLE
refactor(connection): unify node-local ListConnections pagination with the cluster path (#488)

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -183,6 +183,8 @@ linters:
             - github.com/google/go-github/v72/github
             - github.com/golang-jwt/jwt/v5
             - k8s.io/utils/clock
+            - github.com/samber/lo
+            - github.com/samber/mo
 formatters:
   enable:
     - gci

--- a/pkg/apiserver/domain/agent/service/connection.go
+++ b/pkg/apiserver/domain/agent/service/connection.go
@@ -207,32 +207,35 @@ func (s *Service) ListConnections(
 	keys := lo.Keys(keyValues)
 	sort.Strings(keys)
 
+	// Exclusive resume after the token, mirroring the persistence layer so both
+	// listing paths share one continue-token contract (see model.ListResponse).
 	if options.Continue != "" {
-		// Find the index of the continue token
 		index := sort.SearchStrings(keys, options.Continue)
-		if index < len(keys) {
-			keys = keys[index:]
-		} else {
-			keys = nil // If continue token not found, return empty list
+		if index < len(keys) && keys[index] == options.Continue {
+			index++
 		}
+
+		keys = keys[index:]
 	}
 
-	totalMatchedItemsCount := len(keys)
+	remainingFromHere := len(keys)
 
-	var nextContinue string
+	page := keys
 	if options.Limit > 0 && int64(len(keys)) > options.Limit {
-		nextContinue = keys[options.Limit]
-		keys = keys[:options.Limit]
-	} else {
-		nextContinue = "\xff" // Use a sentinel value to indicate no more items
+		page = keys[:options.Limit]
+	}
+
+	continueToken := ""
+	if len(page) > 0 {
+		continueToken = page[len(page)-1]
 	}
 
 	return &model.ListResponse[*agentmodel.Connection]{
-		Items: lo.Map(keys, func(key string, _ int) *agentmodel.Connection {
+		Items: lo.Map(page, func(key string, _ int) *agentmodel.Connection {
 			return keyValues[key]
 		}),
-		Continue:           nextContinue,
-		RemainingItemCount: int64(totalMatchedItemsCount - len(keys)),
+		Continue:           continueToken,
+		RemainingItemCount: int64(remainingFromHere - len(page)),
 	}, nil
 }
 

--- a/pkg/apiserver/domain/agent/service/connection_internal_test.go
+++ b/pkg/apiserver/domain/agent/service/connection_internal_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/google/uuid"
+	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -148,7 +149,10 @@ func TestConnectionService_ListConnectionsPaginationConvention(t *testing.T) {
 	assert.Equal(t, int64(0), empty.RemainingItemCount)
 
 	// Paged traversal returns every item exactly once, in the full-listing order.
-	pagedIDs := make([]string, 0, total)
+	connID := func(conn *agentmodel.Connection, _ int) string { return conn.IDString() }
+
+	var pagedIDs []string
+
 	cont := ""
 
 	for pages := 0; ; pages++ {
@@ -157,9 +161,7 @@ func TestConnectionService_ListConnectionsPaginationConvention(t *testing.T) {
 		resp, listErr := svc.ListConnections(ctx, "default", &model.ListOptions{Limit: 2, Continue: cont})
 		require.NoError(t, listErr)
 
-		for _, item := range resp.Items {
-			pagedIDs = append(pagedIDs, item.IDString())
-		}
+		pagedIDs = append(pagedIDs, lo.Map(resp.Items, connID)...)
 
 		if resp.RemainingItemCount == 0 {
 			break
@@ -168,12 +170,8 @@ func TestConnectionService_ListConnectionsPaginationConvention(t *testing.T) {
 		cont = resp.Continue
 	}
 
-	fullIDs := make([]string, 0, len(full.Items))
-	for _, conn := range full.Items {
-		fullIDs = append(fullIDs, conn.IDString())
-	}
-
-	assert.Equal(t, fullIDs, pagedIDs, "paged traversal must equal the full ordered listing, with no repeats")
+	assert.Equal(t, lo.Map(full.Items, connID), pagedIDs,
+		"paged traversal must equal the full ordered listing, with no repeats")
 }
 
 func TestConnectionService_ListClusterConnectionsPassesServerIDFilter(t *testing.T) {

--- a/pkg/apiserver/domain/agent/service/connection_internal_test.go
+++ b/pkg/apiserver/domain/agent/service/connection_internal_test.go
@@ -2,6 +2,7 @@ package agentservice
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"testing"
 	"time"
@@ -109,6 +110,70 @@ func TestConnectionService_ListClusterConnectionsAppliesStalenessWindow(t *testi
 	assert.WithinRange(t, store.listNotBefore,
 		before.Add(-DefaultConnectionSnapshotStaleness),
 		after.Add(-DefaultConnectionSnapshotStaleness))
+}
+
+// TestConnectionService_ListConnectionsPaginationConvention pins the shared pagination
+// contract on the node-local path (see model.ListResponse), guarding the previous
+// divergence where it emitted a "\xff" end-of-list sentinel token.
+func TestConnectionService_ListConnectionsPaginationConvention(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc := NewConnectionService(nil, stubServerIdentity{id: "s1"}, &fakeServerConnectionStore{}, slog.Default())
+
+	const total = 5
+	for i := range total {
+		conn := agentmodel.NewConnection(fmt.Sprintf("default-conn-%d", i), agentmodel.ConnectionTypeWebSocket)
+		conn.SetNamespace("default")
+		require.NoError(t, svc.SaveConnection(ctx, conn))
+	}
+	// Filtered out by namespace.
+	other := agentmodel.NewConnection("other-conn", agentmodel.ConnectionTypeWebSocket)
+	other.SetNamespace("other")
+	require.NoError(t, svc.SaveConnection(ctx, other))
+
+	// Full listing: all items, end-of-list, Continue still a token (not "\xff").
+	full, err := svc.ListConnections(ctx, "default", &model.ListOptions{Limit: 0})
+	require.NoError(t, err)
+	require.Len(t, full.Items, total)
+	assert.Equal(t, int64(0), full.RemainingItemCount)
+	assert.NotEmpty(t, full.Continue, "Continue is a resume token, non-empty when items are returned")
+	assert.NotContains(t, full.Continue, "\xff", "the \\xff end-of-list sentinel must be gone")
+
+	// Empty page: no items, empty Continue.
+	empty, err := svc.ListConnections(ctx, "nonexistent", &model.ListOptions{Limit: 10})
+	require.NoError(t, err)
+	assert.Empty(t, empty.Items)
+	assert.Empty(t, empty.Continue)
+	assert.Equal(t, int64(0), empty.RemainingItemCount)
+
+	// Paged traversal returns every item exactly once, in the full-listing order.
+	pagedIDs := make([]string, 0, total)
+	cont := ""
+
+	for pages := 0; ; pages++ {
+		require.LessOrEqual(t, pages, total, "pagination must terminate")
+
+		resp, listErr := svc.ListConnections(ctx, "default", &model.ListOptions{Limit: 2, Continue: cont})
+		require.NoError(t, listErr)
+
+		for _, item := range resp.Items {
+			pagedIDs = append(pagedIDs, item.IDString())
+		}
+
+		if resp.RemainingItemCount == 0 {
+			break
+		}
+
+		cont = resp.Continue
+	}
+
+	fullIDs := make([]string, 0, len(full.Items))
+	for _, conn := range full.Items {
+		fullIDs = append(fullIDs, conn.IDString())
+	}
+
+	assert.Equal(t, fullIDs, pagedIDs, "paged traversal must equal the full ordered listing, with no repeats")
 }
 
 func TestConnectionService_ListClusterConnectionsPassesServerIDFilter(t *testing.T) {

--- a/pkg/apiserver/domain/model/listoption.go
+++ b/pkg/apiserver/domain/model/listoption.go
@@ -33,6 +33,11 @@ type GetOptions struct {
 }
 
 // ListResponse is a generic struct that represents a paginated response for listing resources.
+//
+// Pagination convention, shared by every listing path: Continue is an opaque resume token,
+// non-empty whenever Items is non-empty (even on the final page) and echoed back verbatim on
+// the next request. End-of-list is signaled by RemainingItemCount reaching 0, not by Continue
+// becoming empty.
 type ListResponse[T any] struct {
 	RemainingItemCount int64
 	Continue           string


### PR DESCRIPTION
## Summary

Closes the pagination-contract divergence in #488.

The two connection-listing paths encoded "no more items" differently:
- **Node-local** `ListConnections` emitted a `"\xff"` **sentinel** continue token at end-of-list.
- **Cluster** `ListClusterConnections` → `ListServerConnections` uses an opaque resume token and signals the end via `RemainingItemCount`.

Both admin methods pass `Continue` through verbatim, so the sentinel leaked into the API's `continue` field (a control character), forcing any consumer of both paths to special-case each.

## Change

- Align the node-local path on the persistence-layer contract: `Continue` is an opaque resume token (the last returned key), **resume is exclusive** so a paged traversal never repeats an item, and end-of-list is `RemainingItemCount == 0`. No more `"\xff"`.
- Document the convention once on `model.ListResponse`.
- Add a white-box test locking it: full listing (end-of-list with a token, not the sentinel), empty page (empty Continue), and an exclusive paged traversal that reconstructs the full ordered listing with no repeats.

## Acceptance (from #488)
- [x] Both paths use the same end-of-list signaling convention (`RemainingItemCount == 0`, opaque `Continue`)
- [x] Documented in code where the convention lives (`model.ListResponse`)
- [x] Existing pagination tests pass

## Verification
- `go test -short ./pkg/apiserver/...` (connection service, admin service, connection controller) passes
- `go build ./...` clean, `golangci-lint run` — 0 issues

Closes #488

🤖 Generated with [Claude Code](https://claude.com/claude-code)