### PR TITLE
perf(connection): incremental cluster connection snapshots via server heartbeats (#486)

### DIFF
--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/inmemory_test.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/inmemory_test.go
@@ -486,7 +486,7 @@ func TestAgentRepository_PutAgentConflictOnConcurrentCreate(t *testing.T) {
 	require.ErrorIs(t, repo.PutAgent(ctx, createB), model.ErrConflict)
 }
 
-func TestServerConnectionRepository_ReplaceAndList(t *testing.T) {
+func TestServerConnectionRepository_SyncAndList(t *testing.T) {
 	t.Parallel()
 
 	ctx := context.Background()
@@ -506,29 +506,27 @@ func TestServerConnectionRepository_ReplaceAndList(t *testing.T) {
 	}
 
 	a1, a2, b1 := uuid.New(), uuid.New(), uuid.New()
-	require.NoError(t, repo.ReplaceServerConnections(ctx, "server-a", []*agentmodel.ServerConnection{
+	require.NoError(t, repo.SyncServerConnections(ctx, "server-a", now, []*agentmodel.ServerConnection{
 		sc("server-a", "default", a1), sc("server-a", "default", a2),
-	}))
-	require.NoError(t, repo.ReplaceServerConnections(ctx, "server-b", []*agentmodel.ServerConnection{
+	}, nil))
+	require.NoError(t, repo.SyncServerConnections(ctx, "server-b", now, []*agentmodel.ServerConnection{
 		sc("server-b", "default", b1),
-	}))
+	}, nil))
 
-	// Cluster view spans both servers.
+	// Cluster view spans both live servers.
 	resp, err := repo.ListServerConnections(ctx, "default", "", time.Time{}, nil)
 	require.NoError(t, err)
 	assert.Len(t, resp.Items, 3)
 
-	// Replacing one server's set only affects that server.
-	require.NoError(t, repo.ReplaceServerConnections(ctx, "server-a", []*agentmodel.ServerConnection{
-		sc("server-a", "default", a1),
-	}))
+	// An incremental delete only affects the named connection.
+	require.NoError(t, repo.SyncServerConnections(ctx, "server-a", now, nil, []uuid.UUID{a2}))
 
 	resp, err = repo.ListServerConnections(ctx, "default", "", time.Time{}, nil)
 	require.NoError(t, err)
 	assert.Len(t, resp.Items, 2) // a1 + b1
 
-	// Clearing a server removes its records.
-	require.NoError(t, repo.ReplaceServerConnections(ctx, "server-b", nil))
+	// Removing a server drops its heartbeat and records.
+	require.NoError(t, repo.RemoveServer(ctx, "server-b"))
 
 	resp, err = repo.ListServerConnections(ctx, "default", "", time.Time{}, nil)
 	require.NoError(t, err)
@@ -553,18 +551,20 @@ func TestServerConnectionRepository_ListFiltersNamespaceAndStaleness(t *testing.
 		Type: agentmodel.ConnectionTypeHTTP, Namespace: "ns-b",
 		LastCommunicatedAt: now, SnapshotAt: now,
 	}
+	// Owned by a server whose heartbeat is stale (crashed), so it must be excluded.
 	stale := &agentmodel.ServerConnection{
 		ServerID: "server-c", UID: uuid.New(), InstanceUID: uuid.New(),
 		Type: agentmodel.ConnectionTypeHTTP, Namespace: "ns-a",
-		LastCommunicatedAt: now, SnapshotAt: now.Add(-10 * time.Minute),
+		LastCommunicatedAt: now, SnapshotAt: now,
 	}
 
-	require.NoError(t, repo.ReplaceServerConnections(ctx, "server-a",
-		[]*agentmodel.ServerConnection{fresh, otherNS}))
-	require.NoError(t, repo.ReplaceServerConnections(ctx, "server-c",
-		[]*agentmodel.ServerConnection{stale}))
+	require.NoError(t, repo.SyncServerConnections(ctx, "server-a", now,
+		[]*agentmodel.ServerConnection{fresh, otherNS}, nil))
+	require.NoError(t, repo.SyncServerConnections(ctx, "server-c", now.Add(-10*time.Minute),
+		[]*agentmodel.ServerConnection{stale}, nil))
 
-	// Namespace filter + staleness cutoff (notBefore) excludes other-namespace and stale records.
+	// Namespace filter + staleness cutoff (notBefore on the owning server's heartbeat) excludes
+	// the other-namespace record and the crashed server's record.
 	resp, err := repo.ListServerConnections(ctx, "ns-a", "", now.Add(-90*time.Second), nil)
 	require.NoError(t, err)
 	require.Len(t, resp.Items, 1)
@@ -587,10 +587,10 @@ func TestServerConnectionRepository_ListFiltersByServerID(t *testing.T) {
 	}
 
 	x1, y1 := uuid.New(), uuid.New()
-	require.NoError(t, repo.ReplaceServerConnections(ctx, "server-x",
-		[]*agentmodel.ServerConnection{rec("server-x", x1)}))
-	require.NoError(t, repo.ReplaceServerConnections(ctx, "server-y",
-		[]*agentmodel.ServerConnection{rec("server-y", y1)}))
+	require.NoError(t, repo.SyncServerConnections(ctx, "server-x", now,
+		[]*agentmodel.ServerConnection{rec("server-x", x1)}, nil))
+	require.NoError(t, repo.SyncServerConnections(ctx, "server-y", now,
+		[]*agentmodel.ServerConnection{rec("server-y", y1)}, nil))
 
 	resp, err := repo.ListServerConnections(ctx, "default", "server-x", time.Time{}, nil)
 	require.NoError(t, err)

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/serverconnection.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/serverconnection.go
@@ -44,10 +44,8 @@ func (r *ServerConnectionRepository) SyncServerConnections(
 	upserts []*agentmodel.ServerConnection,
 	deletes []uuid.UUID,
 ) error {
-	r.heartbeatMu.Lock()
-	r.heartbeats[serverID] = heartbeatAt
-	r.heartbeatMu.Unlock()
-
+	// Apply membership before the heartbeat, mirroring the MongoDB adapter's ordering so the
+	// server only becomes visible once its connection set is in place.
 	for _, conn := range upserts {
 		r.store.put(conn.UID, conn)
 	}
@@ -55,6 +53,10 @@ func (r *ServerConnectionRepository) SyncServerConnections(
 	for _, uid := range deletes {
 		_ = r.store.delete(uid)
 	}
+
+	r.heartbeatMu.Lock()
+	r.heartbeats[serverID] = heartbeatAt
+	r.heartbeatMu.Unlock()
 
 	return nil
 }

--- a/pkg/apiserver/adapter/secondary/persistence/inmemory/serverconnection.go
+++ b/pkg/apiserver/adapter/secondary/persistence/inmemory/serverconnection.go
@@ -2,7 +2,10 @@ package inmemory
 
 import (
 	"context"
+	"sync"
 	"time"
+
+	"github.com/google/uuid"
 
 	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent"
 	agentport "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent/port"
@@ -13,33 +16,60 @@ var _ agentport.ServerConnectionPersistencePort = (*ServerConnectionRepository)(
 
 // ServerConnectionRepository is the in-memory implementation of
 // [agentport.ServerConnectionPersistencePort]. It backs standalone mode, where there is
-// only one server, so the cluster view is simply this process's own snapshot.
+// only one server, so the cluster view is simply this process's own connections.
+//
+// Connections are stored keyed by UID (stable pagination); a heartbeats map tracks per-server
+// liveness. A connection is visible only while its owning server's heartbeat is fresh.
 type ServerConnectionRepository struct {
-	store *store[string, *agentmodel.ServerConnection]
+	store *store[uuid.UUID, *agentmodel.ServerConnection]
+
+	heartbeatMu sync.RWMutex
+	heartbeats  map[string]time.Time
 }
 
 // NewServerConnectionRepository creates a new in-memory ServerConnectionRepository.
 func NewServerConnectionRepository() *ServerConnectionRepository {
 	return &ServerConnectionRepository{
-		store: newStore[string](cloneServerConnection, nil),
+		store:       newStore[uuid.UUID](cloneServerConnection, nil),
+		heartbeatMu: sync.RWMutex{},
+		heartbeats:  make(map[string]time.Time),
 	}
 }
 
-// ReplaceServerConnections implements agentport.ServerConnectionPersistencePort.
-func (r *ServerConnectionRepository) ReplaceServerConnections(
+// SyncServerConnections implements agentport.ServerConnectionPersistencePort.
+func (r *ServerConnectionRepository) SyncServerConnections(
 	_ context.Context,
 	serverID string,
-	conns []*agentmodel.ServerConnection,
+	heartbeatAt time.Time,
+	upserts []*agentmodel.ServerConnection,
+	deletes []uuid.UUID,
 ) error {
-	existing := r.store.snapshot(false, func(sc *agentmodel.ServerConnection) bool {
-		return sc.ServerID == serverID
-	})
-	for _, sc := range existing {
-		_ = r.store.delete(serverConnectionKey(sc))
+	r.heartbeatMu.Lock()
+	r.heartbeats[serverID] = heartbeatAt
+	r.heartbeatMu.Unlock()
+
+	for _, conn := range upserts {
+		r.store.put(conn.UID, conn)
 	}
 
-	for _, sc := range conns {
-		r.store.put(serverConnectionKey(sc), sc)
+	for _, uid := range deletes {
+		_ = r.store.delete(uid)
+	}
+
+	return nil
+}
+
+// RemoveServer implements agentport.ServerConnectionPersistencePort.
+func (r *ServerConnectionRepository) RemoveServer(_ context.Context, serverID string) error {
+	r.heartbeatMu.Lock()
+	delete(r.heartbeats, serverID)
+	r.heartbeatMu.Unlock()
+
+	owned := r.store.snapshot(false, func(sc *agentmodel.ServerConnection) bool {
+		return sc.ServerID == serverID
+	})
+	for _, sc := range owned {
+		_ = r.store.delete(sc.UID)
 	}
 
 	return nil
@@ -53,6 +83,8 @@ func (r *ServerConnectionRepository) ListServerConnections(
 	notBefore time.Time,
 	options *model.ListOptions,
 ) (*model.ListResponse[*agentmodel.ServerConnection], error) {
+	live := r.liveServers(notBefore)
+
 	return r.store.list(options, func(conn *agentmodel.ServerConnection) bool {
 		if conn.Namespace != namespace {
 			return false
@@ -62,16 +94,25 @@ func (r *ServerConnectionRepository) ListServerConnections(
 			return false
 		}
 
-		if !notBefore.IsZero() && conn.SnapshotAt.Before(notBefore) {
-			return false
-		}
-
-		return true
+		return live[conn.ServerID]
 	})
 }
 
-func serverConnectionKey(sc *agentmodel.ServerConnection) string {
-	return sc.ServerID + "/" + sc.UID.String()
+// liveServers returns the set of serverIDs whose heartbeat is at or after notBefore (all of
+// them when notBefore is zero).
+func (r *ServerConnectionRepository) liveServers(notBefore time.Time) map[string]bool {
+	r.heartbeatMu.RLock()
+	defer r.heartbeatMu.RUnlock()
+
+	live := make(map[string]bool, len(r.heartbeats))
+
+	for id, lastSeen := range r.heartbeats {
+		if notBefore.IsZero() || !lastSeen.Before(notBefore) {
+			live[id] = true
+		}
+	}
+
+	return live
 }
 
 func cloneServerConnection(sc *agentmodel.ServerConnection) *agentmodel.ServerConnection {

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/entity/serverconnection.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/entity/serverconnection.go
@@ -68,3 +68,12 @@ func ServerConnectionFromDomain(conn *agentmodel.ServerConnection) *ServerConnec
 		SnapshotAt:         conn.SnapshotAt,
 	}
 }
+
+// ServerHeartbeat is a per-server liveness record in MongoDB. Each alive server refreshes
+// LastSeenAt every snapshot cycle; a connection is visible in the cluster view only while its
+// owning server's heartbeat is fresh. A TTL index on LastSeenAt drops dead servers' heartbeats.
+type ServerHeartbeat struct {
+	ID         *bson.ObjectID `bson:"_id,omitempty"`
+	ServerID   string         `bson:"serverId"`
+	LastSeenAt time.Time      `bson:"lastSeenAt"`
+}

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/mongodb.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/mongodb.go
@@ -6,12 +6,18 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/samber/lo"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
 	"go.mongodb.org/mongo-driver/v2/mongo/options"
 )
+
+// serverHeartbeatTTL is how long a server heartbeat survives without a refresh before MongoDB's
+// TTL monitor drops it. Sized well above the snapshot interval so a live server (which refreshes
+// every cycle) is never expired; it only garbage-collects heartbeats of crashed servers.
+const serverHeartbeatTTL = 10 * time.Minute
 
 // sanitizeResourceName validates and returns a safe resource name for MongoDB queries.
 // Each rune is checked against a whitelist and copied to a new string, preventing
@@ -50,6 +56,7 @@ var (
 		namespaceCollectionName,
 		serverCollectionName,
 		serverConnectionCollectionName,
+		serverHeartbeatCollectionName,
 	}
 
 	indexes = []collectionAndIndexes{
@@ -200,20 +207,36 @@ var (
 		{
 			collectionName: serverConnectionCollectionName,
 			indexes: []mongo.IndexModel{
-				// Backs ReplaceServerConnections' per-server delete and the cluster-list
-				// query's namespace + snapshot-staleness filter.
+				// Unique key backing the incremental upsert (ReplaceOne by uid) and the
+				// delete-by-uid path in SyncServerConnections.
+				{
+					Keys:    bson.D{{Key: "uid", Value: 1}},
+					Options: options.Index().SetUnique(true),
+				},
+				// Backs RemoveServer's per-server delete and the cluster-list query's
+				// namespace + owning-server filter.
 				{
 					Keys: bson.D{
+						{Key: "namespace", Value: 1},
 						{Key: "serverId", Value: 1},
 					},
 					Options: nil,
 				},
+			},
+		},
+		{
+			collectionName: serverHeartbeatCollectionName,
+			indexes: []mongo.IndexModel{
+				// One heartbeat per server; backs the upsert and the liveness lookup.
 				{
-					Keys: bson.D{
-						{Key: "namespace", Value: 1},
-						{Key: "snapshotAt", Value: 1},
-					},
-					Options: nil,
+					Keys:    bson.D{{Key: "serverId", Value: 1}},
+					Options: options.Index().SetUnique(true),
+				},
+				// TTL index: a crashed server's heartbeat (and thus its cluster-view
+				// visibility) expires automatically once it stops refreshing.
+				{
+					Keys:    bson.D{{Key: "lastSeenAt", Value: 1}},
+					Options: options.Index().SetExpireAfterSeconds(int32(serverHeartbeatTTL.Seconds())),
 				},
 			},
 		},

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/mongodb.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/mongodb.go
@@ -15,9 +15,11 @@ import (
 )
 
 // serverHeartbeatTTL is how long a server heartbeat survives without a refresh before MongoDB's
-// TTL monitor drops it. Sized well above the snapshot interval so a live server (which refreshes
-// every cycle) is never expired; it only garbage-collects heartbeats of crashed servers.
-const serverHeartbeatTTL = 10 * time.Minute
+// TTL monitor drops it. It is pure garbage collection of crashed servers, NOT the liveness
+// cutoff (reads use the caller's notBefore); it must therefore stay far above any configured
+// read-staleness window, or a still-"live" server's heartbeat could be reaped early. Sized at
+// 24h so no realistic staleness setting approaches it.
+const serverHeartbeatTTL = 24 * time.Hour
 
 // sanitizeResourceName validates and returns a safe resource name for MongoDB queries.
 // Each rune is checked against a whitelist and copied to a new string, preventing
@@ -207,11 +209,13 @@ var (
 		{
 			collectionName: serverConnectionCollectionName,
 			indexes: []mongo.IndexModel{
-				// Unique key backing the incremental upsert (ReplaceOne by uid) and the
-				// delete-by-uid path in SyncServerConnections.
+				// Backs the incremental upsert (ReplaceOne by uid) and the delete-by-uid path
+				// in SyncServerConnections. Not unique: connection UIDs are already unique by
+				// construction (one owning server each), and a unique index would abort
+				// EnsureSchema at startup if pre-upgrade data happened to contain a duplicate.
 				{
 					Keys:    bson.D{{Key: "uid", Value: 1}},
-					Options: options.Index().SetUnique(true),
+					Options: nil,
 				},
 				// Backs RemoveServer's per-server delete and the cluster-list query's
 				// namespace + owning-server filter.

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/serverconnection.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/serverconnection.go
@@ -6,9 +6,11 @@ import (
 	"log/slog"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/samber/lo"
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
+	"go.mongodb.org/mongo-driver/v2/mongo/options"
 
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/adapter/secondary/persistence/mongodb/entity"
 	agentmodel "github.com/minuk-dev/opampcommander/pkg/apiserver/domain/agent"
@@ -16,13 +18,19 @@ import (
 	"github.com/minuk-dev/opampcommander/pkg/apiserver/domain/model"
 )
 
-const serverConnectionCollectionName = "serverconnections"
+const (
+	serverConnectionCollectionName = "serverconnections"
+	serverHeartbeatCollectionName  = "serverheartbeats"
+)
 
 var _ agentport.ServerConnectionPersistencePort = (*ServerConnectionAdapter)(nil)
 
-// ServerConnectionAdapter persists per-server connection snapshots in MongoDB.
+// ServerConnectionAdapter persists per-server connection records and liveness heartbeats in
+// MongoDB. Membership (connections) is written incrementally; liveness (heartbeats) is a single
+// O(1) upsert per cycle, and reads join the two so a stale server's connections drop out.
 type ServerConnectionAdapter struct {
 	collection *mongo.Collection
+	heartbeats *mongo.Collection
 	logger     *slog.Logger
 }
 
@@ -30,42 +38,66 @@ type ServerConnectionAdapter struct {
 func NewServerConnectionAdapter(database *mongo.Database, logger *slog.Logger) *ServerConnectionAdapter {
 	return &ServerConnectionAdapter{
 		collection: database.Collection(serverConnectionCollectionName),
+		heartbeats: database.Collection(serverHeartbeatCollectionName),
 		logger:     logger,
 	}
 }
 
-// ReplaceServerConnections implements agentport.ServerConnectionPersistencePort.
+// SyncServerConnections implements agentport.ServerConnectionPersistencePort.
 //
-// It deletes the owning server's existing records and inserts the new set. The two steps
-// are not transactional; a reader hitting the brief gap simply sees this server's
-// connections momentarily missing, which is acceptable for a periodic snapshot view.
-func (a *ServerConnectionAdapter) ReplaceServerConnections(
+// It refreshes the server's heartbeat and applies the incremental change set. The steps are
+// not transactional, which is acceptable for a periodic snapshot view: a reader may briefly see
+// a just-added connection missing or a just-removed one present until the next cycle.
+func (a *ServerConnectionAdapter) SyncServerConnections(
 	ctx context.Context,
 	serverID string,
-	conns []*agentmodel.ServerConnection,
+	heartbeatAt time.Time,
+	upserts []*agentmodel.ServerConnection,
+	deletes []uuid.UUID,
 ) error {
-	_, err := a.collection.DeleteMany(ctx, bson.M{"serverId": serverID})
+	err := a.refreshHeartbeat(ctx, serverID, heartbeatAt)
 	if err != nil {
-		return fmt.Errorf("failed to delete server connections from mongodb: %w", err)
+		return err
 	}
 
-	if len(conns) == 0 {
-		return nil
+	if len(deletes) > 0 {
+		deleteIDs := lo.Map(deletes, func(uid uuid.UUID, _ int) string { return uid.String() })
+
+		_, err = a.collection.DeleteMany(ctx, bson.M{"serverId": serverID, "uid": bson.M{"$in": deleteIDs}})
+		if err != nil {
+			return fmt.Errorf("failed to delete server connections from mongodb: %w", err)
+		}
 	}
 
-	docs := lo.Map(conns, func(conn *agentmodel.ServerConnection, _ int) any {
-		return entity.ServerConnectionFromDomain(conn)
-	})
+	for _, conn := range upserts {
+		ent := entity.ServerConnectionFromDomain(conn)
 
-	_, err = a.collection.InsertMany(ctx, docs)
-	if err != nil {
-		return fmt.Errorf("failed to insert server connections to mongodb: %w", err)
+		_, err = a.collection.ReplaceOne(ctx, bson.M{"uid": ent.UID}, ent, options.Replace().SetUpsert(true))
+		if err != nil {
+			return fmt.Errorf("failed to upsert server connection to mongodb: %w", err)
+		}
 	}
 
 	return nil
 }
 
-// ListServerConnections implements agentport.ServerConnectionPersistencePort.
+// RemoveServer implements agentport.ServerConnectionPersistencePort.
+func (a *ServerConnectionAdapter) RemoveServer(ctx context.Context, serverID string) error {
+	_, err := a.heartbeats.DeleteOne(ctx, bson.M{"serverId": serverID})
+	if err != nil {
+		return fmt.Errorf("failed to delete server heartbeat from mongodb: %w", err)
+	}
+
+	_, err = a.collection.DeleteMany(ctx, bson.M{"serverId": serverID})
+	if err != nil {
+		return fmt.Errorf("failed to delete server connections from mongodb: %w", err)
+	}
+
+	return nil
+}
+
+// ListServerConnections implements agentport.ServerConnectionPersistencePort. It first resolves
+// the set of live servers from the heartbeat collection, then returns only their connections.
 func (a *ServerConnectionAdapter) ListServerConnections(
 	ctx context.Context,
 	namespace string,
@@ -78,15 +110,19 @@ func (a *ServerConnectionAdapter) ListServerConnections(
 		options = &model.ListOptions{}
 	}
 
-	conditions := []bson.M{{"namespace": sanitizeResourceName(namespace)}}
-	if serverID != "" {
-		// Sanitize the user-provided serverId the same way as namespace so it can only
-		// ever be a literal equality match, never a MongoDB operator (NoSQL injection).
-		conditions = append(conditions, bson.M{"serverId": sanitizeResourceName(serverID)})
+	liveServerIDs, err := a.liveServerIDs(ctx, serverID, notBefore)
+	if err != nil {
+		return nil, err
 	}
 
-	if !notBefore.IsZero() {
-		conditions = append(conditions, bson.M{"snapshotAt": bson.M{"$gte": notBefore}})
+	if len(liveServerIDs) == 0 {
+		//exhaustruct:ignore
+		return &model.ListResponse[*agentmodel.ServerConnection]{}, nil
+	}
+
+	conditions := []bson.M{
+		{"namespace": sanitizeResourceName(namespace)},
+		{"serverId": bson.M{"$in": liveServerIDs}},
 	}
 
 	continueTokenObjectID, err := bson.ObjectIDFromHex(options.Continue)
@@ -117,6 +153,55 @@ func (a *ServerConnectionAdapter) ListServerConnections(
 		Continue:           continueToken,
 		RemainingItemCount: count - int64(len(entities)),
 	}, nil
+}
+
+func (a *ServerConnectionAdapter) refreshHeartbeat(ctx context.Context, serverID string, at time.Time) error {
+	heartbeat := &entity.ServerHeartbeat{ID: nil, ServerID: serverID, LastSeenAt: at}
+
+	_, err := a.heartbeats.ReplaceOne(ctx, bson.M{"serverId": serverID}, heartbeat, options.Replace().SetUpsert(true))
+	if err != nil {
+		return fmt.Errorf("failed to refresh server heartbeat in mongodb: %w", err)
+	}
+
+	return nil
+}
+
+// liveServerIDs returns the serverIDs whose heartbeat is at or after notBefore. A non-empty
+// serverID restricts the query to that one server; a zero notBefore matches every heartbeat.
+func (a *ServerConnectionAdapter) liveServerIDs(
+	ctx context.Context,
+	serverID string,
+	notBefore time.Time,
+) ([]string, error) {
+	filter := bson.M{}
+	if serverID != "" {
+		filter["serverId"] = sanitizeResourceName(serverID)
+	}
+
+	if !notBefore.IsZero() {
+		filter["lastSeenAt"] = bson.M{"$gte": notBefore}
+	}
+
+	cursor, err := a.heartbeats.Find(ctx, filter, options.Find().SetProjection(bson.M{"serverId": 1}))
+	if err != nil {
+		return nil, fmt.Errorf("failed to find server heartbeats in mongodb: %w", err)
+	}
+
+	defer func() {
+		closeErr := cursor.Close(ctx)
+		if closeErr != nil {
+			a.logger.Warn("failed to close mongodb cursor", slog.String("error", closeErr.Error()))
+		}
+	}()
+
+	var heartbeats []*entity.ServerHeartbeat
+
+	err = cursor.All(ctx, &heartbeats)
+	if err != nil {
+		return nil, fmt.Errorf("failed to decode server heartbeats from mongodb: %w", err)
+	}
+
+	return lo.Map(heartbeats, func(hb *entity.ServerHeartbeat, _ int) string { return hb.ServerID }), nil
 }
 
 // findServerConnections runs the paginated find and returns the decoded entities plus the

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/serverconnection.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/serverconnection.go
@@ -45,9 +45,10 @@ func NewServerConnectionAdapter(database *mongo.Database, logger *slog.Logger) *
 
 // SyncServerConnections implements agentport.ServerConnectionPersistencePort.
 //
-// It refreshes the server's heartbeat and applies the incremental change set. The steps are
-// not transactional, which is acceptable for a periodic snapshot view: a reader may briefly see
-// a just-added connection missing or a just-removed one present until the next cycle.
+// Membership (upserts/deletes) is applied first and the heartbeat is refreshed last, so a
+// partial failure never leaves a fresh heartbeat advertising an incomplete connection set: the
+// server stays out of the cluster view until a fully-successful cycle. The steps are not
+// transactional, which is acceptable for a periodic snapshot view.
 func (a *ServerConnectionAdapter) SyncServerConnections(
 	ctx context.Context,
 	serverID string,
@@ -55,15 +56,10 @@ func (a *ServerConnectionAdapter) SyncServerConnections(
 	upserts []*agentmodel.ServerConnection,
 	deletes []uuid.UUID,
 ) error {
-	err := a.refreshHeartbeat(ctx, serverID, heartbeatAt)
-	if err != nil {
-		return err
-	}
-
 	if len(deletes) > 0 {
 		deleteIDs := lo.Map(deletes, func(uid uuid.UUID, _ int) string { return uid.String() })
 
-		_, err = a.collection.DeleteMany(ctx, bson.M{"serverId": serverID, "uid": bson.M{"$in": deleteIDs}})
+		_, err := a.collection.DeleteMany(ctx, bson.M{"serverId": serverID, "uid": bson.M{"$in": deleteIDs}})
 		if err != nil {
 			return fmt.Errorf("failed to delete server connections from mongodb: %w", err)
 		}
@@ -72,13 +68,13 @@ func (a *ServerConnectionAdapter) SyncServerConnections(
 	for _, conn := range upserts {
 		ent := entity.ServerConnectionFromDomain(conn)
 
-		_, err = a.collection.ReplaceOne(ctx, bson.M{"uid": ent.UID}, ent, options.Replace().SetUpsert(true))
+		_, err := a.collection.ReplaceOne(ctx, bson.M{"uid": ent.UID}, ent, options.Replace().SetUpsert(true))
 		if err != nil {
 			return fmt.Errorf("failed to upsert server connection to mongodb: %w", err)
 		}
 	}
 
-	return nil
+	return a.refreshHeartbeat(ctx, serverID, heartbeatAt)
 }
 
 // RemoveServer implements agentport.ServerConnectionPersistencePort.

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/serverconnection_test.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/serverconnection_test.go
@@ -35,32 +35,34 @@ func TestServerConnectionMongoAdapter(t *testing.T) {
 	})
 
 	database := client.Database("testdb")
+	require.NoError(t, mongodb.EnsureSchema(ctx, database))
+
 	adapter := mongodb.NewServerConnectionAdapter(database, base.Logger)
 
 	now := time.Now()
-	rec := func(server, ns string, uid uuid.UUID, snapshotAt time.Time) *agentmodel.ServerConnection {
+	rec := func(server, ns string, uid uuid.UUID) *agentmodel.ServerConnection {
 		return &agentmodel.ServerConnection{
 			ServerID: server, UID: uid, InstanceUID: uuid.New(),
 			Type: agentmodel.ConnectionTypeWebSocket, Namespace: ns,
-			LastCommunicatedAt: now, SnapshotAt: snapshotAt,
+			LastCommunicatedAt: now, SnapshotAt: now,
 		}
 	}
 
 	a1, b1 := uuid.New(), uuid.New()
 
-	t.Run("replace per server and list cluster-wide", func(t *testing.T) {
+	t.Run("sync per server and list cluster-wide", func(t *testing.T) {
 		t.Parallel()
-		require.NoError(t, adapter.ReplaceServerConnections(ctx, "server-a",
-			[]*agentmodel.ServerConnection{rec("server-a", "default", a1, now)}))
-		require.NoError(t, adapter.ReplaceServerConnections(ctx, "server-b",
-			[]*agentmodel.ServerConnection{rec("server-b", "default", b1, now)}))
+		require.NoError(t, adapter.SyncServerConnections(ctx, "server-a", now,
+			[]*agentmodel.ServerConnection{rec("server-a", "default", a1)}, nil))
+		require.NoError(t, adapter.SyncServerConnections(ctx, "server-b", now,
+			[]*agentmodel.ServerConnection{rec("server-b", "default", b1)}, nil))
 
 		resp, err := adapter.ListServerConnections(ctx, "default", "", time.Time{}, nil)
 		require.NoError(t, err)
 		assert.Len(t, resp.Items, 2)
 
-		// Replacing one server's set leaves the other untouched.
-		require.NoError(t, adapter.ReplaceServerConnections(ctx, "server-a", nil))
+		// Removing one server leaves the other untouched.
+		require.NoError(t, adapter.RemoveServer(ctx, "server-a"))
 
 		resp, err = adapter.ListServerConnections(ctx, "default", "", time.Time{}, nil)
 		require.NoError(t, err)
@@ -69,10 +71,11 @@ func TestServerConnectionMongoAdapter(t *testing.T) {
 		assert.Equal(t, b1, resp.Items[0].UID)
 	})
 
-	t.Run("staleness cutoff excludes old snapshots", func(t *testing.T) {
+	t.Run("staleness cutoff excludes crashed servers", func(t *testing.T) {
 		t.Parallel()
-		require.NoError(t, adapter.ReplaceServerConnections(ctx, "server-stale",
-			[]*agentmodel.ServerConnection{rec("server-stale", "ns-stale", uuid.New(), now.Add(-10*time.Minute))}))
+		// A stale heartbeat marks the server crashed, so its connections drop out.
+		require.NoError(t, adapter.SyncServerConnections(ctx, "server-stale", now.Add(-10*time.Minute),
+			[]*agentmodel.ServerConnection{rec("server-stale", "ns-stale", uuid.New())}, nil))
 
 		resp, err := adapter.ListServerConnections(ctx, "ns-stale", "", now.Add(-90*time.Second), nil)
 		require.NoError(t, err)
@@ -83,10 +86,10 @@ func TestServerConnectionMongoAdapter(t *testing.T) {
 		t.Parallel()
 
 		x1, y1 := uuid.New(), uuid.New()
-		require.NoError(t, adapter.ReplaceServerConnections(ctx, "server-x",
-			[]*agentmodel.ServerConnection{rec("server-x", "ns-filter", x1, now)}))
-		require.NoError(t, adapter.ReplaceServerConnections(ctx, "server-y",
-			[]*agentmodel.ServerConnection{rec("server-y", "ns-filter", y1, now)}))
+		require.NoError(t, adapter.SyncServerConnections(ctx, "server-x", now,
+			[]*agentmodel.ServerConnection{rec("server-x", "ns-filter", x1)}, nil))
+		require.NoError(t, adapter.SyncServerConnections(ctx, "server-y", now,
+			[]*agentmodel.ServerConnection{rec("server-y", "ns-filter", y1)}, nil))
 
 		resp, err := adapter.ListServerConnections(ctx, "ns-filter", "server-x", time.Time{}, nil)
 		require.NoError(t, err)

--- a/pkg/apiserver/domain/agent/connection.go
+++ b/pkg/apiserver/domain/agent/connection.go
@@ -134,11 +134,14 @@ type ServerConnection struct {
 	Type ConnectionType
 	// Namespace is the namespace the connection belongs to.
 	Namespace string
-	// LastCommunicatedAt is the last time the connection was communicated with.
+	// LastCommunicatedAt is the last time the connection was communicated with. It is
+	// informational in the cluster view: the record is not re-written just because it advances
+	// (that would defeat the incremental-write model), so it reflects the connection's last
+	// identity-changing sync rather than its most recent message.
 	LastCommunicatedAt time.Time
-	// SnapshotAt is when this record was last refreshed by its owning server. It bounds
-	// staleness: records from a crashed server stop refreshing and are filtered out of
-	// cluster reads once SnapshotAt falls outside the staleness window.
+	// SnapshotAt is when this record was last written by its owning server. It is informational
+	// only; cluster-read staleness is now gated on the owning server's heartbeat, not on this
+	// field.
 	SnapshotAt time.Time
 }
 

--- a/pkg/apiserver/domain/agent/port/out.go
+++ b/pkg/apiserver/domain/agent/port/out.go
@@ -98,17 +98,32 @@ type ServerPersistencePort interface {
 	ListServers(ctx context.Context) ([]*agentmodel.Server, error)
 }
 
-// ServerConnectionPersistencePort persists per-server snapshots of live connections so the
-// cluster-wide connection view can be queried from any node.
+// ServerConnectionPersistencePort persists per-server connection records so the cluster-wide
+// connection view can be queried from any node.
+//
+// Liveness is decoupled from membership: a server refreshes a single heartbeat every cycle
+// (O(1)), while connection records are written only when they change. A record is visible in
+// the cluster view only while its owning server's heartbeat is fresh, so a crashed server's
+// connections drop out without any per-record rewrite.
 type ServerConnectionPersistencePort interface {
-	// ReplaceServerConnections atomically replaces all snapshot records owned by serverID
-	// with the provided set. An empty set clears the server's records (e.g. on shutdown or
-	// when it holds no connections).
-	ReplaceServerConnections(ctx context.Context, serverID string, conns []*agentmodel.ServerConnection) error
-	// ListServerConnections lists snapshot records, filtered by namespace. A non-empty
-	// serverID restricts the result to that one server; an empty serverID spans all servers.
-	// notBefore drops records whose SnapshotAt is older than it (stale/crashed servers); a
-	// zero notBefore returns all records.
+	// SyncServerConnections refreshes serverID's heartbeat to heartbeatAt and applies an
+	// incremental change set: upserts the given records (keyed by connection UID) and deletes
+	// the given UIDs. In steady state upserts and deletes are empty and only the heartbeat is
+	// written. Called once per snapshot cycle by the owning server.
+	SyncServerConnections(
+		ctx context.Context,
+		serverID string,
+		heartbeatAt time.Time,
+		upserts []*agentmodel.ServerConnection,
+		deletes []uuid.UUID,
+	) error
+	// RemoveServer deletes serverID's heartbeat and all its connection records, dropping the
+	// server out of the cluster view immediately (graceful shutdown, or self-cleanup on start).
+	RemoveServer(ctx context.Context, serverID string) error
+	// ListServerConnections lists connections owned by servers whose heartbeat is at or after
+	// notBefore (stale/crashed servers excluded); a zero notBefore includes every server. A
+	// non-empty serverID restricts the result to that one server; an empty serverID spans all.
+	// Results are filtered by namespace.
 	ListServerConnections(ctx context.Context, namespace string, serverID string, notBefore time.Time,
 		options *model.ListOptions) (*model.ListResponse[*agentmodel.ServerConnection], error)
 }

--- a/pkg/apiserver/domain/agent/service/connection.go
+++ b/pkg/apiserver/domain/agent/service/connection.go
@@ -65,6 +65,11 @@ type Service struct {
 	// UID. It is the baseline for the next cycle's incremental diff and is touched only from
 	// the single Run goroutine, so it needs no lock.
 	lastSnapshot map[uuid.UUID]agentmodel.ServerConnection
+
+	// needsReconcile forces the next snapshot to first clear any records left by a prior
+	// incarnation of this serverID before diffing. It stays set until that clear succeeds, so a
+	// transient failure cannot leave orphaned records advertised as live.
+	needsReconcile bool
 }
 
 // NewConnectionService creates a new instance of the Service struct.
@@ -84,6 +89,7 @@ func NewConnectionService(
 		snapshotInterval:                DefaultConnectionSnapshotInterval,
 		snapshotStaleness:               DefaultConnectionSnapshotStaleness,
 		lastSnapshot:                    nil,
+		needsReconcile:                  true,
 	}
 }
 
@@ -97,9 +103,10 @@ func (s *Service) Name() string {
 // the server's records on graceful shutdown so a stopped node drops out immediately rather
 // than lingering until its snapshot goes stale.
 func (s *Service) Run(ctx context.Context) error {
-	// Clear any records left by a prior incarnation of this server, then take an initial
-	// snapshot so connections appear promptly instead of only after the first interval.
-	s.reconcileFromScratch(ctx)
+	// Take an initial snapshot so connections appear promptly instead of only after the first
+	// interval. The first snapshot also clears any records left by a prior incarnation (see the
+	// needsReconcile handling in snapshotConnections).
+	s.snapshotConnections(ctx)
 
 	ticker := time.NewTicker(s.effectiveSnapshotInterval())
 	defer ticker.Stop()
@@ -327,31 +334,32 @@ func (s *Service) detectConnectionType(id any) agentmodel.ConnectionType {
 	return agentmodel.ConnectionTypeWebSocket
 }
 
-// reconcileFromScratch drops this server's stored records and re-syncs from an empty baseline,
-// so leftover records from a previous incarnation (same serverID) cannot linger as orphans.
-func (s *Service) reconcileFromScratch(ctx context.Context) {
-	serverID := s.serverIdentityProvider.CurrentServerID()
-	if serverID != "" {
-		err := s.serverConnectionPersistencePort.RemoveServer(ctx, serverID)
-		if err != nil {
-			s.logger.Warn("failed to clear stale connection records on start", slog.String("error", err.Error()))
-		}
-	}
-
-	s.lastSnapshot = nil
-
-	s.snapshotConnections(ctx)
-}
-
 // snapshotConnections refreshes this server's heartbeat and syncs only the connections that
 // changed since the last cycle: newly-added or field-changed records are upserted and dropped
 // connections are deleted. In steady state the diff is empty, so only the heartbeat is written.
+//
+// The first call (and any retry after a failed reconcile) first clears records left by a prior
+// incarnation of this serverID; until that clear succeeds it returns without writing anything,
+// so the server never advertises a fresh heartbeat over orphaned records.
 func (s *Service) snapshotConnections(ctx context.Context) {
 	serverID := s.serverIdentityProvider.CurrentServerID()
 	if serverID == "" {
 		s.logger.Warn("skipping connection snapshot: current server has no identity")
 
 		return
+	}
+
+	if s.needsReconcile {
+		err := s.serverConnectionPersistencePort.RemoveServer(ctx, serverID)
+		if err != nil {
+			s.logger.Warn("failed to clear stale connection records; staying out of the cluster view until it succeeds",
+				slog.String("error", err.Error()))
+
+			return
+		}
+
+		s.needsReconcile = false
+		s.lastSnapshot = nil
 	}
 
 	now := s.clock.Now()

--- a/pkg/apiserver/domain/agent/service/connection.go
+++ b/pkg/apiserver/domain/agent/service/connection.go
@@ -60,6 +60,11 @@ type Service struct {
 
 	snapshotInterval  time.Duration
 	snapshotStaleness time.Duration
+
+	// lastSnapshot is the set of connection records last synced to the shared store, keyed by
+	// UID. It is the baseline for the next cycle's incremental diff and is touched only from
+	// the single Run goroutine, so it needs no lock.
+	lastSnapshot map[uuid.UUID]agentmodel.ServerConnection
 }
 
 // NewConnectionService creates a new instance of the Service struct.
@@ -78,6 +83,7 @@ func NewConnectionService(
 		clock:                           clock.NewRealClock(),
 		snapshotInterval:                DefaultConnectionSnapshotInterval,
 		snapshotStaleness:               DefaultConnectionSnapshotStaleness,
+		lastSnapshot:                    nil,
 	}
 }
 
@@ -91,6 +97,10 @@ func (s *Service) Name() string {
 // the server's records on graceful shutdown so a stopped node drops out immediately rather
 // than lingering until its snapshot goes stale.
 func (s *Service) Run(ctx context.Context) error {
+	// Clear any records left by a prior incarnation of this server, then take an initial
+	// snapshot so connections appear promptly instead of only after the first interval.
+	s.reconcileFromScratch(ctx)
+
 	ticker := time.NewTicker(s.effectiveSnapshotInterval())
 	defer ticker.Stop()
 
@@ -317,8 +327,25 @@ func (s *Service) detectConnectionType(id any) agentmodel.ConnectionType {
 	return agentmodel.ConnectionTypeWebSocket
 }
 
-// snapshotConnections persists the current set of this server's local connections,
-// replacing any previously stored set for this server.
+// reconcileFromScratch drops this server's stored records and re-syncs from an empty baseline,
+// so leftover records from a previous incarnation (same serverID) cannot linger as orphans.
+func (s *Service) reconcileFromScratch(ctx context.Context) {
+	serverID := s.serverIdentityProvider.CurrentServerID()
+	if serverID != "" {
+		err := s.serverConnectionPersistencePort.RemoveServer(ctx, serverID)
+		if err != nil {
+			s.logger.Warn("failed to clear stale connection records on start", slog.String("error", err.Error()))
+		}
+	}
+
+	s.lastSnapshot = nil
+
+	s.snapshotConnections(ctx)
+}
+
+// snapshotConnections refreshes this server's heartbeat and syncs only the connections that
+// changed since the last cycle: newly-added or field-changed records are upserted and dropped
+// connections are deleted. In steady state the diff is empty, so only the heartbeat is written.
 func (s *Service) snapshotConnections(ctx context.Context) {
 	serverID := s.serverIdentityProvider.CurrentServerID()
 	if serverID == "" {
@@ -328,11 +355,55 @@ func (s *Service) snapshotConnections(ctx context.Context) {
 	}
 
 	now := s.clock.Now()
+	current := s.currentServerConnections(serverID, now)
+
+	var (
+		upserts []*agentmodel.ServerConnection
+		deletes []uuid.UUID
+	)
+
+	for uid, record := range current {
+		if prev, ok := s.lastSnapshot[uid]; !ok || !serverConnectionEqual(prev, *record) {
+			upserts = append(upserts, record)
+		}
+	}
+
+	for uid := range s.lastSnapshot {
+		if _, ok := current[uid]; !ok {
+			deletes = append(deletes, uid)
+		}
+	}
+
+	err := s.serverConnectionPersistencePort.SyncServerConnections(ctx, serverID, now, upserts, deletes)
+	if err != nil {
+		// Keep lastSnapshot unchanged so the same diff is retried next cycle.
+		s.logger.Error("failed to sync connection snapshot", slog.String("error", err.Error()))
+
+		return
+	}
+
+	next := make(map[uuid.UUID]agentmodel.ServerConnection, len(current))
+	for uid, record := range current {
+		next[uid] = *record
+	}
+
+	s.lastSnapshot = next
+
+	s.logger.Debug("synced connection snapshot",
+		slog.Int("upserts", len(upserts)), slog.Int("deletes", len(deletes)))
+}
+
+// currentServerConnections builds this server's connection records from its live connection
+// map, keyed by UID.
+func (s *Service) currentServerConnections(
+	serverID string,
+	now time.Time,
+) map[uuid.UUID]*agentmodel.ServerConnection {
 	conns := s.connectionMap.Values()
 
-	records := make([]*agentmodel.ServerConnection, 0, len(conns))
+	records := make(map[uuid.UUID]*agentmodel.ServerConnection, len(conns))
 	for _, conn := range conns {
-		records = append(records, &agentmodel.ServerConnection{
+		records[conn.UID] = &agentmodel.ServerConnection{
 			ServerID:           serverID,
 			UID:                conn.UID,
 			InstanceUID:        conn.InstanceUID,
@@ -340,17 +411,22 @@ func (s *Service) snapshotConnections(ctx context.Context) {
 			Namespace:          conn.Namespace,
 			LastCommunicatedAt: conn.LastCommunicatedAt,
 			SnapshotAt:         now,
-		})
+		}
 	}
 
-	err := s.serverConnectionPersistencePort.ReplaceServerConnections(ctx, serverID, records)
-	if err != nil {
-		s.logger.Error("failed to snapshot connections", slog.String("error", err.Error()))
+	return records
+}
 
-		return
-	}
-
-	s.logger.Debug("snapshotted connections", slog.Int("count", len(records)))
+// serverConnectionEqual compares the stable identity of two records, ignoring the timestamps
+// (SnapshotAt, LastCommunicatedAt). Excluding LastCommunicatedAt is deliberate: it changes on
+// every agent message and re-upserting for it would defeat the incremental-write goal, so the
+// cluster view's LastCommunicatedAt is best-effort (as of the record's last identity change).
+func serverConnectionEqual(a, b agentmodel.ServerConnection) bool {
+	return a.ServerID == b.ServerID &&
+		a.UID == b.UID &&
+		a.InstanceUID == b.InstanceUID &&
+		a.Type == b.Type &&
+		a.Namespace == b.Namespace
 }
 
 // clearSnapshotOnShutdown removes this server's snapshot records so it drops out of the
@@ -369,7 +445,7 @@ func (s *Service) clearSnapshotOnShutdown(ctx context.Context) {
 	clearCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), clearTimeout)
 	defer cancel()
 
-	err := s.serverConnectionPersistencePort.ReplaceServerConnections(clearCtx, serverID, nil)
+	err := s.serverConnectionPersistencePort.RemoveServer(clearCtx, serverID)
 	if err != nil {
 		s.logger.Warn("failed to clear connection snapshot on shutdown", slog.String("error", err.Error()))
 	}

--- a/pkg/apiserver/domain/agent/service/connection_internal_test.go
+++ b/pkg/apiserver/domain/agent/service/connection_internal_test.go
@@ -182,6 +182,77 @@ func TestConnectionService_snapshotConnectionsIsIncremental(t *testing.T) {
 	assert.Equal(t, conn.UID, store.deletes[0])
 }
 
+// reconcileFailStore fails the first N RemoveServer calls, then succeeds.
+type reconcileFailStore struct {
+	fakeServerConnectionStore
+
+	removeFailsLeft int
+}
+
+func (s *reconcileFailStore) RemoveServer(ctx context.Context, serverID string) error {
+	if s.removeFailsLeft > 0 {
+		s.removeFailsLeft--
+
+		return errFakeSend
+	}
+
+	return s.fakeServerConnectionStore.RemoveServer(ctx, serverID)
+}
+
+// TestConnectionService_snapshotRetriesReconcile guards the fix for the startup-orphan risk:
+// while the initial clear-of-prior-records fails, the server writes nothing (no heartbeat), so
+// it never advertises a fresh heartbeat over records it could not reconcile; it retries until
+// the clear succeeds.
+func TestConnectionService_snapshotRetriesReconcile(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := &reconcileFailStore{fakeServerConnectionStore: fakeServerConnectionStore{}, removeFailsLeft: 1}
+	svc := NewConnectionService(nil, stubServerIdentity{id: "server-1"}, store, slog.Default())
+
+	conn := agentmodel.NewConnection("conn-a", agentmodel.ConnectionTypeWebSocket)
+	conn.SetNamespace("default")
+	require.NoError(t, svc.SaveConnection(ctx, conn))
+
+	// First cycle: the reconcile clear fails, so nothing is synced.
+	svc.snapshotConnections(ctx)
+	assert.Empty(t, store.syncedServerID, "no heartbeat or membership until the clear succeeds")
+
+	// Next cycle: the clear succeeds and the connection is synced.
+	svc.snapshotConnections(ctx)
+	assert.Equal(t, "server-1", store.syncedServerID)
+	require.Len(t, store.upserts, 1)
+}
+
+// syncFailStore reconciles fine but fails every SyncServerConnections.
+type syncFailStore struct {
+	fakeServerConnectionStore
+}
+
+func (s *syncFailStore) SyncServerConnections(
+	_ context.Context, _ string, _ time.Time, _ []*agentmodel.ServerConnection, _ []uuid.UUID,
+) error {
+	return errFakeSend
+}
+
+// TestConnectionService_snapshotKeepsBaselineOnSyncError checks that a failed sync leaves the
+// diff baseline untouched so the same change set is retried next cycle.
+func TestConnectionService_snapshotKeepsBaselineOnSyncError(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	svc := NewConnectionService(nil, stubServerIdentity{id: "server-1"}, &syncFailStore{}, slog.Default())
+
+	conn := agentmodel.NewConnection("conn-a", agentmodel.ConnectionTypeWebSocket)
+	conn.SetNamespace("default")
+	require.NoError(t, svc.SaveConnection(ctx, conn))
+
+	svc.snapshotConnections(ctx)
+
+	assert.False(t, svc.needsReconcile, "the reconcile clear succeeded")
+	assert.Nil(t, svc.lastSnapshot, "a failed sync must not advance the diff baseline")
+}
+
 func TestConnectionService_ListClusterConnectionsAppliesStalenessWindow(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/apiserver/domain/agent/service/connection_internal_test.go
+++ b/pkg/apiserver/domain/agent/service/connection_internal_test.go
@@ -59,18 +59,30 @@ func (s stubServerIdentity) CurrentServer(context.Context) (*agentmodel.Server, 
 }
 
 type fakeServerConnectionStore struct {
-	replacedServerID string
-	replaced         []*agentmodel.ServerConnection
-	listNotBefore    time.Time
-	listServerID     string
-	listResult       []*agentmodel.ServerConnection
+	syncedServerID  string
+	heartbeatAt     time.Time
+	upserts         []*agentmodel.ServerConnection
+	deletes         []uuid.UUID
+	removedServerID string
+	listNotBefore   time.Time
+	listServerID    string
+	listResult      []*agentmodel.ServerConnection
 }
 
-func (f *fakeServerConnectionStore) ReplaceServerConnections(
-	_ context.Context, serverID string, conns []*agentmodel.ServerConnection,
+func (f *fakeServerConnectionStore) SyncServerConnections(
+	_ context.Context, serverID string, heartbeatAt time.Time,
+	upserts []*agentmodel.ServerConnection, deletes []uuid.UUID,
 ) error {
-	f.replacedServerID = serverID
-	f.replaced = conns
+	f.syncedServerID = serverID
+	f.heartbeatAt = heartbeatAt
+	f.upserts = upserts
+	f.deletes = deletes
+
+	return nil
+}
+
+func (f *fakeServerConnectionStore) RemoveServer(_ context.Context, serverID string) error {
+	f.removedServerID = serverID
 
 	return nil
 }
@@ -103,11 +115,11 @@ func TestConnectionService_snapshotConnections(t *testing.T) {
 
 	svc.snapshotConnections(ctx)
 
-	assert.Equal(t, "server-1", store.replacedServerID)
-	require.Len(t, store.replaced, 1)
-	assert.Equal(t, "server-1", store.replaced[0].ServerID)
-	assert.Equal(t, instanceUID, store.replaced[0].InstanceUID)
-	assert.Equal(t, conn.UID, store.replaced[0].UID)
+	assert.Equal(t, "server-1", store.syncedServerID)
+	require.Len(t, store.upserts, 1)
+	assert.Equal(t, "server-1", store.upserts[0].ServerID)
+	assert.Equal(t, instanceUID, store.upserts[0].InstanceUID)
+	assert.Equal(t, conn.UID, store.upserts[0].UID)
 }
 
 func TestConnectionService_snapshotConnectionsSkipsWithoutIdentity(t *testing.T) {
@@ -118,8 +130,56 @@ func TestConnectionService_snapshotConnectionsSkipsWithoutIdentity(t *testing.T)
 
 	svc.snapshotConnections(context.Background())
 
-	assert.Empty(t, store.replacedServerID)
-	assert.Nil(t, store.replaced)
+	assert.Empty(t, store.syncedServerID)
+	assert.Nil(t, store.upserts)
+}
+
+// TestConnectionService_snapshotConnectionsIsIncremental pins the #486 behavior: each cycle
+// writes only the diff since the last one — new/changed connections are upserted, dropped ones
+// deleted, and a steady state writes nothing but the heartbeat.
+func TestConnectionService_snapshotConnectionsIsIncremental(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store := &fakeServerConnectionStore{}
+	svc := NewConnectionService(nil, stubServerIdentity{id: "server-1"}, store, slog.Default())
+
+	conn := agentmodel.NewConnection("conn-a", agentmodel.ConnectionTypeWebSocket)
+	conn.SetNamespace("default")
+	require.NoError(t, svc.SaveConnection(ctx, conn))
+
+	// First cycle upserts the new connection.
+	svc.snapshotConnections(ctx)
+	require.Len(t, store.upserts, 1)
+	assert.Empty(t, store.deletes)
+
+	// Steady state: nothing changed, so nothing is written but the heartbeat.
+	store.upserts, store.deletes = nil, nil
+
+	svc.snapshotConnections(ctx)
+	assert.Empty(t, store.upserts)
+	assert.Empty(t, store.deletes)
+	assert.Equal(t, "server-1", store.syncedServerID, "the heartbeat is still refreshed")
+
+	// An identity change re-upserts just that record.
+	conn.SetInstanceUID(uuid.New())
+	require.NoError(t, svc.SaveConnection(ctx, conn))
+
+	store.upserts, store.deletes = nil, nil
+
+	svc.snapshotConnections(ctx)
+	require.Len(t, store.upserts, 1)
+	assert.Empty(t, store.deletes)
+
+	// Dropping the connection deletes it.
+	require.NoError(t, svc.DeleteConnection(ctx, conn))
+
+	store.upserts, store.deletes = nil, nil
+
+	svc.snapshotConnections(ctx)
+	assert.Empty(t, store.upserts)
+	require.Len(t, store.deletes, 1)
+	assert.Equal(t, conn.UID, store.deletes[0])
 }
 
 func TestConnectionService_ListClusterConnectionsAppliesStalenessWindow(t *testing.T) {
@@ -403,8 +463,7 @@ func TestConnectionService_RunClearsSnapshotOnCancel(t *testing.T) {
 	cancel() // Run must observe the cancelled ctx and clear this server's snapshot.
 
 	require.NoError(t, svc.Run(ctx))
-	assert.Equal(t, "server-1", store.replacedServerID)
-	assert.Nil(t, store.replaced, "shutdown clears the server's records")
+	assert.Equal(t, "server-1", store.removedServerID, "shutdown removes the server's records")
 }
 
 func TestConnectionService_clearSnapshotOnShutdownSkipsWithoutIdentity(t *testing.T) {
@@ -414,7 +473,7 @@ func TestConnectionService_clearSnapshotOnShutdownSkipsWithoutIdentity(t *testin
 	svc := NewConnectionService(nil, stubServerIdentity{id: ""}, store, slog.Default())
 
 	svc.clearSnapshotOnShutdown(context.Background())
-	assert.Empty(t, store.replacedServerID, "no identity means no clear call")
+	assert.Empty(t, store.removedServerID, "no identity means no clear call")
 }
 
 func TestConnectionErrors(t *testing.T) {
@@ -432,9 +491,13 @@ func TestConnectionErrors(t *testing.T) {
 // error branches of the snapshot/cluster paths.
 type erroringServerConnectionStore struct{ err error }
 
-func (e *erroringServerConnectionStore) ReplaceServerConnections(
-	_ context.Context, _ string, _ []*agentmodel.ServerConnection,
+func (e *erroringServerConnectionStore) SyncServerConnections(
+	_ context.Context, _ string, _ time.Time, _ []*agentmodel.ServerConnection, _ []uuid.UUID,
 ) error {
+	return e.err
+}
+
+func (e *erroringServerConnectionStore) RemoveServer(_ context.Context, _ string) error {
 	return e.err
 }
 
@@ -477,18 +540,20 @@ func TestConnectionService_ListConnectionsNilOptions(t *testing.T) {
 
 // signalingStore reports each ReplaceServerConnections call on a channel so a test
 // can observe the periodic snapshot tick deterministically.
-type signalingStore struct{ replaced chan struct{} }
+type signalingStore struct{ synced chan struct{} }
 
-func (s *signalingStore) ReplaceServerConnections(
-	_ context.Context, _ string, _ []*agentmodel.ServerConnection,
+func (s *signalingStore) SyncServerConnections(
+	_ context.Context, _ string, _ time.Time, _ []*agentmodel.ServerConnection, _ []uuid.UUID,
 ) error {
 	select {
-	case s.replaced <- struct{}{}:
+	case s.synced <- struct{}{}:
 	default:
 	}
 
 	return nil
 }
+
+func (s *signalingStore) RemoveServer(_ context.Context, _ string) error { return nil }
 
 func (s *signalingStore) ListServerConnections(
 	_ context.Context, _ string, _ string, _ time.Time, _ *model.ListOptions,
@@ -500,7 +565,7 @@ func (s *signalingStore) ListServerConnections(
 func TestConnectionService_RunSnapshotsOnTick(t *testing.T) {
 	t.Parallel()
 
-	store := &signalingStore{replaced: make(chan struct{}, 1)}
+	store := &signalingStore{synced: make(chan struct{}, 2)}
 	svc := NewConnectionService(nil, stubServerIdentity{id: "server-1"}, store, slog.Default())
 	svc.snapshotInterval = time.Millisecond
 
@@ -510,10 +575,14 @@ func TestConnectionService_RunSnapshotsOnTick(t *testing.T) {
 
 	go func() { done <- svc.Run(ctx) }()
 
-	select {
-	case <-store.replaced:
-	case <-time.After(2 * time.Second):
-		t.Fatal("expected a snapshot within the interval")
+	// The first sync is Run's initial reconcile; wait for a second one so the periodic
+	// ticker.C branch is exercised, not only the startup snapshot.
+	for range 2 {
+		select {
+		case <-store.synced:
+		case <-time.After(2 * time.Second):
+			t.Fatal("expected a periodic snapshot within the interval")
+		}
 	}
 
 	cancel()


### PR DESCRIPTION
## Summary

Implements #486. The cluster-wide connection view had each server **rewrite its entire connection set every 30s** (`ReplaceServerConnections` = `DeleteMany` + `InsertMany`): write amplification proportional to the connection count even when nothing changed, and liveness lag of 3× the interval.

**Decision (per the issue's first acceptance item): incremental, by decoupling liveness from membership via a per-server heartbeat.**

## Design

- **Liveness** — each server refreshes a single heartbeat record per cycle (**O(1)**). A connection is visible in the cluster view only while its owning server's heartbeat is fresh, so a crashed server's connections drop out without any per-record rewrite. MongoDB carries a **TTL index** on the heartbeat so dead servers self-clean.
- **Membership** — the scheduler diffs its current connections against the last synced set and writes **only the delta**: new/changed records upserted (keyed by UID), dropped records deleted. **In steady state only the heartbeat is written.**
- On start, each server clears any records left by a prior incarnation of its `serverID`, then takes an initial snapshot (connections appear promptly, no orphans).

## Port change

`ServerConnectionPersistencePort`:
- `ReplaceServerConnections` → `SyncServerConnections(serverID, heartbeatAt, upserts, deletes)` + `RemoveServer(serverID)`
- `ListServerConnections` now joins connections to fresh heartbeats (liveness), instead of filtering a per-record `snapshotAt`.

Both the MongoDB and in-memory adapters implement the new contract; the connection service does the diffing.

## Correctness / trade-offs

- `ListClusterConnections` correctness preserved: alive servers visible, stale/crashed excluded (now by heartbeat, verified in both adapters' tests).
- The cluster view's `LastCommunicatedAt` is intentionally **best-effort** — a record is not re-written just because that field changed, since re-upserting on every agent message would defeat the incremental-write goal. The agent record remains the authoritative source of connectivity (as the code already documented).
- Crashed-server connection docs are read-excluded immediately and cleaned when that `serverID` restarts; their heartbeats expire via the TTL index. A global reaper is a possible follow-up but not needed for correctness.

## Verification
- `go test -short -race ./pkg/apiserver/domain/agent/service/ ./pkg/apiserver/adapter/secondary/persistence/inmemory/` passes; new tests cover the incremental diff (upsert-added / skip-unchanged / delete-removed / heartbeat-only steady state) and the heartbeat-based staleness filter. `connection.go` stays ~100% covered.
- MongoDB adapter test updated to the new API (runs via testcontainers in CI; skipped locally without Docker).
- `go build ./...` clean, `golangci-lint run` — 0 issues.

Closes #486

🤖 Generated with [Claude Code](https://claude.com/claude-code)