### PR TITLE
docs: add CONTRIBUTING with branch lifecycle guidance (#494)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,85 @@
+# Contributing
+
+Thanks for helping improve OpAMP Commander. This guide covers the local workflow
+and, in particular, how branches are expected to live and die so that merged work
+doesn't linger and drift.
+
+## Getting started
+
+See the [README](README.md#development) for setup, build, test, and lint commands.
+Before opening a pull request, run the relevant checks:
+
+```sh
+make lint && make test        # Go
+cd web && npx tsc --noEmit && npm run lint && npm test && npm run build   # web
+```
+
+## Commits and pull requests
+
+- **Conventional Commits.** Format subjects as `type(scope): summary`
+  (e.g. `feat(agent): …`, `fix(opamp): …`, `chore(dev): …`). Common types:
+  `feat`, `fix`, `refactor`, `perf`, `test`, `docs`, `chore`, `ci`.
+- **Reference the issue** the PR closes in the body (`Closes #494`).
+- **Squash merge.** PRs land on `main` as a single squashed commit. This means the
+  individual commits on your branch do *not* appear in `main`'s history — which is
+  why `git branch --merged` cannot detect a squash-merged branch (see below).
+
+## Branch lifecycle
+
+Branches are cheap to create and cheap to delete. The failure mode we care about
+is the opposite: a branch that was **already merged** hanging around, masquerading
+as work-in-progress, and silently carrying a stale version of code that `main` has
+since moved past. Rebasing such a branch can produce add/add conflict storms and,
+worse, can *revert* a shipped feature during a careless conflict resolution.
+
+### Naming
+
+Use `type/short-description`, optionally suffixed with the issue number:
+`feat/agent-search`, `fix/http-idle-timeout`, `chore/branch-lifecycle-doc-494`.
+
+### While a branch is open
+
+- **Rebase onto `main`, don't merge `main` in.** `git fetch origin && git rebase
+  origin/main` keeps history linear and the diff honest. Avoid
+  `git merge main` into a feature branch — it muddies the diff and hides drift.
+- **Rebase regularly**, not just once at the end. A branch that tracks `main`
+  closely rarely conflicts; one that diverges for weeks becomes a hazard.
+
+### Rebase vs. abandon
+
+Before rebasing an old branch, first ask whether its work has **already landed**:
+
+```sh
+git fetch origin --prune
+# Has this branch's content already been merged (even via squash)?
+git log --oneline origin/main..my-branch     # commits unique to the branch
+git diff origin/main...my-branch --stat        # net change vs. main
+```
+
+- If the unique commits / diff are **empty or already represent shipped work**,
+  the branch is superseded — **delete it, don't rebase it.** Rebasing a
+  superseded branch is what produces add/add conflicts and risks reverting `main`.
+- If it still holds genuinely unmerged work, rebase it onto `origin/main` and
+  continue.
+
+### After a merge
+
+Merged PR branches are deleted automatically on the remote
+(`delete_branch_on_merge` is enabled on the repository), but the **local copy
+stays** until you remove it. Prune periodically:
+
+```sh
+git fetch origin --prune          # drop remote-tracking refs whose remote is gone
+
+# List local branches whose upstream was deleted (typically = merged):
+git for-each-ref --format='%(refname:short) %(upstream:track)' refs/heads \
+  | grep '\[gone\]'
+
+# Delete one:
+git branch -D <branch>
+```
+
+`git branch -d` (lowercase) refuses to delete a branch that isn't reachable-merged
+into `main` — which, because of squash merges, includes most already-merged
+branches. Verify a branch is truly merged (with the `git log`/`git diff` checks
+above) before reaching for `git branch -D`.

--- a/README.md
+++ b/README.md
@@ -117,6 +117,9 @@ Open <http://localhost:3000>. See [`web/README.md`](web/README.md) for details.
 
 ## Development
 
+See [`CONTRIBUTING.md`](CONTRIBUTING.md) for commit conventions, the pull-request
+flow, and the branch lifecycle (when to rebase vs. delete a branch).
+
 ### Infrastructure
 
 ```sh


### PR DESCRIPTION
Closes #494.

## What

Adds a `CONTRIBUTING.md` and links it from the README's Development section.

The doc's core is the **Branch lifecycle** section addressing the issue: how to
tell a superseded (already-merged) branch from genuinely unmerged work — noting
that squash merges hide merged branches from `git branch --merged` — plus rebase
(not merge) onto `main`, and pruning local branches whose upstream is `[gone]`.

## Issue proposals status

- **Auto-delete head branches on merge** — already enabled on the repo
  (`delete_branch_on_merge: true`), so remote branches are pruned on merge. No change needed.
- **Dev-doc on branch lifecycle** — this PR.
- **Prune stale local branches** — done separately on the maintainer's clone
  (175 local branches whose upstream remote was already deleted were removed,
  259 → 84).

🤖 Generated with [Claude Code](https://claude.com/claude-code)