### PR TITLE
perf(persistence): single-pass, consistent list pagination via $facet

### DIFF
--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/agent.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/agent.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
-	"sync"
 
 	"github.com/google/uuid"
 	"github.com/samber/lo"
@@ -181,20 +180,11 @@ func (a *AgentRepository) DeleteAgent(ctx context.Context, instanceUID uuid.UUID
 }
 
 // ListAgentsBySelector implements agentport.AgentPersistencePort.
-//
-//nolint:funlen // Reason: unavoidable.
 func (a *AgentRepository) ListAgentsBySelector(
 	ctx context.Context,
 	selector agentmodel.AgentSelector,
 	options *model.ListOptions,
 ) (*model.ListResponse[*agentmodel.Agent], error) {
-	var (
-		// To prevent shadowing in goroutines, we use retval suffix.
-		countRetval         int64
-		continueTokenRetval string
-		entitiesRetval      []*entity.Agent
-	)
-
 	if options == nil {
 		//exhaustruct:ignore
 		options = &model.ListOptions{}
@@ -205,85 +195,26 @@ func (a *AgentRepository) ListAgentsBySelector(
 		return nil, fmt.Errorf("invalid continue token: %w", err)
 	}
 
-	allConditions := SelectorToMatchConditions(AgentSelectorToEntity(selector))
-
+	conditions := SelectorToMatchConditions(AgentSelectorToEntity(selector))
 	if options.ConnectedOnly {
-		allConditions = append(allConditions, connectedMatchFilter())
+		conditions = append(conditions, connectedMatchFilter())
 	}
 
-	// Add continue token condition if present
-	continueTokenFilter := withContinueToken(continueTokenObjectID)
-	if continueTokenFilter != nil {
-		allConditions = append(allConditions, continueTokenFilter)
-	}
+	prefix := mongo.Pipeline{bson.D{{Key: "$match", Value: buildFilter(conditions)}}}
 
-	filter := buildFilter(allConditions)
-
-	var queryWg sync.WaitGroup
-
-	var (
-		fErr error
-		lErr error
+	entities, continueToken, remaining, err := aggregateListPage[entity.Agent](
+		ctx, a.logger, a.collection, prefix, continueTokenObjectID, options.Limit,
 	)
-
-	queryWg.Go(func() {
-		cursor, err := a.collection.Find(ctx, filter, withPageOptions(options.Limit))
-		if err != nil {
-			fErr = fmt.Errorf("failed to find agents by selector from mongodb: %w", err)
-
-			return
-		}
-
-		defer func() {
-			closeErr := cursor.Close(ctx)
-			if closeErr != nil {
-				a.logger.Warn("failed to close mongodb cursor", slog.String("error", closeErr.Error()))
-			}
-		}()
-
-		var entities []*entity.Agent
-
-		err = cursor.All(ctx, &entities)
-		if err != nil {
-			fErr = fmt.Errorf("failed to decode agents by selector from mongodb: %w", err)
-
-			return
-		}
-
-		continueToken, err := getContinueTokenFromEntities(entities)
-		if err != nil {
-			fErr = fmt.Errorf("failed to get continue token from entities: %w", err)
-
-			return
-		}
-
-		entitiesRetval = entities
-		continueTokenRetval = continueToken
-	})
-
-	queryWg.Go(func() {
-		cnt, err := a.collection.CountDocuments(ctx, filter)
-		if err != nil {
-			lErr = fmt.Errorf("failed to count agents by selector in mongodb: %w", err)
-
-			return
-		}
-
-		countRetval = cnt
-	})
-
-	queryWg.Wait()
-
-	if fErr != nil || lErr != nil {
-		return nil, fmt.Errorf("list by selector operation failed: %w %w", fErr, lErr)
+	if err != nil {
+		return nil, err
 	}
 
 	return &model.ListResponse[*agentmodel.Agent]{
-		Items: lo.Map(entitiesRetval, func(item *entity.Agent, _ int) *agentmodel.Agent {
+		Items: lo.Map(entities, func(item *entity.Agent, _ int) *agentmodel.Agent {
 			return item.ToDomain()
 		}),
-		Continue:           continueTokenRetval,
-		RemainingItemCount: countRetval - int64(len(entitiesRetval)),
+		Continue:           continueToken,
+		RemainingItemCount: remaining,
 	}, nil
 }
 
@@ -334,25 +265,28 @@ func (a *AgentRepository) SearchAgents(
 		}, nil
 	}
 
-	// Build search filter
-	filter, err := a.buildSearchFilter(namespace, query, options)
+	continueTokenObjectID, err := bson.ObjectIDFromHex(options.Continue)
+	if err != nil && options.Continue != "" {
+		return nil, fmt.Errorf("invalid continue token: %w", err)
+	}
+
+	prefix := mongo.Pipeline{
+		bson.D{{Key: "$match", Value: buildFilter(a.buildSearchConditions(namespace, query, options))}},
+	}
+
+	entities, continueToken, remaining, err := aggregateListPage[entity.Agent](
+		ctx, a.logger, a.collection, prefix, continueTokenObjectID, options.Limit,
+	)
 	if err != nil {
 		return nil, err
 	}
 
-	// Execute parallel queries
-	entities, continueToken, count, err := a.executeSearchQueries(ctx, filter, options)
-	if err != nil {
-		return nil, err
-	}
-
-	// Convert to domain models
 	return &model.ListResponse[*agentmodel.Agent]{
 		Items: lo.Map(entities, func(item *entity.Agent, _ int) *agentmodel.Agent {
 			return item.ToDomain()
 		}),
 		Continue:           continueToken,
-		RemainingItemCount: count - int64(len(entities)),
+		RemainingItemCount: remaining,
 	}, nil
 }
 
@@ -377,20 +311,13 @@ func validateSearchQuery(query string) error {
 	return nil
 }
 
-func (a *AgentRepository) buildSearchFilter(
+// buildSearchConditions builds the match conditions for a non-empty search query. The
+// continue-token condition is applied by [aggregateListPage], not here.
+func (a *AgentRepository) buildSearchConditions(
 	namespace string,
 	query string,
 	options *model.ListOptions,
-) (bson.M, error) {
-	if query == "" {
-		return bson.M{}, nil
-	}
-
-	continueTokenObjectID, err := bson.ObjectIDFromHex(options.Continue)
-	if err != nil && options.Continue != "" {
-		return nil, fmt.Errorf("invalid continue token: %w", err)
-	}
-
+) []bson.M {
 	// Prefix-match instanceUidString with a parameterized range scan instead of a
 	// user-built $regex: instanceUidString is always a lower-cased UUID, so we
 	// lower-case the query (preserving the previous case-insensitive behaviour) and
@@ -413,86 +340,7 @@ func (a *AgentRepository) buildSearchFilter(
 		conditions = append(conditions, connectedMatchFilter())
 	}
 
-	// Add continue token condition if present
-	continueTokenFilter := withContinueToken(continueTokenObjectID)
-	if continueTokenFilter != nil {
-		conditions = append(conditions, continueTokenFilter)
-	}
-
-	return buildFilter(conditions), nil
-}
-
-func (a *AgentRepository) executeSearchQueries(
-	ctx context.Context,
-	filter bson.M,
-	options *model.ListOptions,
-) ([]*entity.Agent, string, int64, error) {
-	var (
-		entities      []*entity.Agent
-		continueToken string
-		count         int64
-		findErr       error
-		countErr      error
-	)
-
-	var queryWg sync.WaitGroup
-
-	queryWg.Go(func() {
-		entities, continueToken, findErr = a.findAgents(ctx, filter, options)
-	})
-
-	queryWg.Go(func() {
-		count, countErr = a.countAgents(ctx, filter)
-	})
-
-	queryWg.Wait()
-
-	if findErr != nil || countErr != nil {
-		return nil, "", 0, fmt.Errorf("search operation failed: %w %w", findErr, countErr)
-	}
-
-	return entities, continueToken, count, nil
-}
-
-func (a *AgentRepository) findAgents(
-	ctx context.Context,
-	filter bson.M,
-	options *model.ListOptions,
-) ([]*entity.Agent, string, error) {
-	cursor, err := a.collection.Find(ctx, filter, withPageOptions(options.Limit))
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to search agents from mongodb: %w", err)
-	}
-
-	defer func() {
-		closeErr := cursor.Close(ctx)
-		if closeErr != nil {
-			a.logger.Warn("failed to close mongodb cursor", slog.String("error", closeErr.Error()))
-		}
-	}()
-
-	var entities []*entity.Agent
-
-	err = cursor.All(ctx, &entities)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to decode search agents from mongodb: %w", err)
-	}
-
-	continueToken, err := getContinueTokenFromEntities(entities)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to get continue token from entities: %w", err)
-	}
-
-	return entities, continueToken, nil
-}
-
-func (a *AgentRepository) countAgents(ctx context.Context, filter bson.M) (int64, error) {
-	count, err := a.collection.CountDocuments(ctx, filter)
-	if err != nil {
-		return 0, fmt.Errorf("failed to count search agents in mongodb: %w", err)
-	}
-
-	return count, nil
+	return conditions
 }
 
 // ensureIndexes creates necessary indexes for the agent collection.

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/common.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/common.go
@@ -7,7 +7,7 @@ import (
 	"log/slog"
 	"maps"
 	"reflect"
-	"sync"
+	"slices"
 
 	"go.mongodb.org/mongo-driver/v2/bson"
 	"go.mongodb.org/mongo-driver/v2/mongo"
@@ -90,7 +90,7 @@ func (a *commonEntityAdapter[Entity, KeyType]) list(
 	return a.listWithFilter(ctx, options, nil)
 }
 
-//nolint:funlen // Reason: unavoidable, runs find + count and assembles a list response.
+// listWithFilter lists entities matching the soft-delete filter combined with extraFilter.
 func (a *commonEntityAdapter[Entity, KeyType]) listWithFilter(
 	ctx context.Context,
 	options *model.ListOptions,
@@ -113,80 +113,104 @@ func (a *commonEntityAdapter[Entity, KeyType]) listWithFilter(
 		baseFilter = combineFilters(a.excludeDeletedFilter(), extraFilter)
 	}
 
-	var (
-		countRetval         int64
-		continueTokenRetval string
-		entitiesRetval      []*Entity
-		fErr                error
-		lErr                error
+	if baseFilter == nil {
+		baseFilter = bson.M{}
+	}
+
+	prefix := mongo.Pipeline{bson.D{{Key: "$match", Value: baseFilter}}}
+
+	entities, continueToken, remaining, err := aggregateListPage[Entity](
+		ctx, a.logger, a.collection, prefix, continueTokenObjectID, options.Limit,
 	)
-
-	findTask := func() {
-		entities, listErr := a.listWithContinueTokenAndLimit(
-			ctx, continueTokenObjectID, options.Limit, baseFilter,
-		)
-		if listErr != nil {
-			fErr = fmt.Errorf("failed to list resources from mongodb: %w", listErr)
-
-			return
-		}
-
-		continueToken, tokenErr := getContinueTokenFromEntities(entities)
-		if tokenErr != nil {
-			fErr = fmt.Errorf("failed to get continue token from entities: %w", tokenErr)
-
-			return
-		}
-
-		entitiesRetval = entities
-		continueTokenRetval = continueToken
-	}
-
-	countTask := func() {
-		filter := combineFilters(baseFilter, withContinueToken(continueTokenObjectID))
-
-		cnt, countErr := a.collection.CountDocuments(ctx, filter)
-		if countErr != nil {
-			lErr = fmt.Errorf("failed to count resources in mongodb: %w", countErr)
-
-			return
-		}
-
-		countRetval = cnt
-	}
-
-	runListQueries(ctx, findTask, countTask)
-
-	if fErr != nil || lErr != nil {
-		return nil, fmt.Errorf("list operation failed: %w %w", fErr, lErr)
+	if err != nil {
+		return nil, err
 	}
 
 	return &model.ListResponse[*Entity]{
-		Items:              entitiesRetval,
-		Continue:           continueTokenRetval,
-		RemainingItemCount: countRetval - int64(len(entitiesRetval)),
+		Items:              entities,
+		Continue:           continueToken,
+		RemainingItemCount: remaining,
 	}, nil
 }
 
-// runListQueries runs the find and count queries that back list operations.
-// Outside a MongoDB session it runs them in parallel to save a round-trip.
-// Inside a session (i.e. a transaction) the driver's *mongo.Session is NOT
-// goroutine-safe — see https://pkg.go.dev/go.mongodb.org/mongo-driver/v2/mongo#Session
-// — so we serialise to avoid session-state corruption / "transaction in progress"
-// errors when a List call happens inside [port.TransactionRunner].
-func runListQueries(ctx context.Context, findTask, countTask func()) {
-	if mongo.SessionFromContext(ctx) != nil {
-		findTask()
-		countTask()
+// facetPage is the single document a $facet emits: the page plus a one-element count array
+// ($count emits nothing when zero documents match).
+type facetPage[Entity any] struct {
+	Items []*Entity `bson:"items"`
+	Count []struct {
+		Count int64 `bson:"count"`
+	} `bson:"count"`
+}
 
-		return
+// aggregateListPage runs a single-snapshot paginated list. prefix selects the candidate
+// documents (a $match, plus e.g. a $lookup); a $facet then returns the page and the total count
+// in one snapshot, so RemainingItemCount cannot skew against the page the way a separate find +
+// CountDocuments can. The single round-trip is also session-safe inside a transaction.
+//
+// The _id-ascending sort makes the {_id: {$gt: token}} continue-token scheme stable and lets a
+// sharded mongos merge-sort shard results; it is required for correctness, not just determinism.
+// A non-positive limit means "no limit".
+func aggregateListPage[Entity any](
+	ctx context.Context,
+	logger *slog.Logger,
+	collection *mongo.Collection,
+	prefix mongo.Pipeline,
+	continueToken bson.ObjectID,
+	limit int64,
+) ([]*Entity, string, int64, error) {
+	pipeline := slices.Clone(prefix)
+
+	if continueTokenFilter := withContinueToken(continueToken); continueTokenFilter != nil {
+		pipeline = append(pipeline, bson.D{{Key: "$match", Value: continueTokenFilter}})
 	}
 
-	var queryWg sync.WaitGroup
+	itemStages := bson.A{bson.D{{Key: "$sort", Value: bson.D{{Key: "_id", Value: 1}}}}}
+	if limit > 0 {
+		itemStages = append(itemStages, bson.D{{Key: "$limit", Value: limit}})
+	}
 
-	queryWg.Go(findTask)
-	queryWg.Go(countTask)
-	queryWg.Wait()
+	pipeline = append(pipeline, bson.D{{Key: "$facet", Value: bson.D{
+		{Key: "items", Value: itemStages},
+		{Key: "count", Value: bson.A{bson.D{{Key: "$count", Value: "count"}}}},
+	}}})
+
+	cursor, err := collection.Aggregate(ctx, pipeline)
+	if err != nil {
+		return nil, "", 0, fmt.Errorf("failed to list resources from mongodb: %w", err)
+	}
+
+	defer func() {
+		closeErr := cursor.Close(ctx)
+		if closeErr != nil {
+			logger.Warn("failed to close mongodb cursor", slog.String("error", closeErr.Error()))
+		}
+	}()
+
+	var results []facetPage[Entity]
+
+	err = cursor.All(ctx, &results)
+	if err != nil {
+		return nil, "", 0, fmt.Errorf("failed to decode resources from mongodb: %w", err)
+	}
+
+	// $facet emits exactly one document; a missing one means an empty page.
+	if len(results) == 0 {
+		return nil, "", 0, nil
+	}
+
+	page := results[0]
+
+	continueTokenStr, err := getContinueTokenFromEntities(page.Items)
+	if err != nil {
+		return nil, "", 0, fmt.Errorf("failed to get continue token from entities: %w", err)
+	}
+
+	var count int64
+	if len(page.Count) > 0 {
+		count = page.Count[0].Count
+	}
+
+	return page.Items, continueTokenStr, count - int64(len(page.Items)), nil
 }
 
 func (a *commonEntityAdapter[Entity, KeyType]) put(ctx context.Context, entity *Entity) error {
@@ -266,36 +290,6 @@ func (a *commonEntityAdapter[Entity, KeyType]) deleteOne(ctx context.Context, ke
 	return nil
 }
 
-func (a *commonEntityAdapter[Entity, KeyType]) listWithContinueTokenAndLimit(
-	ctx context.Context,
-	continueTokenObjectID bson.ObjectID,
-	limit int64,
-	baseFilter bson.M,
-) ([]*Entity, error) {
-	filter := combineFilters(baseFilter, withContinueToken(continueTokenObjectID))
-
-	cursor, err := a.collection.Find(ctx, filter, withPageOptions(limit))
-	if err != nil {
-		return nil, fmt.Errorf("failed to list resources from mongodb: %w", err)
-	}
-
-	defer func() {
-		closeErr := cursor.Close(ctx)
-		if closeErr != nil {
-			a.logger.Warn("failed to close mongodb cursor", slog.String("error", closeErr.Error()))
-		}
-	}()
-
-	var entities []*Entity
-
-	err = cursor.All(ctx, &entities)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode resources from mongodb: %w", err)
-	}
-
-	return entities, nil
-}
-
 func getContinueTokenFromEntities[Entity any](entities []*Entity) (string, error) {
 	if len(entities) == 0 {
 		return "", nil
@@ -344,20 +338,4 @@ func withContinueToken(continueToken bson.ObjectID) bson.M {
 	}
 
 	return bson.M{"_id": bson.M{"$gt": continueToken}}
-}
-
-// withPageOptions builds Find options for cursor pagination. Results are always
-// sorted by _id ascending so the {_id: {$gt: token}} continue-token scheme is
-// stable: every page resumes exactly after the previous one, with no skipped or
-// duplicated documents. Without an explicit sort the query planner may return a
-// different order (e.g. when another index is selected), and a sharded cluster's
-// mongos only merge-sorts results when a sort is given — so this sort is required
-// for correctness, not just determinism. A non-positive limit means "no limit".
-func withPageOptions(limit int64) *options.FindOptionsBuilder {
-	opts := options.Find().SetSort(bson.D{{Key: "_id", Value: 1}})
-	if limit > 0 {
-		opts.SetLimit(limit)
-	}
-
-	return opts
 }

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/serverconnection.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/serverconnection.go
@@ -21,6 +21,9 @@ import (
 const (
 	serverConnectionCollectionName = "serverconnections"
 	serverHeartbeatCollectionName  = "serverheartbeats"
+
+	// heartbeatLookupField is the transient $lookup field; $unset before the page is decoded.
+	heartbeatLookupField = "heartbeat"
 )
 
 var _ agentport.ServerConnectionPersistencePort = (*ServerConnectionAdapter)(nil)
@@ -92,8 +95,9 @@ func (a *ServerConnectionAdapter) RemoveServer(ctx context.Context, serverID str
 	return nil
 }
 
-// ListServerConnections implements agentport.ServerConnectionPersistencePort. It first resolves
-// the set of live servers from the heartbeat collection, then returns only their connections.
+// ListServerConnections implements agentport.ServerConnectionPersistencePort. It returns the
+// namespace's connections whose owning server is still live, joining each connection to its
+// heartbeat with a single $lookup instead of a separate heartbeat query plus a large $in.
 func (a *ServerConnectionAdapter) ListServerConnections(
 	ctx context.Context,
 	namespace string,
@@ -106,38 +110,35 @@ func (a *ServerConnectionAdapter) ListServerConnections(
 		options = &model.ListOptions{}
 	}
 
-	liveServerIDs, err := a.liveServerIDs(ctx, serverID, notBefore)
-	if err != nil {
-		return nil, err
-	}
-
-	if len(liveServerIDs) == 0 {
-		//exhaustruct:ignore
-		return &model.ListResponse[*agentmodel.ServerConnection]{}, nil
-	}
-
-	conditions := []bson.M{
-		{"namespace": sanitizeResourceName(namespace)},
-		{"serverId": bson.M{"$in": liveServerIDs}},
-	}
-
 	continueTokenObjectID, err := bson.ObjectIDFromHex(options.Continue)
 	if err != nil && options.Continue != "" {
 		return nil, fmt.Errorf("invalid continue token: %w", err)
 	}
 
-	if continueTokenFilter := withContinueToken(continueTokenObjectID); continueTokenFilter != nil {
-		conditions = append(conditions, continueTokenFilter)
+	match := bson.M{"namespace": sanitizeResourceName(namespace)}
+	if serverID != "" {
+		match["serverId"] = sanitizeResourceName(serverID)
 	}
 
-	filter := buildFilter(conditions)
-
-	count, err := a.collection.CountDocuments(ctx, filter)
-	if err != nil {
-		return nil, fmt.Errorf("failed to count server connections in mongodb: %w", err)
+	// Keep only connections whose server has a heartbeat at/after notBefore. A zero notBefore
+	// still requires a heartbeat to exist, since an absent one yields no lastSeenAt to match.
+	prefix := mongo.Pipeline{
+		bson.D{{Key: "$match", Value: match}},
+		bson.D{{Key: "$lookup", Value: bson.D{
+			{Key: "from", Value: serverHeartbeatCollectionName},
+			{Key: "localField", Value: "serverId"},
+			{Key: "foreignField", Value: "serverId"},
+			{Key: "as", Value: heartbeatLookupField},
+		}}},
+		bson.D{{Key: "$match", Value: bson.M{
+			heartbeatLookupField + ".lastSeenAt": bson.M{"$gte": notBefore},
+		}}},
+		bson.D{{Key: "$unset", Value: heartbeatLookupField}},
 	}
 
-	entities, continueToken, err := a.findServerConnections(ctx, filter, options.Limit)
+	entities, continueToken, remaining, err := aggregateListPage[entity.ServerConnection](
+		ctx, a.logger, a.collection, prefix, continueTokenObjectID, options.Limit,
+	)
 	if err != nil {
 		return nil, err
 	}
@@ -147,7 +148,7 @@ func (a *ServerConnectionAdapter) ListServerConnections(
 			return item.ToDomain()
 		}),
 		Continue:           continueToken,
-		RemainingItemCount: count - int64(len(entities)),
+		RemainingItemCount: remaining,
 	}, nil
 }
 
@@ -160,76 +161,4 @@ func (a *ServerConnectionAdapter) refreshHeartbeat(ctx context.Context, serverID
 	}
 
 	return nil
-}
-
-// liveServerIDs returns the serverIDs whose heartbeat is at or after notBefore. A non-empty
-// serverID restricts the query to that one server; a zero notBefore matches every heartbeat.
-func (a *ServerConnectionAdapter) liveServerIDs(
-	ctx context.Context,
-	serverID string,
-	notBefore time.Time,
-) ([]string, error) {
-	filter := bson.M{}
-	if serverID != "" {
-		filter["serverId"] = sanitizeResourceName(serverID)
-	}
-
-	if !notBefore.IsZero() {
-		filter["lastSeenAt"] = bson.M{"$gte": notBefore}
-	}
-
-	cursor, err := a.heartbeats.Find(ctx, filter, options.Find().SetProjection(bson.M{"serverId": 1}))
-	if err != nil {
-		return nil, fmt.Errorf("failed to find server heartbeats in mongodb: %w", err)
-	}
-
-	defer func() {
-		closeErr := cursor.Close(ctx)
-		if closeErr != nil {
-			a.logger.Warn("failed to close mongodb cursor", slog.String("error", closeErr.Error()))
-		}
-	}()
-
-	var heartbeats []*entity.ServerHeartbeat
-
-	err = cursor.All(ctx, &heartbeats)
-	if err != nil {
-		return nil, fmt.Errorf("failed to decode server heartbeats from mongodb: %w", err)
-	}
-
-	return lo.Map(heartbeats, func(hb *entity.ServerHeartbeat, _ int) string { return hb.ServerID }), nil
-}
-
-// findServerConnections runs the paginated find and returns the decoded entities plus the
-// continue token for the next page.
-func (a *ServerConnectionAdapter) findServerConnections(
-	ctx context.Context,
-	filter bson.M,
-	limit int64,
-) ([]*entity.ServerConnection, string, error) {
-	cursor, err := a.collection.Find(ctx, filter, withPageOptions(limit))
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to find server connections in mongodb: %w", err)
-	}
-
-	defer func() {
-		closeErr := cursor.Close(ctx)
-		if closeErr != nil {
-			a.logger.Warn("failed to close mongodb cursor", slog.String("error", closeErr.Error()))
-		}
-	}()
-
-	var entities []*entity.ServerConnection
-
-	err = cursor.All(ctx, &entities)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to decode server connections from mongodb: %w", err)
-	}
-
-	continueToken, err := getContinueTokenFromEntities(entities)
-	if err != nil {
-		return nil, "", fmt.Errorf("failed to get continue token from entities: %w", err)
-	}
-
-	return entities, continueToken, nil
 }

--- a/pkg/apiserver/adapter/secondary/persistence/mongodb/transaction_test.go
+++ b/pkg/apiserver/adapter/secondary/persistence/mongodb/transaction_test.go
@@ -100,13 +100,9 @@ func TestTransactionRunner_RollsBackOnError(t *testing.T) {
 	assert.Zero(t, cnt, "all writes should be rolled back when callback errors")
 }
 
-// TestTransactionRunner_ListInsideTransaction guards against issue:
-// commonEntityAdapter.list/listWithFilter previously ran find + count in
-// parallel goroutines sharing the same ctx; inside a transaction this would
-// concurrently use a non-goroutine-safe *mongo.Session and corrupt session
-// state or trip "transaction in progress" errors. This test exercises the
-// real cascade pattern (put then list in the same transaction) to ensure
-// runListQueries correctly serialises inside a session.
+// TestTransactionRunner_ListInsideTransaction keeps list queries session-safe inside a
+// transaction: the list path issues a single $facet aggregation (no goroutines sharing a
+// non-goroutine-safe *mongo.Session), exercised here via put-then-list in one transaction.
 func TestTransactionRunner_ListInsideTransaction(t *testing.T) {
 	testcontainers.SkipIfProviderIsNotHealthy(t)
 	t.Parallel()


### PR DESCRIPTION
Closes #546.

## Problem

MongoDB list queries ran a paginated `find` **and** a separate `CountDocuments`, then reported `RemainingItemCount = count - len(page)`. Because the two observe different snapshots, a concurrent write or TTL expiry between them let a client paginating on `RemainingItemCount` under-/over-read at page boundaries. This affected every adapter following the count+find pattern.

`ListServerConnections` was the sharpest case after the heartbeat redesign (#545/#486): it added a third round-trip (heartbeat lookup) and, for the common cluster view, materialized every live server's ID into a large `$in`.

## Change

- **Shared single-pass helper** `aggregateListPage` (`common.go`): folds count + page into one `$facet` aggregation, so both come from the same snapshot — the skew is gone. Used by the common list path (`listWithFilter`) and agent list/search.
- Because it's a single round-trip, it's session-safe inside a transaction, so the parallel find+count goroutines and their in-session serialization (`runListQueries`) are removed.
- **`ListServerConnections`**: replaces the heartbeat find + `$in` fan-out with a single `$lookup` join to `serverheartbeats` filtered by `lastSeenAt >= notBefore`. A zero `notBefore` still requires a heartbeat to exist (matches prior semantics).

Net **−249 lines**; also drops two `//nolint:funlen` waivers.

## Acceptance

- [x] Decision: change the shared pagination convention (fold count+find into `$facet`) rather than document the skew.
- [x] Continue-token / `RemainingItemCount` semantics (`model.ListResponse`) preserved.
- [x] `ListServerConnections` no longer needs a separate heartbeat round-trip + `$in`.

## Testing

- `go build ./...`, `golangci-lint run` (0 issues), test binaries compile, non-container unit tests pass.
- ⚠️ Docker was **not available** in my environment, so the testcontainer-backed MongoDB integration/pagination tests (incl. `TestServerConnectionMongoAdapter`, `TestTransactionRunner_ListInsideTransaction`) were **not run**. Please run `make test` locally to confirm. Note the test image is `mongo:4.4.10`; `$facet`/`$lookup` are supported there, and the only in-transaction list path uses `$match`+`$facet` (no `$lookup`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)