### PR TITLE
chore(remoteconfigschema): backfill config schemas for v0.156.0

### DIFF
--- a/configs/apiserver/initial/remoteconfigschema/otelcol-0.156.0.yaml
+++ b/configs/apiserver/initial/remoteconfigschema/otelcol-0.156.0.yaml
@@ -7,6 +7,3911 @@ metadata:
     namespace: default
 spec:
     binary: otelcol
+    componentConfigs:
+        connectors:
+            forward:
+                type: object
+        exporters:
+            debug:
+                fields:
+                    output_paths:
+                        elem:
+                            type: string
+                        type: array
+                    sampling_initial:
+                        type: int
+                    sampling_thereafter:
+                        type: int
+                    sending_queue:
+                        fields:
+                            batch:
+                                fields:
+                                    flush_timeout:
+                                        type: duration
+                                    max_size:
+                                        type: int
+                                    min_size:
+                                        type: int
+                                    partition:
+                                        fields:
+                                            metadata_keys:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                        type: object
+                                    sizer:
+                                        type: object
+                                type: object
+                            block_on_overflow:
+                                type: bool
+                            num_consumers:
+                                type: int
+                            queue_size:
+                                type: int
+                            sizer:
+                                type: object
+                            storage:
+                                type: object
+                            wait_for_result:
+                                type: bool
+                        type: object
+                    use_internal_logger:
+                        type: bool
+                    verbosity:
+                        type: int
+                type: object
+            file:
+                fields:
+                    append:
+                        type: bool
+                    compression:
+                        type: string
+                    compression_params:
+                        fields:
+                            level:
+                                type: int
+                        type: object
+                    create_directory:
+                        type: bool
+                    directory_permissions:
+                        type: string
+                    encoding:
+                        type: object
+                    flush_interval:
+                        type: duration
+                    format:
+                        type: string
+                    group_by:
+                        fields:
+                            enabled:
+                                type: bool
+                            max_open_files:
+                                type: int
+                            resource_attribute:
+                                type: string
+                        type: object
+                    path:
+                        type: string
+                    rotation:
+                        fields:
+                            localtime:
+                                type: bool
+                            max_backups:
+                                type: int
+                            max_days:
+                                type: int
+                            max_megabytes:
+                                type: int
+                        type: object
+                type: object
+            kafka:
+                fields:
+                    auth:
+                        fields:
+                            kerberos:
+                                fields:
+                                    config_file:
+                                        type: string
+                                    disable_fast_negotiation:
+                                        type: bool
+                                    keytab_file:
+                                        type: string
+                                    password:
+                                        type: string
+                                    realm:
+                                        type: string
+                                    service_name:
+                                        type: string
+                                    use_keytab:
+                                        type: bool
+                                    username:
+                                        type: string
+                                type: object
+                            plain_text:
+                                fields:
+                                    password:
+                                        type: string
+                                    username:
+                                        type: string
+                                type: object
+                            sasl:
+                                fields:
+                                    aws_msk:
+                                        fields:
+                                            region:
+                                                type: string
+                                        type: object
+                                    mechanism:
+                                        type: string
+                                    oauthbearer_token_source:
+                                        type: object
+                                    password:
+                                        type: string
+                                    username:
+                                        type: string
+                                    version:
+                                        type: int
+                                type: object
+                            tls:
+                                fields:
+                                    ca_file:
+                                        type: string
+                                    ca_pem:
+                                        type: string
+                                    cert_file:
+                                        type: string
+                                    cert_pem:
+                                        type: string
+                                    cipher_suites:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    curve_preferences:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    include_insecure_cipher_suites:
+                                        type: bool
+                                    include_system_ca_certs_pool:
+                                        type: bool
+                                    insecure:
+                                        type: bool
+                                    insecure_skip_verify:
+                                        type: bool
+                                    key_file:
+                                        type: string
+                                    key_pem:
+                                        type: string
+                                    max_version:
+                                        type: string
+                                    min_version:
+                                        type: string
+                                    reload_interval:
+                                        type: duration
+                                    server_name_override:
+                                        type: string
+                                    tpm:
+                                        fields:
+                                            auth:
+                                                type: string
+                                            enabled:
+                                                type: bool
+                                            owner_auth:
+                                                type: string
+                                            path:
+                                                type: string
+                                        type: object
+                                type: object
+                        type: object
+                    brokers:
+                        elem:
+                            type: string
+                        type: array
+                    client_id:
+                        type: string
+                    conn_idle_timeout:
+                        type: duration
+                    include_metadata_keys:
+                        elem:
+                            type: string
+                        type: array
+                    logs:
+                        fields:
+                            encoding:
+                                type: string
+                            message_key_from_metadata_key:
+                                type: string
+                            topic:
+                                type: string
+                            topic_from_metadata_key:
+                                type: string
+                        type: object
+                    metadata:
+                        fields:
+                            full:
+                                type: bool
+                            refresh_interval:
+                                type: duration
+                            retry:
+                                fields:
+                                    backoff:
+                                        type: duration
+                                    max:
+                                        type: int
+                                type: object
+                        type: object
+                    metrics:
+                        fields:
+                            encoding:
+                                type: string
+                            message_key_from_metadata_key:
+                                type: string
+                            topic:
+                                type: string
+                            topic_from_metadata_key:
+                                type: string
+                        type: object
+                    partition_logs_by_resource_attributes:
+                        type: bool
+                    partition_logs_by_trace_id:
+                        type: bool
+                    partition_metrics_by_resource_attributes:
+                        type: bool
+                    partition_traces_by_id:
+                        type: bool
+                    producer:
+                        fields:
+                            allow_auto_topic_creation:
+                                type: bool
+                            compression:
+                                type: string
+                            compression_params:
+                                fields:
+                                    level:
+                                        type: int
+                                type: object
+                            flush_max_messages:
+                                type: int
+                            linger:
+                                type: duration
+                            max_broker_write_bytes:
+                                type: int
+                            max_message_bytes:
+                                type: int
+                            required_acks:
+                                type: int
+                        type: object
+                    profiles:
+                        fields:
+                            encoding:
+                                type: string
+                            message_key_from_metadata_key:
+                                type: string
+                            topic:
+                                type: string
+                            topic_from_metadata_key:
+                                type: string
+                        type: object
+                    protocol_version:
+                        type: string
+                    rack_id:
+                        type: string
+                    record_headers:
+                        elem:
+                            fields:
+                                name:
+                                    type: string
+                                value:
+                                    type: string
+                            type: object
+                        type: array
+                    record_partitioner:
+                        fields:
+                            extension:
+                                type: object
+                            least_backup:
+                                type: object
+                            round_robin:
+                                type: object
+                            sticky_key:
+                                fields:
+                                    hasher:
+                                        type: string
+                                type: object
+                        type: object
+                    resolve_canonical_bootstrap_servers_only:
+                        type: bool
+                    retry_on_failure:
+                        fields:
+                            enabled:
+                                type: bool
+                            initial_interval:
+                                type: duration
+                            max_elapsed_time:
+                                type: duration
+                            max_interval:
+                                type: duration
+                            multiplier:
+                                type: float
+                            randomization_factor:
+                                type: float
+                        type: object
+                    sending_queue:
+                        fields:
+                            batch:
+                                fields:
+                                    flush_timeout:
+                                        type: duration
+                                    max_size:
+                                        type: int
+                                    min_size:
+                                        type: int
+                                    partition:
+                                        fields:
+                                            metadata_keys:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                        type: object
+                                    sizer:
+                                        type: object
+                                type: object
+                            block_on_overflow:
+                                type: bool
+                            num_consumers:
+                                type: int
+                            queue_size:
+                                type: int
+                            sizer:
+                                type: object
+                            storage:
+                                type: object
+                            wait_for_result:
+                                type: bool
+                        type: object
+                    timeout:
+                        type: duration
+                    tls:
+                        fields:
+                            ca_file:
+                                type: string
+                            ca_pem:
+                                type: string
+                            cert_file:
+                                type: string
+                            cert_pem:
+                                type: string
+                            cipher_suites:
+                                elem:
+                                    type: string
+                                type: array
+                            curve_preferences:
+                                elem:
+                                    type: string
+                                type: array
+                            include_insecure_cipher_suites:
+                                type: bool
+                            include_system_ca_certs_pool:
+                                type: bool
+                            insecure:
+                                type: bool
+                            insecure_skip_verify:
+                                type: bool
+                            key_file:
+                                type: string
+                            key_pem:
+                                type: string
+                            max_version:
+                                type: string
+                            min_version:
+                                type: string
+                            reload_interval:
+                                type: duration
+                            server_name_override:
+                                type: string
+                            tpm:
+                                fields:
+                                    auth:
+                                        type: string
+                                    enabled:
+                                        type: bool
+                                    owner_auth:
+                                        type: string
+                                    path:
+                                        type: string
+                                type: object
+                        type: object
+                    topic_from_attribute:
+                        type: string
+                    traces:
+                        fields:
+                            encoding:
+                                type: string
+                            message_key_from_metadata_key:
+                                type: string
+                            topic:
+                                type: string
+                            topic_from_metadata_key:
+                                type: string
+                        type: object
+                    use_leader_epoch:
+                        type: bool
+                type: object
+            nop:
+                type: object
+            otlp_grpc:
+                fields:
+                    auth:
+                        fields:
+                            authenticator:
+                                type: object
+                        type: object
+                    authority:
+                        type: string
+                    balancer_name:
+                        type: string
+                    compression:
+                        type: string
+                    endpoint:
+                        type: string
+                    headers:
+                        elem:
+                            fields:
+                                name:
+                                    type: string
+                                value:
+                                    type: string
+                            type: object
+                        type: array
+                    keepalive:
+                        fields:
+                            permit_without_stream:
+                                type: bool
+                            time:
+                                type: duration
+                            timeout:
+                                type: duration
+                        type: object
+                    middlewares:
+                        elem:
+                            fields:
+                                id:
+                                    type: object
+                            type: object
+                        type: array
+                    read_buffer_size:
+                        type: int
+                    retry_on_failure:
+                        fields:
+                            enabled:
+                                type: bool
+                            initial_interval:
+                                type: duration
+                            max_elapsed_time:
+                                type: duration
+                            max_interval:
+                                type: duration
+                            multiplier:
+                                type: float
+                            randomization_factor:
+                                type: float
+                        type: object
+                    sending_queue:
+                        fields:
+                            batch:
+                                fields:
+                                    flush_timeout:
+                                        type: duration
+                                    max_size:
+                                        type: int
+                                    min_size:
+                                        type: int
+                                    partition:
+                                        fields:
+                                            metadata_keys:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                        type: object
+                                    sizer:
+                                        type: object
+                                type: object
+                            block_on_overflow:
+                                type: bool
+                            num_consumers:
+                                type: int
+                            queue_size:
+                                type: int
+                            sizer:
+                                type: object
+                            storage:
+                                type: object
+                            wait_for_result:
+                                type: bool
+                        type: object
+                    timeout:
+                        type: duration
+                    tls:
+                        fields:
+                            ca_file:
+                                type: string
+                            ca_pem:
+                                type: string
+                            cert_file:
+                                type: string
+                            cert_pem:
+                                type: string
+                            cipher_suites:
+                                elem:
+                                    type: string
+                                type: array
+                            curve_preferences:
+                                elem:
+                                    type: string
+                                type: array
+                            include_insecure_cipher_suites:
+                                type: bool
+                            include_system_ca_certs_pool:
+                                type: bool
+                            insecure:
+                                type: bool
+                            insecure_skip_verify:
+                                type: bool
+                            key_file:
+                                type: string
+                            key_pem:
+                                type: string
+                            max_version:
+                                type: string
+                            min_version:
+                                type: string
+                            reload_interval:
+                                type: duration
+                            server_name_override:
+                                type: string
+                            tpm:
+                                fields:
+                                    auth:
+                                        type: string
+                                    enabled:
+                                        type: bool
+                                    owner_auth:
+                                        type: string
+                                    path:
+                                        type: string
+                                type: object
+                        type: object
+                    user_agent:
+                        type: string
+                    wait_for_ready:
+                        type: bool
+                    write_buffer_size:
+                        type: int
+                type: object
+            otlp_http:
+                fields:
+                    auth:
+                        fields:
+                            authenticator:
+                                type: object
+                        type: object
+                    compression:
+                        type: string
+                    compression_params:
+                        fields:
+                            level:
+                                type: int
+                        type: object
+                    cookies:
+                        type: object
+                    disable_keep_alives:
+                        type: bool
+                    encoding:
+                        type: string
+                    endpoint:
+                        type: string
+                    force_attempt_http2:
+                        type: bool
+                    headers:
+                        elem:
+                            fields:
+                                name:
+                                    type: string
+                                value:
+                                    type: string
+                            type: object
+                        type: array
+                    http2_ping_timeout:
+                        type: duration
+                    http2_read_idle_timeout:
+                        type: duration
+                    idle_conn_timeout:
+                        type: duration
+                    logs_endpoint:
+                        type: string
+                    max_conns_per_host:
+                        type: int
+                    max_idle_conns:
+                        type: int
+                    max_idle_conns_per_host:
+                        type: int
+                    metrics_endpoint:
+                        type: string
+                    middlewares:
+                        elem:
+                            fields:
+                                id:
+                                    type: object
+                            type: object
+                        type: array
+                    profiles_endpoint:
+                        type: string
+                    proxy_url:
+                        type: string
+                    read_buffer_size:
+                        type: int
+                    retry_on_failure:
+                        fields:
+                            enabled:
+                                type: bool
+                            initial_interval:
+                                type: duration
+                            max_elapsed_time:
+                                type: duration
+                            max_interval:
+                                type: duration
+                            multiplier:
+                                type: float
+                            randomization_factor:
+                                type: float
+                        type: object
+                    sending_queue:
+                        fields:
+                            batch:
+                                fields:
+                                    flush_timeout:
+                                        type: duration
+                                    max_size:
+                                        type: int
+                                    min_size:
+                                        type: int
+                                    partition:
+                                        fields:
+                                            metadata_keys:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                        type: object
+                                    sizer:
+                                        type: object
+                                type: object
+                            block_on_overflow:
+                                type: bool
+                            num_consumers:
+                                type: int
+                            queue_size:
+                                type: int
+                            sizer:
+                                type: object
+                            storage:
+                                type: object
+                            wait_for_result:
+                                type: bool
+                        type: object
+                    timeout:
+                        type: duration
+                    tls:
+                        fields:
+                            ca_file:
+                                type: string
+                            ca_pem:
+                                type: string
+                            cert_file:
+                                type: string
+                            cert_pem:
+                                type: string
+                            cipher_suites:
+                                elem:
+                                    type: string
+                                type: array
+                            curve_preferences:
+                                elem:
+                                    type: string
+                                type: array
+                            include_insecure_cipher_suites:
+                                type: bool
+                            include_system_ca_certs_pool:
+                                type: bool
+                            insecure:
+                                type: bool
+                            insecure_skip_verify:
+                                type: bool
+                            key_file:
+                                type: string
+                            key_pem:
+                                type: string
+                            max_version:
+                                type: string
+                            min_version:
+                                type: string
+                            reload_interval:
+                                type: duration
+                            server_name_override:
+                                type: string
+                            tpm:
+                                fields:
+                                    auth:
+                                        type: string
+                                    enabled:
+                                        type: bool
+                                    owner_auth:
+                                        type: string
+                                    path:
+                                        type: string
+                                type: object
+                        type: object
+                    traces_endpoint:
+                        type: string
+                    write_buffer_size:
+                        type: int
+                type: object
+            prometheus:
+                fields:
+                    add_metric_suffixes:
+                        type: bool
+                    auth:
+                        fields:
+                            authenticator:
+                                type: object
+                            request_params:
+                                elem:
+                                    type: string
+                                type: array
+                        type: object
+                    compression_algorithms:
+                        elem:
+                            type: string
+                        type: array
+                    const_labels:
+                        elem:
+                            type: string
+                        type: map
+                    cors:
+                        fields:
+                            allowed_headers:
+                                elem:
+                                    type: string
+                                type: array
+                            allowed_origins:
+                                elem:
+                                    type: string
+                                type: array
+                            exposed_headers:
+                                elem:
+                                    type: string
+                                type: array
+                            max_age:
+                                type: int
+                        type: object
+                    dialer:
+                        fields:
+                            timeout:
+                                type: duration
+                        type: object
+                    enable_open_metrics:
+                        type: bool
+                    endpoint:
+                        type: string
+                    idle_timeout:
+                        type: duration
+                    include_metadata:
+                        type: bool
+                    keep_alives_enabled:
+                        type: bool
+                    max_request_body_size:
+                        type: int
+                    metric_expiration:
+                        type: duration
+                    middlewares:
+                        elem:
+                            fields:
+                                id:
+                                    type: object
+                            type: object
+                        type: array
+                    namespace:
+                        type: string
+                    read_header_timeout:
+                        type: duration
+                    read_timeout:
+                        type: duration
+                    resource_to_telemetry_conversion:
+                        fields:
+                            enabled:
+                                type: bool
+                            exclude_service_attributes:
+                                type: bool
+                        type: object
+                    response_headers:
+                        elem:
+                            fields:
+                                name:
+                                    type: string
+                                value:
+                                    type: string
+                            type: object
+                        type: array
+                    send_timestamps:
+                        type: bool
+                    sending_queue:
+                        fields:
+                            batch:
+                                fields:
+                                    flush_timeout:
+                                        type: duration
+                                    max_size:
+                                        type: int
+                                    min_size:
+                                        type: int
+                                    partition:
+                                        fields:
+                                            metadata_keys:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                        type: object
+                                    sizer:
+                                        type: object
+                                type: object
+                            block_on_overflow:
+                                type: bool
+                            num_consumers:
+                                type: int
+                            queue_size:
+                                type: int
+                            sizer:
+                                type: object
+                            storage:
+                                type: object
+                            wait_for_result:
+                                type: bool
+                        type: object
+                    tls:
+                        fields:
+                            ca_file:
+                                type: string
+                            ca_pem:
+                                type: string
+                            cert_file:
+                                type: string
+                            cert_pem:
+                                type: string
+                            cipher_suites:
+                                elem:
+                                    type: string
+                                type: array
+                            client_ca_file:
+                                type: string
+                            client_ca_file_reload:
+                                type: bool
+                            curve_preferences:
+                                elem:
+                                    type: string
+                                type: array
+                            include_insecure_cipher_suites:
+                                type: bool
+                            include_system_ca_certs_pool:
+                                type: bool
+                            key_file:
+                                type: string
+                            key_pem:
+                                type: string
+                            max_version:
+                                type: string
+                            min_version:
+                                type: string
+                            reload_interval:
+                                type: duration
+                            tpm:
+                                fields:
+                                    auth:
+                                        type: string
+                                    enabled:
+                                        type: bool
+                                    owner_auth:
+                                        type: string
+                                    path:
+                                        type: string
+                                type: object
+                        type: object
+                    translation_strategy:
+                        type: string
+                    transport:
+                        type: string
+                    without_scope_info:
+                        type: bool
+                    write_timeout:
+                        type: duration
+                type: object
+            prometheus_remote_write:
+                fields:
+                    add_metric_suffixes:
+                        type: bool
+                    auth:
+                        fields:
+                            authenticator:
+                                type: object
+                        type: object
+                    compression:
+                        type: string
+                    compression_params:
+                        fields:
+                            level:
+                                type: int
+                        type: object
+                    cookies:
+                        type: object
+                    disable_keep_alives:
+                        type: bool
+                    disable_scope_info:
+                        type: bool
+                    endpoint:
+                        type: string
+                    external_labels:
+                        elem:
+                            type: string
+                        type: map
+                    force_attempt_http2:
+                        type: bool
+                    headers:
+                        elem:
+                            fields:
+                                name:
+                                    type: string
+                                value:
+                                    type: string
+                            type: object
+                        type: array
+                    http2_ping_timeout:
+                        type: duration
+                    http2_read_idle_timeout:
+                        type: duration
+                    idle_conn_timeout:
+                        type: duration
+                    max_batch_request_parallelism:
+                        type: int
+                    max_batch_size_bytes:
+                        type: int
+                    max_conns_per_host:
+                        type: int
+                    max_idle_conns:
+                        type: int
+                    max_idle_conns_per_host:
+                        type: int
+                    middlewares:
+                        elem:
+                            fields:
+                                id:
+                                    type: object
+                            type: object
+                        type: array
+                    namespace:
+                        type: string
+                    protobuf_message:
+                        type: string
+                    proxy_url:
+                        type: string
+                    read_buffer_size:
+                        type: int
+                    remote_write_queue:
+                        fields:
+                            enabled:
+                                type: bool
+                            num_consumers:
+                                type: int
+                            queue_size:
+                                type: int
+                        type: object
+                    resource_to_telemetry_conversion:
+                        fields:
+                            enabled:
+                                type: bool
+                            exclude_service_attributes:
+                                type: bool
+                        type: object
+                    retry_on_failure:
+                        fields:
+                            enabled:
+                                type: bool
+                            initial_interval:
+                                type: duration
+                            max_elapsed_time:
+                                type: duration
+                            max_interval:
+                                type: duration
+                            multiplier:
+                                type: float
+                            randomization_factor:
+                                type: float
+                        type: object
+                    send_metadata:
+                        type: bool
+                    target_info:
+                        fields:
+                            enabled:
+                                type: bool
+                        type: object
+                    timeout:
+                        type: duration
+                    tls:
+                        fields:
+                            ca_file:
+                                type: string
+                            ca_pem:
+                                type: string
+                            cert_file:
+                                type: string
+                            cert_pem:
+                                type: string
+                            cipher_suites:
+                                elem:
+                                    type: string
+                                type: array
+                            curve_preferences:
+                                elem:
+                                    type: string
+                                type: array
+                            include_insecure_cipher_suites:
+                                type: bool
+                            include_system_ca_certs_pool:
+                                type: bool
+                            insecure:
+                                type: bool
+                            insecure_skip_verify:
+                                type: bool
+                            key_file:
+                                type: string
+                            key_pem:
+                                type: string
+                            max_version:
+                                type: string
+                            min_version:
+                                type: string
+                            reload_interval:
+                                type: duration
+                            server_name_override:
+                                type: string
+                            tpm:
+                                fields:
+                                    auth:
+                                        type: string
+                                    enabled:
+                                        type: bool
+                                    owner_auth:
+                                        type: string
+                                    path:
+                                        type: string
+                                type: object
+                        type: object
+                    translation_strategy:
+                        type: string
+                    wal:
+                        fields:
+                            buffer_size:
+                                type: int
+                            directory:
+                                type: string
+                            lag_record_frequency:
+                                type: duration
+                            truncate_frequency:
+                                type: duration
+                        type: object
+                    write_buffer_size:
+                        type: int
+                type: object
+            zipkin:
+                fields:
+                    auth:
+                        fields:
+                            authenticator:
+                                type: object
+                        type: object
+                    compression:
+                        type: string
+                    compression_params:
+                        fields:
+                            level:
+                                type: int
+                        type: object
+                    cookies:
+                        type: object
+                    default_service_name:
+                        type: string
+                    disable_keep_alives:
+                        type: bool
+                    endpoint:
+                        type: string
+                    force_attempt_http2:
+                        type: bool
+                    format:
+                        type: string
+                    headers:
+                        elem:
+                            fields:
+                                name:
+                                    type: string
+                                value:
+                                    type: string
+                            type: object
+                        type: array
+                    http2_ping_timeout:
+                        type: duration
+                    http2_read_idle_timeout:
+                        type: duration
+                    idle_conn_timeout:
+                        type: duration
+                    max_conns_per_host:
+                        type: int
+                    max_idle_conns:
+                        type: int
+                    max_idle_conns_per_host:
+                        type: int
+                    middlewares:
+                        elem:
+                            fields:
+                                id:
+                                    type: object
+                            type: object
+                        type: array
+                    proxy_url:
+                        type: string
+                    read_buffer_size:
+                        type: int
+                    retry_on_failure:
+                        fields:
+                            enabled:
+                                type: bool
+                            initial_interval:
+                                type: duration
+                            max_elapsed_time:
+                                type: duration
+                            max_interval:
+                                type: duration
+                            multiplier:
+                                type: float
+                            randomization_factor:
+                                type: float
+                        type: object
+                    sending_queue:
+                        fields:
+                            batch:
+                                fields:
+                                    flush_timeout:
+                                        type: duration
+                                    max_size:
+                                        type: int
+                                    min_size:
+                                        type: int
+                                    partition:
+                                        fields:
+                                            metadata_keys:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                        type: object
+                                    sizer:
+                                        type: object
+                                type: object
+                            block_on_overflow:
+                                type: bool
+                            num_consumers:
+                                type: int
+                            queue_size:
+                                type: int
+                            sizer:
+                                type: object
+                            storage:
+                                type: object
+                            wait_for_result:
+                                type: bool
+                        type: object
+                    timeout:
+                        type: duration
+                    tls:
+                        fields:
+                            ca_file:
+                                type: string
+                            ca_pem:
+                                type: string
+                            cert_file:
+                                type: string
+                            cert_pem:
+                                type: string
+                            cipher_suites:
+                                elem:
+                                    type: string
+                                type: array
+                            curve_preferences:
+                                elem:
+                                    type: string
+                                type: array
+                            include_insecure_cipher_suites:
+                                type: bool
+                            include_system_ca_certs_pool:
+                                type: bool
+                            insecure:
+                                type: bool
+                            insecure_skip_verify:
+                                type: bool
+                            key_file:
+                                type: string
+                            key_pem:
+                                type: string
+                            max_version:
+                                type: string
+                            min_version:
+                                type: string
+                            reload_interval:
+                                type: duration
+                            server_name_override:
+                                type: string
+                            tpm:
+                                fields:
+                                    auth:
+                                        type: string
+                                    enabled:
+                                        type: bool
+                                    owner_auth:
+                                        type: string
+                                    path:
+                                        type: string
+                                type: object
+                        type: object
+                    write_buffer_size:
+                        type: int
+                type: object
+        extensions:
+            health_check:
+                fields:
+                    auth:
+                        fields:
+                            authenticator:
+                                type: object
+                            request_params:
+                                elem:
+                                    type: string
+                                type: array
+                        type: object
+                    check_collector_pipeline:
+                        fields:
+                            enabled:
+                                type: bool
+                            exporter_failure_threshold:
+                                type: int
+                            interval:
+                                type: string
+                        type: object
+                    component_health:
+                        fields:
+                            include_permanent_errors:
+                                type: bool
+                            include_recoverable_errors:
+                                type: bool
+                            recovery_duration:
+                                type: duration
+                        type: object
+                    compression_algorithms:
+                        elem:
+                            type: string
+                        type: array
+                    cors:
+                        fields:
+                            allowed_headers:
+                                elem:
+                                    type: string
+                                type: array
+                            allowed_origins:
+                                elem:
+                                    type: string
+                                type: array
+                            exposed_headers:
+                                elem:
+                                    type: string
+                                type: array
+                            max_age:
+                                type: int
+                        type: object
+                    dialer:
+                        fields:
+                            timeout:
+                                type: duration
+                        type: object
+                    endpoint:
+                        type: string
+                    grpc:
+                        fields:
+                            auth:
+                                fields:
+                                    authenticator:
+                                        type: object
+                                type: object
+                            dialer:
+                                fields:
+                                    timeout:
+                                        type: duration
+                                type: object
+                            endpoint:
+                                type: string
+                            include_metadata:
+                                type: bool
+                            keepalive:
+                                fields:
+                                    enforcement_policy:
+                                        fields:
+                                            min_time:
+                                                type: duration
+                                            permit_without_stream:
+                                                type: bool
+                                        type: object
+                                    server_parameters:
+                                        fields:
+                                            max_connection_age:
+                                                type: duration
+                                            max_connection_age_grace:
+                                                type: duration
+                                            max_connection_idle:
+                                                type: duration
+                                            time:
+                                                type: duration
+                                            timeout:
+                                                type: duration
+                                        type: object
+                                type: object
+                            max_concurrent_streams:
+                                type: int
+                            max_recv_msg_size_mib:
+                                type: int
+                            middlewares:
+                                elem:
+                                    fields:
+                                        id:
+                                            type: object
+                                    type: object
+                                type: array
+                            read_buffer_size:
+                                type: int
+                            tls:
+                                fields:
+                                    ca_file:
+                                        type: string
+                                    ca_pem:
+                                        type: string
+                                    cert_file:
+                                        type: string
+                                    cert_pem:
+                                        type: string
+                                    cipher_suites:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    client_ca_file:
+                                        type: string
+                                    client_ca_file_reload:
+                                        type: bool
+                                    curve_preferences:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    include_insecure_cipher_suites:
+                                        type: bool
+                                    include_system_ca_certs_pool:
+                                        type: bool
+                                    key_file:
+                                        type: string
+                                    key_pem:
+                                        type: string
+                                    max_version:
+                                        type: string
+                                    min_version:
+                                        type: string
+                                    reload_interval:
+                                        type: duration
+                                    tpm:
+                                        fields:
+                                            auth:
+                                                type: string
+                                            enabled:
+                                                type: bool
+                                            owner_auth:
+                                                type: string
+                                            path:
+                                                type: string
+                                        type: object
+                                type: object
+                            transport:
+                                type: string
+                            write_buffer_size:
+                                type: int
+                        type: object
+                    http:
+                        fields:
+                            auth:
+                                fields:
+                                    authenticator:
+                                        type: object
+                                    request_params:
+                                        elem:
+                                            type: string
+                                        type: array
+                                type: object
+                            compression_algorithms:
+                                elem:
+                                    type: string
+                                type: array
+                            config:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    include_attributes:
+                                        type: bool
+                                    path:
+                                        type: string
+                                type: object
+                            cors:
+                                fields:
+                                    allowed_headers:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    allowed_origins:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    exposed_headers:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    max_age:
+                                        type: int
+                                type: object
+                            dialer:
+                                fields:
+                                    timeout:
+                                        type: duration
+                                type: object
+                            endpoint:
+                                type: string
+                            idle_timeout:
+                                type: duration
+                            include_metadata:
+                                type: bool
+                            keep_alives_enabled:
+                                type: bool
+                            max_request_body_size:
+                                type: int
+                            middlewares:
+                                elem:
+                                    fields:
+                                        id:
+                                            type: object
+                                    type: object
+                                type: array
+                            read_header_timeout:
+                                type: duration
+                            read_timeout:
+                                type: duration
+                            response_headers:
+                                elem:
+                                    fields:
+                                        name:
+                                            type: string
+                                        value:
+                                            type: string
+                                    type: object
+                                type: array
+                            status:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    include_attributes:
+                                        type: bool
+                                    path:
+                                        type: string
+                                type: object
+                            tls:
+                                fields:
+                                    ca_file:
+                                        type: string
+                                    ca_pem:
+                                        type: string
+                                    cert_file:
+                                        type: string
+                                    cert_pem:
+                                        type: string
+                                    cipher_suites:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    client_ca_file:
+                                        type: string
+                                    client_ca_file_reload:
+                                        type: bool
+                                    curve_preferences:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    include_insecure_cipher_suites:
+                                        type: bool
+                                    include_system_ca_certs_pool:
+                                        type: bool
+                                    key_file:
+                                        type: string
+                                    key_pem:
+                                        type: string
+                                    max_version:
+                                        type: string
+                                    min_version:
+                                        type: string
+                                    reload_interval:
+                                        type: duration
+                                    tpm:
+                                        fields:
+                                            auth:
+                                                type: string
+                                            enabled:
+                                                type: bool
+                                            owner_auth:
+                                                type: string
+                                            path:
+                                                type: string
+                                        type: object
+                                type: object
+                            transport:
+                                type: string
+                            write_timeout:
+                                type: duration
+                        type: object
+                    idle_timeout:
+                        type: duration
+                    include_metadata:
+                        type: bool
+                    keep_alives_enabled:
+                        type: bool
+                    max_request_body_size:
+                        type: int
+                    middlewares:
+                        elem:
+                            fields:
+                                id:
+                                    type: object
+                            type: object
+                        type: array
+                    path:
+                        type: string
+                    read_header_timeout:
+                        type: duration
+                    read_timeout:
+                        type: duration
+                    response_body:
+                        fields:
+                            healthy:
+                                type: string
+                            unhealthy:
+                                type: string
+                        type: object
+                    response_headers:
+                        elem:
+                            fields:
+                                name:
+                                    type: string
+                                value:
+                                    type: string
+                            type: object
+                        type: array
+                    tls:
+                        fields:
+                            ca_file:
+                                type: string
+                            ca_pem:
+                                type: string
+                            cert_file:
+                                type: string
+                            cert_pem:
+                                type: string
+                            cipher_suites:
+                                elem:
+                                    type: string
+                                type: array
+                            client_ca_file:
+                                type: string
+                            client_ca_file_reload:
+                                type: bool
+                            curve_preferences:
+                                elem:
+                                    type: string
+                                type: array
+                            include_insecure_cipher_suites:
+                                type: bool
+                            include_system_ca_certs_pool:
+                                type: bool
+                            key_file:
+                                type: string
+                            key_pem:
+                                type: string
+                            max_version:
+                                type: string
+                            min_version:
+                                type: string
+                            reload_interval:
+                                type: duration
+                            tpm:
+                                fields:
+                                    auth:
+                                        type: string
+                                    enabled:
+                                        type: bool
+                                    owner_auth:
+                                        type: string
+                                    path:
+                                        type: string
+                                type: object
+                        type: object
+                    transport:
+                        type: string
+                    use_v2:
+                        type: bool
+                    write_timeout:
+                        type: duration
+                type: object
+            pprof:
+                fields:
+                    block_profile_fraction:
+                        type: int
+                    dialer:
+                        fields:
+                            timeout:
+                                type: duration
+                        type: object
+                    endpoint:
+                        type: string
+                    mutex_profile_fraction:
+                        type: int
+                    save_to_file:
+                        type: string
+                type: object
+            zpages:
+                fields:
+                    auth:
+                        fields:
+                            authenticator:
+                                type: object
+                            request_params:
+                                elem:
+                                    type: string
+                                type: array
+                        type: object
+                    compression_algorithms:
+                        elem:
+                            type: string
+                        type: array
+                    cors:
+                        fields:
+                            allowed_headers:
+                                elem:
+                                    type: string
+                                type: array
+                            allowed_origins:
+                                elem:
+                                    type: string
+                                type: array
+                            exposed_headers:
+                                elem:
+                                    type: string
+                                type: array
+                            max_age:
+                                type: int
+                        type: object
+                    dialer:
+                        fields:
+                            timeout:
+                                type: duration
+                        type: object
+                    endpoint:
+                        type: string
+                    expvar:
+                        fields:
+                            enabled:
+                                type: bool
+                        type: object
+                    idle_timeout:
+                        type: duration
+                    include_metadata:
+                        type: bool
+                    keep_alives_enabled:
+                        type: bool
+                    max_request_body_size:
+                        type: int
+                    middlewares:
+                        elem:
+                            fields:
+                                id:
+                                    type: object
+                            type: object
+                        type: array
+                    read_header_timeout:
+                        type: duration
+                    read_timeout:
+                        type: duration
+                    response_headers:
+                        elem:
+                            fields:
+                                name:
+                                    type: string
+                                value:
+                                    type: string
+                            type: object
+                        type: array
+                    tls:
+                        fields:
+                            ca_file:
+                                type: string
+                            ca_pem:
+                                type: string
+                            cert_file:
+                                type: string
+                            cert_pem:
+                                type: string
+                            cipher_suites:
+                                elem:
+                                    type: string
+                                type: array
+                            client_ca_file:
+                                type: string
+                            client_ca_file_reload:
+                                type: bool
+                            curve_preferences:
+                                elem:
+                                    type: string
+                                type: array
+                            include_insecure_cipher_suites:
+                                type: bool
+                            include_system_ca_certs_pool:
+                                type: bool
+                            key_file:
+                                type: string
+                            key_pem:
+                                type: string
+                            max_version:
+                                type: string
+                            min_version:
+                                type: string
+                            reload_interval:
+                                type: duration
+                            tpm:
+                                fields:
+                                    auth:
+                                        type: string
+                                    enabled:
+                                        type: bool
+                                    owner_auth:
+                                        type: string
+                                    path:
+                                        type: string
+                                type: object
+                        type: object
+                    transport:
+                        type: string
+                    write_timeout:
+                        type: duration
+                type: object
+        processors:
+            attributes:
+                fields:
+                    actions:
+                        elem:
+                            fields:
+                                action:
+                                    type: string
+                                converted_type:
+                                    type: string
+                                default_value:
+                                    type: any
+                                from_attribute:
+                                    type: string
+                                from_context:
+                                    type: string
+                                key:
+                                    type: string
+                                pattern:
+                                    type: string
+                                value:
+                                    type: any
+                            type: object
+                        type: array
+                    exclude:
+                        fields:
+                            attributes:
+                                elem:
+                                    fields:
+                                        key:
+                                            type: string
+                                        value:
+                                            type: any
+                                    type: object
+                                type: array
+                            libraries:
+                                elem:
+                                    fields:
+                                        name:
+                                            type: string
+                                        version:
+                                            type: string
+                                    type: object
+                                type: array
+                            log_bodies:
+                                elem:
+                                    type: string
+                                type: array
+                            log_severity_number:
+                                fields:
+                                    match_undefined:
+                                        type: bool
+                                    min:
+                                        type: int
+                                type: object
+                            log_severity_texts:
+                                elem:
+                                    type: string
+                                type: array
+                            match_type:
+                                type: string
+                            metric_names:
+                                elem:
+                                    type: string
+                                type: array
+                            regexp:
+                                fields:
+                                    cacheenabled:
+                                        type: bool
+                                    cachemaxnumentries:
+                                        type: int
+                                type: object
+                            resources:
+                                elem:
+                                    fields:
+                                        key:
+                                            type: string
+                                        value:
+                                            type: any
+                                    type: object
+                                type: array
+                            services:
+                                elem:
+                                    type: string
+                                type: array
+                            span_kinds:
+                                elem:
+                                    type: string
+                                type: array
+                            span_names:
+                                elem:
+                                    type: string
+                                type: array
+                        type: object
+                    include:
+                        fields:
+                            attributes:
+                                elem:
+                                    fields:
+                                        key:
+                                            type: string
+                                        value:
+                                            type: any
+                                    type: object
+                                type: array
+                            libraries:
+                                elem:
+                                    fields:
+                                        name:
+                                            type: string
+                                        version:
+                                            type: string
+                                    type: object
+                                type: array
+                            log_bodies:
+                                elem:
+                                    type: string
+                                type: array
+                            log_severity_number:
+                                fields:
+                                    match_undefined:
+                                        type: bool
+                                    min:
+                                        type: int
+                                type: object
+                            log_severity_texts:
+                                elem:
+                                    type: string
+                                type: array
+                            match_type:
+                                type: string
+                            metric_names:
+                                elem:
+                                    type: string
+                                type: array
+                            regexp:
+                                fields:
+                                    cacheenabled:
+                                        type: bool
+                                    cachemaxnumentries:
+                                        type: int
+                                type: object
+                            resources:
+                                elem:
+                                    fields:
+                                        key:
+                                            type: string
+                                        value:
+                                            type: any
+                                    type: object
+                                type: array
+                            services:
+                                elem:
+                                    type: string
+                                type: array
+                            span_kinds:
+                                elem:
+                                    type: string
+                                type: array
+                            span_names:
+                                elem:
+                                    type: string
+                                type: array
+                        type: object
+                type: object
+            batch:
+                fields:
+                    metadata_cardinality_limit:
+                        type: int
+                    metadata_keys:
+                        elem:
+                            type: string
+                        type: array
+                    send_batch_max_size:
+                        type: int
+                    send_batch_size:
+                        type: int
+                    timeout:
+                        type: duration
+                type: object
+            filter:
+                fields:
+                    error_mode:
+                        type: string
+                    log_conditions:
+                        elem:
+                            fields:
+                                conditions:
+                                    elem:
+                                        type: string
+                                    type: array
+                                context:
+                                    type: string
+                                error_mode:
+                                    type: string
+                            type: object
+                        type: array
+                    logs:
+                        fields:
+                            exclude:
+                                fields:
+                                    bodies:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    match_type:
+                                        type: string
+                                    record_attributes:
+                                        elem:
+                                            fields:
+                                                key:
+                                                    type: string
+                                                value:
+                                                    type: any
+                                            type: object
+                                        type: array
+                                    resource_attributes:
+                                        elem:
+                                            fields:
+                                                key:
+                                                    type: string
+                                                value:
+                                                    type: any
+                                            type: object
+                                        type: array
+                                    severity_number:
+                                        fields:
+                                            match_undefined:
+                                                type: bool
+                                            min:
+                                                type: string
+                                        type: object
+                                    severity_texts:
+                                        elem:
+                                            type: string
+                                        type: array
+                                type: object
+                            include:
+                                fields:
+                                    bodies:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    match_type:
+                                        type: string
+                                    record_attributes:
+                                        elem:
+                                            fields:
+                                                key:
+                                                    type: string
+                                                value:
+                                                    type: any
+                                            type: object
+                                        type: array
+                                    resource_attributes:
+                                        elem:
+                                            fields:
+                                                key:
+                                                    type: string
+                                                value:
+                                                    type: any
+                                            type: object
+                                        type: array
+                                    severity_number:
+                                        fields:
+                                            match_undefined:
+                                                type: bool
+                                            min:
+                                                type: string
+                                        type: object
+                                    severity_texts:
+                                        elem:
+                                            type: string
+                                        type: array
+                                type: object
+                            log_record:
+                                elem:
+                                    type: string
+                                type: array
+                            resource:
+                                elem:
+                                    type: string
+                                type: array
+                        type: object
+                    metric_conditions:
+                        elem:
+                            fields:
+                                conditions:
+                                    elem:
+                                        type: string
+                                    type: array
+                                context:
+                                    type: string
+                                error_mode:
+                                    type: string
+                            type: object
+                        type: array
+                    metrics:
+                        fields:
+                            datapoint:
+                                elem:
+                                    type: string
+                                type: array
+                            exclude:
+                                fields:
+                                    expressions:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    match_type:
+                                        type: string
+                                    metric_names:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    regexp:
+                                        fields:
+                                            cacheenabled:
+                                                type: bool
+                                            cachemaxnumentries:
+                                                type: int
+                                        type: object
+                                    resource_attributes:
+                                        elem:
+                                            fields:
+                                                key:
+                                                    type: string
+                                                value:
+                                                    type: any
+                                            type: object
+                                        type: array
+                                type: object
+                            include:
+                                fields:
+                                    expressions:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    match_type:
+                                        type: string
+                                    metric_names:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    regexp:
+                                        fields:
+                                            cacheenabled:
+                                                type: bool
+                                            cachemaxnumentries:
+                                                type: int
+                                        type: object
+                                    resource_attributes:
+                                        elem:
+                                            fields:
+                                                key:
+                                                    type: string
+                                                value:
+                                                    type: any
+                                            type: object
+                                        type: array
+                                type: object
+                            metric:
+                                elem:
+                                    type: string
+                                type: array
+                            regexp:
+                                fields:
+                                    cacheenabled:
+                                        type: bool
+                                    cachemaxnumentries:
+                                        type: int
+                                type: object
+                            resource:
+                                elem:
+                                    type: string
+                                type: array
+                        type: object
+                    profile_conditions:
+                        elem:
+                            fields:
+                                conditions:
+                                    elem:
+                                        type: string
+                                    type: array
+                                context:
+                                    type: string
+                                error_mode:
+                                    type: string
+                            type: object
+                        type: array
+                    profiles:
+                        fields:
+                            profile:
+                                elem:
+                                    type: string
+                                type: array
+                            resource:
+                                elem:
+                                    type: string
+                                type: array
+                        type: object
+                    spans:
+                        fields:
+                            exclude:
+                                fields:
+                                    attributes:
+                                        elem:
+                                            fields:
+                                                key:
+                                                    type: string
+                                                value:
+                                                    type: any
+                                            type: object
+                                        type: array
+                                    libraries:
+                                        elem:
+                                            fields:
+                                                name:
+                                                    type: string
+                                                version:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    log_bodies:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    log_severity_number:
+                                        fields:
+                                            match_undefined:
+                                                type: bool
+                                            min:
+                                                type: int
+                                        type: object
+                                    log_severity_texts:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    match_type:
+                                        type: string
+                                    metric_names:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    regexp:
+                                        fields:
+                                            cacheenabled:
+                                                type: bool
+                                            cachemaxnumentries:
+                                                type: int
+                                        type: object
+                                    resources:
+                                        elem:
+                                            fields:
+                                                key:
+                                                    type: string
+                                                value:
+                                                    type: any
+                                            type: object
+                                        type: array
+                                    services:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    span_kinds:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    span_names:
+                                        elem:
+                                            type: string
+                                        type: array
+                                type: object
+                            include:
+                                fields:
+                                    attributes:
+                                        elem:
+                                            fields:
+                                                key:
+                                                    type: string
+                                                value:
+                                                    type: any
+                                            type: object
+                                        type: array
+                                    libraries:
+                                        elem:
+                                            fields:
+                                                name:
+                                                    type: string
+                                                version:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    log_bodies:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    log_severity_number:
+                                        fields:
+                                            match_undefined:
+                                                type: bool
+                                            min:
+                                                type: int
+                                        type: object
+                                    log_severity_texts:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    match_type:
+                                        type: string
+                                    metric_names:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    regexp:
+                                        fields:
+                                            cacheenabled:
+                                                type: bool
+                                            cachemaxnumentries:
+                                                type: int
+                                        type: object
+                                    resources:
+                                        elem:
+                                            fields:
+                                                key:
+                                                    type: string
+                                                value:
+                                                    type: any
+                                            type: object
+                                        type: array
+                                    services:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    span_kinds:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    span_names:
+                                        elem:
+                                            type: string
+                                        type: array
+                                type: object
+                        type: object
+                    trace_conditions:
+                        elem:
+                            fields:
+                                conditions:
+                                    elem:
+                                        type: string
+                                    type: array
+                                context:
+                                    type: string
+                                error_mode:
+                                    type: string
+                            type: object
+                        type: array
+                    traces:
+                        fields:
+                            resource:
+                                elem:
+                                    type: string
+                                type: array
+                            span:
+                                elem:
+                                    type: string
+                                type: array
+                            spanevent:
+                                elem:
+                                    type: string
+                                type: array
+                        type: object
+                type: object
+            memory_limiter:
+                fields:
+                    check_interval:
+                        type: duration
+                    limit_mib:
+                        type: int
+                    limit_percentage:
+                        type: int
+                    max_gc_interval_when_hard_limited:
+                        type: duration
+                    max_gc_interval_when_soft_limited:
+                        type: duration
+                    min_gc_interval_when_hard_limited:
+                        type: duration
+                    min_gc_interval_when_soft_limited:
+                        type: duration
+                    spike_limit_mib:
+                        type: int
+                    spike_limit_percentage:
+                        type: int
+                type: object
+            probabilistic_sampler:
+                fields:
+                    attribute_source:
+                        type: string
+                    fail_closed:
+                        type: bool
+                    from_attribute:
+                        type: string
+                    hash_seed:
+                        type: int
+                    mode:
+                        type: string
+                    sampling_percentage:
+                        type: float
+                    sampling_precision:
+                        type: int
+                    sampling_priority:
+                        type: string
+                type: object
+            resource:
+                fields:
+                    attributes:
+                        elem:
+                            fields:
+                                action:
+                                    type: string
+                                converted_type:
+                                    type: string
+                                default_value:
+                                    type: any
+                                from_attribute:
+                                    type: string
+                                from_context:
+                                    type: string
+                                key:
+                                    type: string
+                                pattern:
+                                    type: string
+                                value:
+                                    type: any
+                            type: object
+                        type: array
+                type: object
+            span:
+                fields:
+                    exclude:
+                        fields:
+                            attributes:
+                                elem:
+                                    fields:
+                                        key:
+                                            type: string
+                                        value:
+                                            type: any
+                                    type: object
+                                type: array
+                            libraries:
+                                elem:
+                                    fields:
+                                        name:
+                                            type: string
+                                        version:
+                                            type: string
+                                    type: object
+                                type: array
+                            log_bodies:
+                                elem:
+                                    type: string
+                                type: array
+                            log_severity_number:
+                                fields:
+                                    match_undefined:
+                                        type: bool
+                                    min:
+                                        type: int
+                                type: object
+                            log_severity_texts:
+                                elem:
+                                    type: string
+                                type: array
+                            match_type:
+                                type: string
+                            metric_names:
+                                elem:
+                                    type: string
+                                type: array
+                            regexp:
+                                fields:
+                                    cacheenabled:
+                                        type: bool
+                                    cachemaxnumentries:
+                                        type: int
+                                type: object
+                            resources:
+                                elem:
+                                    fields:
+                                        key:
+                                            type: string
+                                        value:
+                                            type: any
+                                    type: object
+                                type: array
+                            services:
+                                elem:
+                                    type: string
+                                type: array
+                            span_kinds:
+                                elem:
+                                    type: string
+                                type: array
+                            span_names:
+                                elem:
+                                    type: string
+                                type: array
+                        type: object
+                    include:
+                        fields:
+                            attributes:
+                                elem:
+                                    fields:
+                                        key:
+                                            type: string
+                                        value:
+                                            type: any
+                                    type: object
+                                type: array
+                            libraries:
+                                elem:
+                                    fields:
+                                        name:
+                                            type: string
+                                        version:
+                                            type: string
+                                    type: object
+                                type: array
+                            log_bodies:
+                                elem:
+                                    type: string
+                                type: array
+                            log_severity_number:
+                                fields:
+                                    match_undefined:
+                                        type: bool
+                                    min:
+                                        type: int
+                                type: object
+                            log_severity_texts:
+                                elem:
+                                    type: string
+                                type: array
+                            match_type:
+                                type: string
+                            metric_names:
+                                elem:
+                                    type: string
+                                type: array
+                            regexp:
+                                fields:
+                                    cacheenabled:
+                                        type: bool
+                                    cachemaxnumentries:
+                                        type: int
+                                type: object
+                            resources:
+                                elem:
+                                    fields:
+                                        key:
+                                            type: string
+                                        value:
+                                            type: any
+                                    type: object
+                                type: array
+                            services:
+                                elem:
+                                    type: string
+                                type: array
+                            span_kinds:
+                                elem:
+                                    type: string
+                                type: array
+                            span_names:
+                                elem:
+                                    type: string
+                                type: array
+                        type: object
+                    name:
+                        fields:
+                            from_attributes:
+                                elem:
+                                    type: string
+                                type: array
+                            separator:
+                                type: string
+                            to_attributes:
+                                fields:
+                                    break_after_match:
+                                        type: bool
+                                    keep_original_name:
+                                        type: bool
+                                    rules:
+                                        elem:
+                                            type: string
+                                        type: array
+                                type: object
+                        type: object
+                    status:
+                        fields:
+                            code:
+                                type: string
+                            description:
+                                type: string
+                        type: object
+                type: object
+        receivers:
+            host_metrics:
+                fields:
+                    collection_interval:
+                        type: duration
+                    initial_delay:
+                        type: duration
+                    metadata_collection_interval:
+                        type: duration
+                    root_path:
+                        type: string
+                    timeout:
+                        type: duration
+                type: object
+            jaeger:
+                fields:
+                    protocols:
+                        fields:
+                            grpc:
+                                fields:
+                                    auth:
+                                        fields:
+                                            authenticator:
+                                                type: object
+                                        type: object
+                                    dialer:
+                                        fields:
+                                            timeout:
+                                                type: duration
+                                        type: object
+                                    endpoint:
+                                        type: string
+                                    include_metadata:
+                                        type: bool
+                                    keepalive:
+                                        fields:
+                                            enforcement_policy:
+                                                fields:
+                                                    min_time:
+                                                        type: duration
+                                                    permit_without_stream:
+                                                        type: bool
+                                                type: object
+                                            server_parameters:
+                                                fields:
+                                                    max_connection_age:
+                                                        type: duration
+                                                    max_connection_age_grace:
+                                                        type: duration
+                                                    max_connection_idle:
+                                                        type: duration
+                                                    time:
+                                                        type: duration
+                                                    timeout:
+                                                        type: duration
+                                                type: object
+                                        type: object
+                                    max_concurrent_streams:
+                                        type: int
+                                    max_recv_msg_size_mib:
+                                        type: int
+                                    middlewares:
+                                        elem:
+                                            fields:
+                                                id:
+                                                    type: object
+                                            type: object
+                                        type: array
+                                    read_buffer_size:
+                                        type: int
+                                    tls:
+                                        fields:
+                                            ca_file:
+                                                type: string
+                                            ca_pem:
+                                                type: string
+                                            cert_file:
+                                                type: string
+                                            cert_pem:
+                                                type: string
+                                            cipher_suites:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            client_ca_file:
+                                                type: string
+                                            client_ca_file_reload:
+                                                type: bool
+                                            curve_preferences:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            include_insecure_cipher_suites:
+                                                type: bool
+                                            include_system_ca_certs_pool:
+                                                type: bool
+                                            key_file:
+                                                type: string
+                                            key_pem:
+                                                type: string
+                                            max_version:
+                                                type: string
+                                            min_version:
+                                                type: string
+                                            reload_interval:
+                                                type: duration
+                                            tpm:
+                                                fields:
+                                                    auth:
+                                                        type: string
+                                                    enabled:
+                                                        type: bool
+                                                    owner_auth:
+                                                        type: string
+                                                    path:
+                                                        type: string
+                                                type: object
+                                        type: object
+                                    transport:
+                                        type: string
+                                    write_buffer_size:
+                                        type: int
+                                type: object
+                            thrift_binary:
+                                fields:
+                                    endpoint:
+                                        type: string
+                                    max_packet_size:
+                                        type: int
+                                    queue_size:
+                                        type: int
+                                    socket_buffer_size:
+                                        type: int
+                                    workers:
+                                        type: int
+                                type: object
+                            thrift_compact:
+                                fields:
+                                    endpoint:
+                                        type: string
+                                    max_packet_size:
+                                        type: int
+                                    queue_size:
+                                        type: int
+                                    socket_buffer_size:
+                                        type: int
+                                    workers:
+                                        type: int
+                                type: object
+                            thrift_http:
+                                fields:
+                                    auth:
+                                        fields:
+                                            authenticator:
+                                                type: object
+                                            request_params:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                        type: object
+                                    compression_algorithms:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    cors:
+                                        fields:
+                                            allowed_headers:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            allowed_origins:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            exposed_headers:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            max_age:
+                                                type: int
+                                        type: object
+                                    dialer:
+                                        fields:
+                                            timeout:
+                                                type: duration
+                                        type: object
+                                    endpoint:
+                                        type: string
+                                    idle_timeout:
+                                        type: duration
+                                    include_metadata:
+                                        type: bool
+                                    keep_alives_enabled:
+                                        type: bool
+                                    max_request_body_size:
+                                        type: int
+                                    middlewares:
+                                        elem:
+                                            fields:
+                                                id:
+                                                    type: object
+                                            type: object
+                                        type: array
+                                    read_header_timeout:
+                                        type: duration
+                                    read_timeout:
+                                        type: duration
+                                    response_headers:
+                                        elem:
+                                            fields:
+                                                name:
+                                                    type: string
+                                                value:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    tls:
+                                        fields:
+                                            ca_file:
+                                                type: string
+                                            ca_pem:
+                                                type: string
+                                            cert_file:
+                                                type: string
+                                            cert_pem:
+                                                type: string
+                                            cipher_suites:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            client_ca_file:
+                                                type: string
+                                            client_ca_file_reload:
+                                                type: bool
+                                            curve_preferences:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            include_insecure_cipher_suites:
+                                                type: bool
+                                            include_system_ca_certs_pool:
+                                                type: bool
+                                            key_file:
+                                                type: string
+                                            key_pem:
+                                                type: string
+                                            max_version:
+                                                type: string
+                                            min_version:
+                                                type: string
+                                            reload_interval:
+                                                type: duration
+                                            tpm:
+                                                fields:
+                                                    auth:
+                                                        type: string
+                                                    enabled:
+                                                        type: bool
+                                                    owner_auth:
+                                                        type: string
+                                                    path:
+                                                        type: string
+                                                type: object
+                                        type: object
+                                    transport:
+                                        type: string
+                                    write_timeout:
+                                        type: duration
+                                type: object
+                        type: object
+                    remote_sampling:
+                        fields:
+                            auth:
+                                fields:
+                                    authenticator:
+                                        type: object
+                                type: object
+                            authority:
+                                type: string
+                            balancer_name:
+                                type: string
+                            compression:
+                                type: string
+                            endpoint:
+                                type: string
+                            headers:
+                                elem:
+                                    fields:
+                                        name:
+                                            type: string
+                                        value:
+                                            type: string
+                                    type: object
+                                type: array
+                            host_endpoint:
+                                type: string
+                            keepalive:
+                                fields:
+                                    permit_without_stream:
+                                        type: bool
+                                    time:
+                                        type: duration
+                                    timeout:
+                                        type: duration
+                                type: object
+                            middlewares:
+                                elem:
+                                    fields:
+                                        id:
+                                            type: object
+                                    type: object
+                                type: array
+                            read_buffer_size:
+                                type: int
+                            strategy_file:
+                                type: string
+                            strategy_file_reload_interval:
+                                type: duration
+                            tls:
+                                fields:
+                                    ca_file:
+                                        type: string
+                                    ca_pem:
+                                        type: string
+                                    cert_file:
+                                        type: string
+                                    cert_pem:
+                                        type: string
+                                    cipher_suites:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    curve_preferences:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    include_insecure_cipher_suites:
+                                        type: bool
+                                    include_system_ca_certs_pool:
+                                        type: bool
+                                    insecure:
+                                        type: bool
+                                    insecure_skip_verify:
+                                        type: bool
+                                    key_file:
+                                        type: string
+                                    key_pem:
+                                        type: string
+                                    max_version:
+                                        type: string
+                                    min_version:
+                                        type: string
+                                    reload_interval:
+                                        type: duration
+                                    server_name_override:
+                                        type: string
+                                    tpm:
+                                        fields:
+                                            auth:
+                                                type: string
+                                            enabled:
+                                                type: bool
+                                            owner_auth:
+                                                type: string
+                                            path:
+                                                type: string
+                                        type: object
+                                type: object
+                            user_agent:
+                                type: string
+                            wait_for_ready:
+                                type: bool
+                            write_buffer_size:
+                                type: int
+                        type: object
+                type: object
+            kafka:
+                fields:
+                    auth:
+                        fields:
+                            kerberos:
+                                fields:
+                                    config_file:
+                                        type: string
+                                    disable_fast_negotiation:
+                                        type: bool
+                                    keytab_file:
+                                        type: string
+                                    password:
+                                        type: string
+                                    realm:
+                                        type: string
+                                    service_name:
+                                        type: string
+                                    use_keytab:
+                                        type: bool
+                                    username:
+                                        type: string
+                                type: object
+                            plain_text:
+                                fields:
+                                    password:
+                                        type: string
+                                    username:
+                                        type: string
+                                type: object
+                            sasl:
+                                fields:
+                                    aws_msk:
+                                        fields:
+                                            region:
+                                                type: string
+                                        type: object
+                                    mechanism:
+                                        type: string
+                                    oauthbearer_token_source:
+                                        type: object
+                                    password:
+                                        type: string
+                                    username:
+                                        type: string
+                                    version:
+                                        type: int
+                                type: object
+                            tls:
+                                fields:
+                                    ca_file:
+                                        type: string
+                                    ca_pem:
+                                        type: string
+                                    cert_file:
+                                        type: string
+                                    cert_pem:
+                                        type: string
+                                    cipher_suites:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    curve_preferences:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    include_insecure_cipher_suites:
+                                        type: bool
+                                    include_system_ca_certs_pool:
+                                        type: bool
+                                    insecure:
+                                        type: bool
+                                    insecure_skip_verify:
+                                        type: bool
+                                    key_file:
+                                        type: string
+                                    key_pem:
+                                        type: string
+                                    max_version:
+                                        type: string
+                                    min_version:
+                                        type: string
+                                    reload_interval:
+                                        type: duration
+                                    server_name_override:
+                                        type: string
+                                    tpm:
+                                        fields:
+                                            auth:
+                                                type: string
+                                            enabled:
+                                                type: bool
+                                            owner_auth:
+                                                type: string
+                                            path:
+                                                type: string
+                                        type: object
+                                type: object
+                        type: object
+                    autocommit:
+                        fields:
+                            enable:
+                                type: bool
+                            interval:
+                                type: duration
+                        type: object
+                    brokers:
+                        elem:
+                            type: string
+                        type: array
+                    client_id:
+                        type: string
+                    conn_idle_timeout:
+                        type: duration
+                    error_backoff:
+                        fields:
+                            enabled:
+                                type: bool
+                            initial_interval:
+                                type: duration
+                            max_elapsed_time:
+                                type: duration
+                            max_interval:
+                                type: duration
+                            multiplier:
+                                type: float
+                            randomization_factor:
+                                type: float
+                        type: object
+                    group_id:
+                        type: string
+                    group_instance_id:
+                        type: string
+                    group_rebalance_strategies:
+                        elem:
+                            type: string
+                        type: array
+                    group_rebalance_strategy:
+                        type: string
+                    header_extraction:
+                        fields:
+                            extract_headers:
+                                type: bool
+                            headers:
+                                elem:
+                                    type: string
+                                type: array
+                        type: object
+                    heartbeat_interval:
+                        type: duration
+                    initial_offset:
+                        type: string
+                    logs:
+                        fields:
+                            encoding:
+                                type: string
+                            exclude_topics:
+                                elem:
+                                    type: string
+                                type: array
+                            topics:
+                                elem:
+                                    type: string
+                                type: array
+                        type: object
+                    max_fetch_size:
+                        type: int
+                    max_fetch_wait:
+                        type: duration
+                    max_partition_fetch_size:
+                        type: int
+                    message_marking:
+                        fields:
+                            after:
+                                type: bool
+                            on_error:
+                                type: bool
+                            on_permanent_error:
+                                type: bool
+                        type: object
+                    metadata:
+                        fields:
+                            full:
+                                type: bool
+                            refresh_interval:
+                                type: duration
+                            retry:
+                                fields:
+                                    backoff:
+                                        type: duration
+                                    max:
+                                        type: int
+                                type: object
+                        type: object
+                    metrics:
+                        fields:
+                            encoding:
+                                type: string
+                            exclude_topics:
+                                elem:
+                                    type: string
+                                type: array
+                            topics:
+                                elem:
+                                    type: string
+                                type: array
+                        type: object
+                    min_fetch_size:
+                        type: int
+                    profiles:
+                        fields:
+                            encoding:
+                                type: string
+                            exclude_topics:
+                                elem:
+                                    type: string
+                                type: array
+                            topics:
+                                elem:
+                                    type: string
+                                type: array
+                        type: object
+                    protocol_version:
+                        type: string
+                    rack_id:
+                        type: string
+                    resolve_canonical_bootstrap_servers_only:
+                        type: bool
+                    session_timeout:
+                        type: duration
+                    telemetry:
+                        fields:
+                            metrics:
+                                fields:
+                                    kafka_receiver_records_delay:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                type: object
+                        type: object
+                    tls:
+                        fields:
+                            ca_file:
+                                type: string
+                            ca_pem:
+                                type: string
+                            cert_file:
+                                type: string
+                            cert_pem:
+                                type: string
+                            cipher_suites:
+                                elem:
+                                    type: string
+                                type: array
+                            curve_preferences:
+                                elem:
+                                    type: string
+                                type: array
+                            include_insecure_cipher_suites:
+                                type: bool
+                            include_system_ca_certs_pool:
+                                type: bool
+                            insecure:
+                                type: bool
+                            insecure_skip_verify:
+                                type: bool
+                            key_file:
+                                type: string
+                            key_pem:
+                                type: string
+                            max_version:
+                                type: string
+                            min_version:
+                                type: string
+                            reload_interval:
+                                type: duration
+                            server_name_override:
+                                type: string
+                            tpm:
+                                fields:
+                                    auth:
+                                        type: string
+                                    enabled:
+                                        type: bool
+                                    owner_auth:
+                                        type: string
+                                    path:
+                                        type: string
+                                type: object
+                        type: object
+                    traces:
+                        fields:
+                            encoding:
+                                type: string
+                            exclude_topics:
+                                elem:
+                                    type: string
+                                type: array
+                            topics:
+                                elem:
+                                    type: string
+                                type: array
+                        type: object
+                    use_leader_epoch:
+                        type: bool
+                type: object
+            nop:
+                type: object
+            otlp:
+                fields:
+                    protocols:
+                        fields:
+                            grpc:
+                                fields:
+                                    auth:
+                                        fields:
+                                            authenticator:
+                                                type: object
+                                        type: object
+                                    dialer:
+                                        fields:
+                                            timeout:
+                                                type: duration
+                                        type: object
+                                    endpoint:
+                                        type: string
+                                    include_metadata:
+                                        type: bool
+                                    keepalive:
+                                        fields:
+                                            enforcement_policy:
+                                                fields:
+                                                    min_time:
+                                                        type: duration
+                                                    permit_without_stream:
+                                                        type: bool
+                                                type: object
+                                            server_parameters:
+                                                fields:
+                                                    max_connection_age:
+                                                        type: duration
+                                                    max_connection_age_grace:
+                                                        type: duration
+                                                    max_connection_idle:
+                                                        type: duration
+                                                    time:
+                                                        type: duration
+                                                    timeout:
+                                                        type: duration
+                                                type: object
+                                        type: object
+                                    max_concurrent_streams:
+                                        type: int
+                                    max_recv_msg_size_mib:
+                                        type: int
+                                    middlewares:
+                                        elem:
+                                            fields:
+                                                id:
+                                                    type: object
+                                            type: object
+                                        type: array
+                                    read_buffer_size:
+                                        type: int
+                                    tls:
+                                        fields:
+                                            ca_file:
+                                                type: string
+                                            ca_pem:
+                                                type: string
+                                            cert_file:
+                                                type: string
+                                            cert_pem:
+                                                type: string
+                                            cipher_suites:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            client_ca_file:
+                                                type: string
+                                            client_ca_file_reload:
+                                                type: bool
+                                            curve_preferences:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            include_insecure_cipher_suites:
+                                                type: bool
+                                            include_system_ca_certs_pool:
+                                                type: bool
+                                            key_file:
+                                                type: string
+                                            key_pem:
+                                                type: string
+                                            max_version:
+                                                type: string
+                                            min_version:
+                                                type: string
+                                            reload_interval:
+                                                type: duration
+                                            tpm:
+                                                fields:
+                                                    auth:
+                                                        type: string
+                                                    enabled:
+                                                        type: bool
+                                                    owner_auth:
+                                                        type: string
+                                                    path:
+                                                        type: string
+                                                type: object
+                                        type: object
+                                    transport:
+                                        type: string
+                                    write_buffer_size:
+                                        type: int
+                                type: object
+                            http:
+                                fields:
+                                    auth:
+                                        fields:
+                                            authenticator:
+                                                type: object
+                                            request_params:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                        type: object
+                                    compression_algorithms:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    cors:
+                                        fields:
+                                            allowed_headers:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            allowed_origins:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            exposed_headers:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            max_age:
+                                                type: int
+                                        type: object
+                                    dialer:
+                                        fields:
+                                            timeout:
+                                                type: duration
+                                        type: object
+                                    endpoint:
+                                        type: string
+                                    idle_timeout:
+                                        type: duration
+                                    include_metadata:
+                                        type: bool
+                                    keep_alives_enabled:
+                                        type: bool
+                                    logs_url_path:
+                                        type: string
+                                    max_request_body_size:
+                                        type: int
+                                    metrics_url_path:
+                                        type: string
+                                    middlewares:
+                                        elem:
+                                            fields:
+                                                id:
+                                                    type: object
+                                            type: object
+                                        type: array
+                                    read_header_timeout:
+                                        type: duration
+                                    read_timeout:
+                                        type: duration
+                                    response_headers:
+                                        elem:
+                                            fields:
+                                                name:
+                                                    type: string
+                                                value:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    tls:
+                                        fields:
+                                            ca_file:
+                                                type: string
+                                            ca_pem:
+                                                type: string
+                                            cert_file:
+                                                type: string
+                                            cert_pem:
+                                                type: string
+                                            cipher_suites:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            client_ca_file:
+                                                type: string
+                                            client_ca_file_reload:
+                                                type: bool
+                                            curve_preferences:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            include_insecure_cipher_suites:
+                                                type: bool
+                                            include_system_ca_certs_pool:
+                                                type: bool
+                                            key_file:
+                                                type: string
+                                            key_pem:
+                                                type: string
+                                            max_version:
+                                                type: string
+                                            min_version:
+                                                type: string
+                                            reload_interval:
+                                                type: duration
+                                            tpm:
+                                                fields:
+                                                    auth:
+                                                        type: string
+                                                    enabled:
+                                                        type: bool
+                                                    owner_auth:
+                                                        type: string
+                                                    path:
+                                                        type: string
+                                                type: object
+                                        type: object
+                                    traces_url_path:
+                                        type: string
+                                    transport:
+                                        type: string
+                                    write_timeout:
+                                        type: duration
+                                type: object
+                        type: object
+                type: object
+            prometheus:
+                fields:
+                    api_server:
+                        fields:
+                            enabled:
+                                type: bool
+                            max_connections:
+                                type: int
+                            server_config:
+                                fields:
+                                    auth:
+                                        fields:
+                                            authenticator:
+                                                type: object
+                                            request_params:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                        type: object
+                                    compression_algorithms:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    cors:
+                                        fields:
+                                            allowed_headers:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            allowed_origins:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            exposed_headers:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            max_age:
+                                                type: int
+                                        type: object
+                                    dialer:
+                                        fields:
+                                            timeout:
+                                                type: duration
+                                        type: object
+                                    endpoint:
+                                        type: string
+                                    idle_timeout:
+                                        type: duration
+                                    include_metadata:
+                                        type: bool
+                                    keep_alives_enabled:
+                                        type: bool
+                                    max_request_body_size:
+                                        type: int
+                                    middlewares:
+                                        elem:
+                                            fields:
+                                                id:
+                                                    type: object
+                                            type: object
+                                        type: array
+                                    read_header_timeout:
+                                        type: duration
+                                    read_timeout:
+                                        type: duration
+                                    response_headers:
+                                        elem:
+                                            fields:
+                                                name:
+                                                    type: string
+                                                value:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    tls:
+                                        fields:
+                                            ca_file:
+                                                type: string
+                                            ca_pem:
+                                                type: string
+                                            cert_file:
+                                                type: string
+                                            cert_pem:
+                                                type: string
+                                            cipher_suites:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            client_ca_file:
+                                                type: string
+                                            client_ca_file_reload:
+                                                type: bool
+                                            curve_preferences:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            include_insecure_cipher_suites:
+                                                type: bool
+                                            include_system_ca_certs_pool:
+                                                type: bool
+                                            key_file:
+                                                type: string
+                                            key_pem:
+                                                type: string
+                                            max_version:
+                                                type: string
+                                            min_version:
+                                                type: string
+                                            reload_interval:
+                                                type: duration
+                                            tpm:
+                                                fields:
+                                                    auth:
+                                                        type: string
+                                                    enabled:
+                                                        type: bool
+                                                    owner_auth:
+                                                        type: string
+                                                    path:
+                                                        type: string
+                                                type: object
+                                        type: object
+                                    transport:
+                                        type: string
+                                    write_timeout:
+                                        type: duration
+                                type: object
+                        type: object
+                    config:
+                        type: object
+                    discovery_reload_on_startup:
+                        type: bool
+                    initial_scrape_offset:
+                        type: duration
+                    scrape_on_shutdown:
+                        type: bool
+                    target_allocator:
+                        fields:
+                            auth:
+                                fields:
+                                    authenticator:
+                                        type: object
+                                type: object
+                            collector_id:
+                                type: string
+                            compression:
+                                type: string
+                            compression_params:
+                                fields:
+                                    level:
+                                        type: int
+                                type: object
+                            cookies:
+                                type: object
+                            disable_keep_alives:
+                                type: bool
+                            endpoint:
+                                type: string
+                            force_attempt_http2:
+                                type: bool
+                            headers:
+                                elem:
+                                    fields:
+                                        name:
+                                            type: string
+                                        value:
+                                            type: string
+                                    type: object
+                                type: array
+                            http_scrape_config:
+                                type: object
+                            http_sd_config:
+                                type: object
+                            http2_ping_timeout:
+                                type: duration
+                            http2_read_idle_timeout:
+                                type: duration
+                            idle_conn_timeout:
+                                type: duration
+                            interval:
+                                type: duration
+                            max_conns_per_host:
+                                type: int
+                            max_idle_conns:
+                                type: int
+                            max_idle_conns_per_host:
+                                type: int
+                            middlewares:
+                                elem:
+                                    fields:
+                                        id:
+                                            type: object
+                                    type: object
+                                type: array
+                            proxy_url:
+                                type: string
+                            read_buffer_size:
+                                type: int
+                            timeout:
+                                type: duration
+                            tls:
+                                fields:
+                                    ca_file:
+                                        type: string
+                                    ca_pem:
+                                        type: string
+                                    cert_file:
+                                        type: string
+                                    cert_pem:
+                                        type: string
+                                    cipher_suites:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    curve_preferences:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    include_insecure_cipher_suites:
+                                        type: bool
+                                    include_system_ca_certs_pool:
+                                        type: bool
+                                    insecure:
+                                        type: bool
+                                    insecure_skip_verify:
+                                        type: bool
+                                    key_file:
+                                        type: string
+                                    key_pem:
+                                        type: string
+                                    max_version:
+                                        type: string
+                                    min_version:
+                                        type: string
+                                    reload_interval:
+                                        type: duration
+                                    server_name_override:
+                                        type: string
+                                    tpm:
+                                        fields:
+                                            auth:
+                                                type: string
+                                            enabled:
+                                                type: bool
+                                            owner_auth:
+                                                type: string
+                                            path:
+                                                type: string
+                                        type: object
+                                type: object
+                            write_buffer_size:
+                                type: int
+                        type: object
+                    trim_metric_suffixes:
+                        type: bool
+                type: object
+            zipkin:
+                fields:
+                    auth:
+                        fields:
+                            authenticator:
+                                type: object
+                            request_params:
+                                elem:
+                                    type: string
+                                type: array
+                        type: object
+                    compression_algorithms:
+                        elem:
+                            type: string
+                        type: array
+                    cors:
+                        fields:
+                            allowed_headers:
+                                elem:
+                                    type: string
+                                type: array
+                            allowed_origins:
+                                elem:
+                                    type: string
+                                type: array
+                            exposed_headers:
+                                elem:
+                                    type: string
+                                type: array
+                            max_age:
+                                type: int
+                        type: object
+                    dialer:
+                        fields:
+                            timeout:
+                                type: duration
+                        type: object
+                    endpoint:
+                        type: string
+                    idle_timeout:
+                        type: duration
+                    include_metadata:
+                        type: bool
+                    keep_alives_enabled:
+                        type: bool
+                    max_request_body_size:
+                        type: int
+                    middlewares:
+                        elem:
+                            fields:
+                                id:
+                                    type: object
+                            type: object
+                        type: array
+                    parse_string_tags:
+                        type: bool
+                    read_header_timeout:
+                        type: duration
+                    read_timeout:
+                        type: duration
+                    response_headers:
+                        elem:
+                            fields:
+                                name:
+                                    type: string
+                                value:
+                                    type: string
+                            type: object
+                        type: array
+                    tls:
+                        fields:
+                            ca_file:
+                                type: string
+                            ca_pem:
+                                type: string
+                            cert_file:
+                                type: string
+                            cert_pem:
+                                type: string
+                            cipher_suites:
+                                elem:
+                                    type: string
+                                type: array
+                            client_ca_file:
+                                type: string
+                            client_ca_file_reload:
+                                type: bool
+                            curve_preferences:
+                                elem:
+                                    type: string
+                                type: array
+                            include_insecure_cipher_suites:
+                                type: bool
+                            include_system_ca_certs_pool:
+                                type: bool
+                            key_file:
+                                type: string
+                            key_pem:
+                                type: string
+                            max_version:
+                                type: string
+                            min_version:
+                                type: string
+                            reload_interval:
+                                type: duration
+                            tpm:
+                                fields:
+                                    auth:
+                                        type: string
+                                    enabled:
+                                        type: bool
+                                    owner_auth:
+                                        type: string
+                                    path:
+                                        type: string
+                                type: object
+                        type: object
+                    transport:
+                        type: string
+                    write_timeout:
+                        type: duration
+                type: object
     components:
         connectors:
             - forward

--- a/configs/apiserver/initial/remoteconfigschema/otelcol-k8s-0.156.0.yaml
+++ b/configs/apiserver/initial/remoteconfigschema/otelcol-k8s-0.156.0.yaml
@@ -7,6 +7,9358 @@ metadata:
     namespace: default
 spec:
     binary: otelcol-k8s
+    componentConfigs:
+        connectors:
+            count:
+                fields:
+                    datapoints:
+                        elem:
+                            fields:
+                                attributes:
+                                    elem:
+                                        fields:
+                                            default_value:
+                                                type: any
+                                            key:
+                                                type: string
+                                        type: object
+                                    type: array
+                                conditions:
+                                    elem:
+                                        type: string
+                                    type: array
+                                description:
+                                    type: string
+                            type: object
+                        type: map
+                    logs:
+                        elem:
+                            fields:
+                                attributes:
+                                    elem:
+                                        fields:
+                                            default_value:
+                                                type: any
+                                            key:
+                                                type: string
+                                        type: object
+                                    type: array
+                                conditions:
+                                    elem:
+                                        type: string
+                                    type: array
+                                description:
+                                    type: string
+                            type: object
+                        type: map
+                    metrics:
+                        elem:
+                            fields:
+                                attributes:
+                                    elem:
+                                        fields:
+                                            default_value:
+                                                type: any
+                                            key:
+                                                type: string
+                                        type: object
+                                    type: array
+                                conditions:
+                                    elem:
+                                        type: string
+                                    type: array
+                                description:
+                                    type: string
+                            type: object
+                        type: map
+                    profiles:
+                        elem:
+                            fields:
+                                attributes:
+                                    elem:
+                                        fields:
+                                            default_value:
+                                                type: any
+                                            key:
+                                                type: string
+                                        type: object
+                                    type: array
+                                conditions:
+                                    elem:
+                                        type: string
+                                    type: array
+                                description:
+                                    type: string
+                            type: object
+                        type: map
+                    spanevents:
+                        elem:
+                            fields:
+                                attributes:
+                                    elem:
+                                        fields:
+                                            default_value:
+                                                type: any
+                                            key:
+                                                type: string
+                                        type: object
+                                    type: array
+                                conditions:
+                                    elem:
+                                        type: string
+                                    type: array
+                                description:
+                                    type: string
+                            type: object
+                        type: map
+                    spans:
+                        elem:
+                            fields:
+                                attributes:
+                                    elem:
+                                        fields:
+                                            default_value:
+                                                type: any
+                                            key:
+                                                type: string
+                                        type: object
+                                    type: array
+                                conditions:
+                                    elem:
+                                        type: string
+                                    type: array
+                                description:
+                                    type: string
+                            type: object
+                        type: map
+                type: object
+            exceptions:
+                fields:
+                    dimensions:
+                        elem:
+                            fields:
+                                default:
+                                    type: string
+                                name:
+                                    type: string
+                            type: object
+                        type: array
+                    exemplars:
+                        fields:
+                            enabled:
+                                type: bool
+                        type: object
+                type: object
+            failover:
+                fields:
+                    max_retries:
+                        type: int
+                    priority_levels:
+                        elem:
+                            elem:
+                                type: object
+                            type: array
+                        type: array
+                    retry_gap:
+                        type: duration
+                    retry_interval:
+                        type: duration
+                    sending_queue:
+                        fields:
+                            batch:
+                                fields:
+                                    flush_timeout:
+                                        type: duration
+                                    max_size:
+                                        type: int
+                                    min_size:
+                                        type: int
+                                    partition:
+                                        fields:
+                                            metadata_keys:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                        type: object
+                                    sizer:
+                                        type: object
+                                type: object
+                            block_on_overflow:
+                                type: bool
+                            num_consumers:
+                                type: int
+                            queue_size:
+                                type: int
+                            sizer:
+                                type: object
+                            storage:
+                                type: object
+                            wait_for_result:
+                                type: bool
+                        type: object
+                type: object
+            forward:
+                type: object
+            otlp_json:
+                type: object
+            round_robin:
+                type: object
+            routing:
+                fields:
+                    default_pipelines:
+                        elem:
+                            type: object
+                        type: array
+                    error_mode:
+                        type: string
+                    table:
+                        elem:
+                            fields:
+                                action:
+                                    type: string
+                                condition:
+                                    type: string
+                                context:
+                                    type: string
+                                pipelines:
+                                    elem:
+                                        type: object
+                                    type: array
+                                statement:
+                                    type: string
+                            type: object
+                        type: array
+                type: object
+            service_graph:
+                fields:
+                    cache_loop:
+                        type: duration
+                    database_name_attributes:
+                        elem:
+                            type: string
+                        type: array
+                    dimensions:
+                        elem:
+                            type: string
+                        type: array
+                    exponential_histogram_max_size:
+                        type: int
+                    latency_histogram_buckets:
+                        elem:
+                            type: duration
+                        type: array
+                    metrics_flush_interval:
+                        type: duration
+                    metrics_timestamp_offset:
+                        type: duration
+                    store:
+                        fields:
+                            max_items:
+                                type: int
+                            ttl:
+                                type: duration
+                        type: object
+                    store_expiration_loop:
+                        type: duration
+                    virtual_node_extra_label:
+                        type: bool
+                    virtual_node_peer_attributes:
+                        elem:
+                            type: string
+                        type: array
+                type: object
+            span_metrics:
+                fields:
+                    add_resource_attributes:
+                        type: bool
+                    aggregation_cardinality_limit:
+                        type: int
+                    aggregation_temporality:
+                        type: string
+                    calls_dimensions:
+                        elem:
+                            fields:
+                                default:
+                                    type: string
+                                glob:
+                                    type: string
+                                name:
+                                    type: string
+                            type: object
+                        type: array
+                    dimensions:
+                        elem:
+                            fields:
+                                default:
+                                    type: string
+                                glob:
+                                    type: string
+                                name:
+                                    type: string
+                            type: object
+                        type: array
+                    dimensions_cache_size:
+                        type: int
+                    enable_metrics_sampling_method:
+                        type: bool
+                    events:
+                        fields:
+                            dimensions:
+                                elem:
+                                    fields:
+                                        default:
+                                            type: string
+                                        glob:
+                                            type: string
+                                        name:
+                                            type: string
+                                    type: object
+                                type: array
+                            enabled:
+                                type: bool
+                        type: object
+                    exclude_dimensions:
+                        elem:
+                            type: string
+                        type: array
+                    exemplars:
+                        fields:
+                            enabled:
+                                type: bool
+                            max_per_data_point:
+                                type: int
+                        type: object
+                    histogram:
+                        fields:
+                            dimensions:
+                                elem:
+                                    fields:
+                                        default:
+                                            type: string
+                                        glob:
+                                            type: string
+                                        name:
+                                            type: string
+                                    type: object
+                                type: array
+                            disable:
+                                type: bool
+                            explicit:
+                                fields:
+                                    buckets:
+                                        elem:
+                                            type: duration
+                                        type: array
+                                type: object
+                            exponential:
+                                fields:
+                                    max_size:
+                                        type: int
+                                type: object
+                            unit:
+                                type: int
+                        type: object
+                    include_instrumentation_scope:
+                        elem:
+                            type: string
+                        type: array
+                    metric_timestamp_cache_size:
+                        type: int
+                    metrics_expiration:
+                        type: duration
+                    metrics_flush_interval:
+                        type: duration
+                    namespace:
+                        type: string
+                    resource_metrics_cache_size:
+                        type: int
+                    resource_metrics_key_attributes:
+                        elem:
+                            type: string
+                        type: array
+                    series_expiration:
+                        type: duration
+                type: object
+        exporters:
+            debug:
+                fields:
+                    output_paths:
+                        elem:
+                            type: string
+                        type: array
+                    sampling_initial:
+                        type: int
+                    sampling_thereafter:
+                        type: int
+                    sending_queue:
+                        fields:
+                            batch:
+                                fields:
+                                    flush_timeout:
+                                        type: duration
+                                    max_size:
+                                        type: int
+                                    min_size:
+                                        type: int
+                                    partition:
+                                        fields:
+                                            metadata_keys:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                        type: object
+                                    sizer:
+                                        type: object
+                                type: object
+                            block_on_overflow:
+                                type: bool
+                            num_consumers:
+                                type: int
+                            queue_size:
+                                type: int
+                            sizer:
+                                type: object
+                            storage:
+                                type: object
+                            wait_for_result:
+                                type: bool
+                        type: object
+                    use_internal_logger:
+                        type: bool
+                    verbosity:
+                        type: int
+                type: object
+            file:
+                fields:
+                    append:
+                        type: bool
+                    compression:
+                        type: string
+                    compression_params:
+                        fields:
+                            level:
+                                type: int
+                        type: object
+                    create_directory:
+                        type: bool
+                    directory_permissions:
+                        type: string
+                    encoding:
+                        type: object
+                    flush_interval:
+                        type: duration
+                    format:
+                        type: string
+                    group_by:
+                        fields:
+                            enabled:
+                                type: bool
+                            max_open_files:
+                                type: int
+                            resource_attribute:
+                                type: string
+                        type: object
+                    path:
+                        type: string
+                    rotation:
+                        fields:
+                            localtime:
+                                type: bool
+                            max_backups:
+                                type: int
+                            max_days:
+                                type: int
+                            max_megabytes:
+                                type: int
+                        type: object
+                type: object
+            load_balancing:
+                fields:
+                    protocol:
+                        fields:
+                            otlp:
+                                fields:
+                                    auth:
+                                        fields:
+                                            authenticator:
+                                                type: object
+                                        type: object
+                                    authority:
+                                        type: string
+                                    balancer_name:
+                                        type: string
+                                    compression:
+                                        type: string
+                                    endpoint:
+                                        type: string
+                                    headers:
+                                        elem:
+                                            fields:
+                                                name:
+                                                    type: string
+                                                value:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    keepalive:
+                                        fields:
+                                            permit_without_stream:
+                                                type: bool
+                                            time:
+                                                type: duration
+                                            timeout:
+                                                type: duration
+                                        type: object
+                                    middlewares:
+                                        elem:
+                                            fields:
+                                                id:
+                                                    type: object
+                                            type: object
+                                        type: array
+                                    read_buffer_size:
+                                        type: int
+                                    retry_on_failure:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                            initial_interval:
+                                                type: duration
+                                            max_elapsed_time:
+                                                type: duration
+                                            max_interval:
+                                                type: duration
+                                            multiplier:
+                                                type: float
+                                            randomization_factor:
+                                                type: float
+                                        type: object
+                                    sending_queue:
+                                        fields:
+                                            batch:
+                                                fields:
+                                                    flush_timeout:
+                                                        type: duration
+                                                    max_size:
+                                                        type: int
+                                                    min_size:
+                                                        type: int
+                                                    partition:
+                                                        fields:
+                                                            metadata_keys:
+                                                                elem:
+                                                                    type: string
+                                                                type: array
+                                                        type: object
+                                                    sizer:
+                                                        type: object
+                                                type: object
+                                            block_on_overflow:
+                                                type: bool
+                                            num_consumers:
+                                                type: int
+                                            queue_size:
+                                                type: int
+                                            sizer:
+                                                type: object
+                                            storage:
+                                                type: object
+                                            wait_for_result:
+                                                type: bool
+                                        type: object
+                                    timeout:
+                                        type: duration
+                                    tls:
+                                        fields:
+                                            ca_file:
+                                                type: string
+                                            ca_pem:
+                                                type: string
+                                            cert_file:
+                                                type: string
+                                            cert_pem:
+                                                type: string
+                                            cipher_suites:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            curve_preferences:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            include_insecure_cipher_suites:
+                                                type: bool
+                                            include_system_ca_certs_pool:
+                                                type: bool
+                                            insecure:
+                                                type: bool
+                                            insecure_skip_verify:
+                                                type: bool
+                                            key_file:
+                                                type: string
+                                            key_pem:
+                                                type: string
+                                            max_version:
+                                                type: string
+                                            min_version:
+                                                type: string
+                                            reload_interval:
+                                                type: duration
+                                            server_name_override:
+                                                type: string
+                                            tpm:
+                                                fields:
+                                                    auth:
+                                                        type: string
+                                                    enabled:
+                                                        type: bool
+                                                    owner_auth:
+                                                        type: string
+                                                    path:
+                                                        type: string
+                                                type: object
+                                        type: object
+                                    user_agent:
+                                        type: string
+                                    wait_for_ready:
+                                        type: bool
+                                    write_buffer_size:
+                                        type: int
+                                type: object
+                        type: object
+                    resolver:
+                        fields:
+                            aws_cloud_map:
+                                fields:
+                                    health_status:
+                                        type: string
+                                    interval:
+                                        type: duration
+                                    namespace:
+                                        type: string
+                                    owner_account:
+                                        type: string
+                                    port:
+                                        type: int
+                                    service_name:
+                                        type: string
+                                    timeout:
+                                        type: duration
+                                type: object
+                            dns:
+                                fields:
+                                    hostname:
+                                        type: string
+                                    interval:
+                                        type: duration
+                                    port:
+                                        type: string
+                                    timeout:
+                                        type: duration
+                                type: object
+                            k8s:
+                                fields:
+                                    ports:
+                                        elem:
+                                            type: int
+                                        type: array
+                                    return_hostnames:
+                                        type: bool
+                                    service:
+                                        type: string
+                                    timeout:
+                                        type: duration
+                                type: object
+                            static:
+                                fields:
+                                    hostnames:
+                                        elem:
+                                            type: string
+                                        type: array
+                                type: object
+                        type: object
+                    retry_on_failure:
+                        fields:
+                            enabled:
+                                type: bool
+                            initial_interval:
+                                type: duration
+                            max_elapsed_time:
+                                type: duration
+                            max_interval:
+                                type: duration
+                            multiplier:
+                                type: float
+                            randomization_factor:
+                                type: float
+                        type: object
+                    routing_attributes:
+                        elem:
+                            type: string
+                        type: array
+                    routing_key:
+                        type: string
+                    sending_queue:
+                        fields:
+                            batch:
+                                fields:
+                                    flush_timeout:
+                                        type: duration
+                                    max_size:
+                                        type: int
+                                    min_size:
+                                        type: int
+                                    partition:
+                                        fields:
+                                            metadata_keys:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                        type: object
+                                    sizer:
+                                        type: object
+                                type: object
+                            block_on_overflow:
+                                type: bool
+                            num_consumers:
+                                type: int
+                            queue_size:
+                                type: int
+                            sizer:
+                                type: object
+                            storage:
+                                type: object
+                            wait_for_result:
+                                type: bool
+                        type: object
+                    timeout:
+                        type: duration
+                type: object
+            nop:
+                type: object
+            otelarrow:
+                fields:
+                    arrow:
+                        fields:
+                            disable_downgrade:
+                                type: bool
+                            disabled:
+                                type: bool
+                            max_stream_lifetime:
+                                type: duration
+                            num_streams:
+                                type: int
+                            payload_compression:
+                                type: string
+                            prioritizer:
+                                type: string
+                            zstd:
+                                fields:
+                                    concurrency:
+                                        type: int
+                                    level:
+                                        type: int
+                                    window_size_mib:
+                                        type: int
+                                type: object
+                        type: object
+                    auth:
+                        fields:
+                            authenticator:
+                                type: object
+                        type: object
+                    authority:
+                        type: string
+                    balancer_name:
+                        type: string
+                    compression:
+                        type: string
+                    endpoint:
+                        type: string
+                    headers:
+                        elem:
+                            fields:
+                                name:
+                                    type: string
+                                value:
+                                    type: string
+                            type: object
+                        type: array
+                    keepalive:
+                        fields:
+                            permit_without_stream:
+                                type: bool
+                            time:
+                                type: duration
+                            timeout:
+                                type: duration
+                        type: object
+                    metadata_cardinality_limit:
+                        type: int
+                    metadata_keys:
+                        elem:
+                            type: string
+                        type: array
+                    middlewares:
+                        elem:
+                            fields:
+                                id:
+                                    type: object
+                            type: object
+                        type: array
+                    read_buffer_size:
+                        type: int
+                    retry_on_failure:
+                        fields:
+                            enabled:
+                                type: bool
+                            initial_interval:
+                                type: duration
+                            max_elapsed_time:
+                                type: duration
+                            max_interval:
+                                type: duration
+                            multiplier:
+                                type: float
+                            randomization_factor:
+                                type: float
+                        type: object
+                    sending_queue:
+                        fields:
+                            batch:
+                                fields:
+                                    flush_timeout:
+                                        type: duration
+                                    max_size:
+                                        type: int
+                                    min_size:
+                                        type: int
+                                    partition:
+                                        fields:
+                                            metadata_keys:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                        type: object
+                                    sizer:
+                                        type: object
+                                type: object
+                            block_on_overflow:
+                                type: bool
+                            num_consumers:
+                                type: int
+                            queue_size:
+                                type: int
+                            sizer:
+                                type: object
+                            storage:
+                                type: object
+                            wait_for_result:
+                                type: bool
+                        type: object
+                    timeout:
+                        type: duration
+                    tls:
+                        fields:
+                            ca_file:
+                                type: string
+                            ca_pem:
+                                type: string
+                            cert_file:
+                                type: string
+                            cert_pem:
+                                type: string
+                            cipher_suites:
+                                elem:
+                                    type: string
+                                type: array
+                            curve_preferences:
+                                elem:
+                                    type: string
+                                type: array
+                            include_insecure_cipher_suites:
+                                type: bool
+                            include_system_ca_certs_pool:
+                                type: bool
+                            insecure:
+                                type: bool
+                            insecure_skip_verify:
+                                type: bool
+                            key_file:
+                                type: string
+                            key_pem:
+                                type: string
+                            max_version:
+                                type: string
+                            min_version:
+                                type: string
+                            reload_interval:
+                                type: duration
+                            server_name_override:
+                                type: string
+                            tpm:
+                                fields:
+                                    auth:
+                                        type: string
+                                    enabled:
+                                        type: bool
+                                    owner_auth:
+                                        type: string
+                                    path:
+                                        type: string
+                                type: object
+                        type: object
+                    user_agent:
+                        type: string
+                    wait_for_ready:
+                        type: bool
+                    write_buffer_size:
+                        type: int
+                type: object
+            otlp_grpc:
+                fields:
+                    auth:
+                        fields:
+                            authenticator:
+                                type: object
+                        type: object
+                    authority:
+                        type: string
+                    balancer_name:
+                        type: string
+                    compression:
+                        type: string
+                    endpoint:
+                        type: string
+                    headers:
+                        elem:
+                            fields:
+                                name:
+                                    type: string
+                                value:
+                                    type: string
+                            type: object
+                        type: array
+                    keepalive:
+                        fields:
+                            permit_without_stream:
+                                type: bool
+                            time:
+                                type: duration
+                            timeout:
+                                type: duration
+                        type: object
+                    middlewares:
+                        elem:
+                            fields:
+                                id:
+                                    type: object
+                            type: object
+                        type: array
+                    read_buffer_size:
+                        type: int
+                    retry_on_failure:
+                        fields:
+                            enabled:
+                                type: bool
+                            initial_interval:
+                                type: duration
+                            max_elapsed_time:
+                                type: duration
+                            max_interval:
+                                type: duration
+                            multiplier:
+                                type: float
+                            randomization_factor:
+                                type: float
+                        type: object
+                    sending_queue:
+                        fields:
+                            batch:
+                                fields:
+                                    flush_timeout:
+                                        type: duration
+                                    max_size:
+                                        type: int
+                                    min_size:
+                                        type: int
+                                    partition:
+                                        fields:
+                                            metadata_keys:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                        type: object
+                                    sizer:
+                                        type: object
+                                type: object
+                            block_on_overflow:
+                                type: bool
+                            num_consumers:
+                                type: int
+                            queue_size:
+                                type: int
+                            sizer:
+                                type: object
+                            storage:
+                                type: object
+                            wait_for_result:
+                                type: bool
+                        type: object
+                    timeout:
+                        type: duration
+                    tls:
+                        fields:
+                            ca_file:
+                                type: string
+                            ca_pem:
+                                type: string
+                            cert_file:
+                                type: string
+                            cert_pem:
+                                type: string
+                            cipher_suites:
+                                elem:
+                                    type: string
+                                type: array
+                            curve_preferences:
+                                elem:
+                                    type: string
+                                type: array
+                            include_insecure_cipher_suites:
+                                type: bool
+                            include_system_ca_certs_pool:
+                                type: bool
+                            insecure:
+                                type: bool
+                            insecure_skip_verify:
+                                type: bool
+                            key_file:
+                                type: string
+                            key_pem:
+                                type: string
+                            max_version:
+                                type: string
+                            min_version:
+                                type: string
+                            reload_interval:
+                                type: duration
+                            server_name_override:
+                                type: string
+                            tpm:
+                                fields:
+                                    auth:
+                                        type: string
+                                    enabled:
+                                        type: bool
+                                    owner_auth:
+                                        type: string
+                                    path:
+                                        type: string
+                                type: object
+                        type: object
+                    user_agent:
+                        type: string
+                    wait_for_ready:
+                        type: bool
+                    write_buffer_size:
+                        type: int
+                type: object
+            otlp_http:
+                fields:
+                    auth:
+                        fields:
+                            authenticator:
+                                type: object
+                        type: object
+                    compression:
+                        type: string
+                    compression_params:
+                        fields:
+                            level:
+                                type: int
+                        type: object
+                    cookies:
+                        type: object
+                    disable_keep_alives:
+                        type: bool
+                    encoding:
+                        type: string
+                    endpoint:
+                        type: string
+                    force_attempt_http2:
+                        type: bool
+                    headers:
+                        elem:
+                            fields:
+                                name:
+                                    type: string
+                                value:
+                                    type: string
+                            type: object
+                        type: array
+                    http2_ping_timeout:
+                        type: duration
+                    http2_read_idle_timeout:
+                        type: duration
+                    idle_conn_timeout:
+                        type: duration
+                    logs_endpoint:
+                        type: string
+                    max_conns_per_host:
+                        type: int
+                    max_idle_conns:
+                        type: int
+                    max_idle_conns_per_host:
+                        type: int
+                    metrics_endpoint:
+                        type: string
+                    middlewares:
+                        elem:
+                            fields:
+                                id:
+                                    type: object
+                            type: object
+                        type: array
+                    profiles_endpoint:
+                        type: string
+                    proxy_url:
+                        type: string
+                    read_buffer_size:
+                        type: int
+                    retry_on_failure:
+                        fields:
+                            enabled:
+                                type: bool
+                            initial_interval:
+                                type: duration
+                            max_elapsed_time:
+                                type: duration
+                            max_interval:
+                                type: duration
+                            multiplier:
+                                type: float
+                            randomization_factor:
+                                type: float
+                        type: object
+                    sending_queue:
+                        fields:
+                            batch:
+                                fields:
+                                    flush_timeout:
+                                        type: duration
+                                    max_size:
+                                        type: int
+                                    min_size:
+                                        type: int
+                                    partition:
+                                        fields:
+                                            metadata_keys:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                        type: object
+                                    sizer:
+                                        type: object
+                                type: object
+                            block_on_overflow:
+                                type: bool
+                            num_consumers:
+                                type: int
+                            queue_size:
+                                type: int
+                            sizer:
+                                type: object
+                            storage:
+                                type: object
+                            wait_for_result:
+                                type: bool
+                        type: object
+                    timeout:
+                        type: duration
+                    tls:
+                        fields:
+                            ca_file:
+                                type: string
+                            ca_pem:
+                                type: string
+                            cert_file:
+                                type: string
+                            cert_pem:
+                                type: string
+                            cipher_suites:
+                                elem:
+                                    type: string
+                                type: array
+                            curve_preferences:
+                                elem:
+                                    type: string
+                                type: array
+                            include_insecure_cipher_suites:
+                                type: bool
+                            include_system_ca_certs_pool:
+                                type: bool
+                            insecure:
+                                type: bool
+                            insecure_skip_verify:
+                                type: bool
+                            key_file:
+                                type: string
+                            key_pem:
+                                type: string
+                            max_version:
+                                type: string
+                            min_version:
+                                type: string
+                            reload_interval:
+                                type: duration
+                            server_name_override:
+                                type: string
+                            tpm:
+                                fields:
+                                    auth:
+                                        type: string
+                                    enabled:
+                                        type: bool
+                                    owner_auth:
+                                        type: string
+                                    path:
+                                        type: string
+                                type: object
+                        type: object
+                    traces_endpoint:
+                        type: string
+                    write_buffer_size:
+                        type: int
+                type: object
+        extensions:
+            ack:
+                fields:
+                    max_number_of_partition:
+                        type: int
+                    max_number_of_pending_acks_per_partition:
+                        type: int
+                    storage:
+                        type: object
+                type: object
+            basicauth:
+                fields:
+                    client_auth:
+                        fields:
+                            password:
+                                type: string
+                            password_file:
+                                type: string
+                            username:
+                                type: string
+                            username_file:
+                                type: string
+                        type: object
+                    htpasswd:
+                        fields:
+                            file:
+                                type: string
+                            inline:
+                                type: string
+                        type: object
+                type: object
+            bearertokenauth:
+                fields:
+                    filename:
+                        type: string
+                    header:
+                        type: string
+                    scheme:
+                        type: string
+                    token:
+                        type: string
+                    tokens:
+                        elem:
+                            type: string
+                        type: array
+                type: object
+            cgroup_runtime:
+                fields:
+                    gomaxprocs:
+                        fields:
+                            enabled:
+                                type: bool
+                        type: object
+                    gomemlimit:
+                        fields:
+                            enabled:
+                                type: bool
+                            ratio:
+                                type: float
+                            refresh_interval:
+                                type: duration
+                        type: object
+                type: object
+            file_storage:
+                fields:
+                    compaction:
+                        fields:
+                            check_interval:
+                                type: duration
+                            cleanup_on_start:
+                                type: bool
+                            directory:
+                                type: string
+                            max_transaction_size:
+                                type: int
+                            on_rebound:
+                                type: bool
+                            on_start:
+                                type: bool
+                            rebound_needed_threshold_mib:
+                                type: int
+                            rebound_trigger_threshold_mib:
+                                type: int
+                        type: object
+                    create_directory:
+                        type: bool
+                    directory:
+                        type: string
+                    directory_permissions:
+                        type: string
+                    fsync:
+                        type: bool
+                    max_size:
+                        type: int
+                    recreate:
+                        type: bool
+                    timeout:
+                        type: duration
+                type: object
+            headers_setter:
+                fields:
+                    additional_auth:
+                        type: object
+                    headers:
+                        elem:
+                            fields:
+                                action:
+                                    type: string
+                                default_value:
+                                    type: string
+                                from_attribute:
+                                    type: string
+                                from_context:
+                                    type: string
+                                key:
+                                    type: string
+                                value:
+                                    type: string
+                                value_file:
+                                    type: string
+                            type: object
+                        type: array
+                type: object
+            health_check:
+                fields:
+                    auth:
+                        fields:
+                            authenticator:
+                                type: object
+                            request_params:
+                                elem:
+                                    type: string
+                                type: array
+                        type: object
+                    check_collector_pipeline:
+                        fields:
+                            enabled:
+                                type: bool
+                            exporter_failure_threshold:
+                                type: int
+                            interval:
+                                type: string
+                        type: object
+                    component_health:
+                        fields:
+                            include_permanent_errors:
+                                type: bool
+                            include_recoverable_errors:
+                                type: bool
+                            recovery_duration:
+                                type: duration
+                        type: object
+                    compression_algorithms:
+                        elem:
+                            type: string
+                        type: array
+                    cors:
+                        fields:
+                            allowed_headers:
+                                elem:
+                                    type: string
+                                type: array
+                            allowed_origins:
+                                elem:
+                                    type: string
+                                type: array
+                            exposed_headers:
+                                elem:
+                                    type: string
+                                type: array
+                            max_age:
+                                type: int
+                        type: object
+                    dialer:
+                        fields:
+                            timeout:
+                                type: duration
+                        type: object
+                    endpoint:
+                        type: string
+                    grpc:
+                        fields:
+                            auth:
+                                fields:
+                                    authenticator:
+                                        type: object
+                                type: object
+                            dialer:
+                                fields:
+                                    timeout:
+                                        type: duration
+                                type: object
+                            endpoint:
+                                type: string
+                            include_metadata:
+                                type: bool
+                            keepalive:
+                                fields:
+                                    enforcement_policy:
+                                        fields:
+                                            min_time:
+                                                type: duration
+                                            permit_without_stream:
+                                                type: bool
+                                        type: object
+                                    server_parameters:
+                                        fields:
+                                            max_connection_age:
+                                                type: duration
+                                            max_connection_age_grace:
+                                                type: duration
+                                            max_connection_idle:
+                                                type: duration
+                                            time:
+                                                type: duration
+                                            timeout:
+                                                type: duration
+                                        type: object
+                                type: object
+                            max_concurrent_streams:
+                                type: int
+                            max_recv_msg_size_mib:
+                                type: int
+                            middlewares:
+                                elem:
+                                    fields:
+                                        id:
+                                            type: object
+                                    type: object
+                                type: array
+                            read_buffer_size:
+                                type: int
+                            tls:
+                                fields:
+                                    ca_file:
+                                        type: string
+                                    ca_pem:
+                                        type: string
+                                    cert_file:
+                                        type: string
+                                    cert_pem:
+                                        type: string
+                                    cipher_suites:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    client_ca_file:
+                                        type: string
+                                    client_ca_file_reload:
+                                        type: bool
+                                    curve_preferences:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    include_insecure_cipher_suites:
+                                        type: bool
+                                    include_system_ca_certs_pool:
+                                        type: bool
+                                    key_file:
+                                        type: string
+                                    key_pem:
+                                        type: string
+                                    max_version:
+                                        type: string
+                                    min_version:
+                                        type: string
+                                    reload_interval:
+                                        type: duration
+                                    tpm:
+                                        fields:
+                                            auth:
+                                                type: string
+                                            enabled:
+                                                type: bool
+                                            owner_auth:
+                                                type: string
+                                            path:
+                                                type: string
+                                        type: object
+                                type: object
+                            transport:
+                                type: string
+                            write_buffer_size:
+                                type: int
+                        type: object
+                    http:
+                        fields:
+                            auth:
+                                fields:
+                                    authenticator:
+                                        type: object
+                                    request_params:
+                                        elem:
+                                            type: string
+                                        type: array
+                                type: object
+                            compression_algorithms:
+                                elem:
+                                    type: string
+                                type: array
+                            config:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    include_attributes:
+                                        type: bool
+                                    path:
+                                        type: string
+                                type: object
+                            cors:
+                                fields:
+                                    allowed_headers:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    allowed_origins:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    exposed_headers:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    max_age:
+                                        type: int
+                                type: object
+                            dialer:
+                                fields:
+                                    timeout:
+                                        type: duration
+                                type: object
+                            endpoint:
+                                type: string
+                            idle_timeout:
+                                type: duration
+                            include_metadata:
+                                type: bool
+                            keep_alives_enabled:
+                                type: bool
+                            max_request_body_size:
+                                type: int
+                            middlewares:
+                                elem:
+                                    fields:
+                                        id:
+                                            type: object
+                                    type: object
+                                type: array
+                            read_header_timeout:
+                                type: duration
+                            read_timeout:
+                                type: duration
+                            response_headers:
+                                elem:
+                                    fields:
+                                        name:
+                                            type: string
+                                        value:
+                                            type: string
+                                    type: object
+                                type: array
+                            status:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    include_attributes:
+                                        type: bool
+                                    path:
+                                        type: string
+                                type: object
+                            tls:
+                                fields:
+                                    ca_file:
+                                        type: string
+                                    ca_pem:
+                                        type: string
+                                    cert_file:
+                                        type: string
+                                    cert_pem:
+                                        type: string
+                                    cipher_suites:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    client_ca_file:
+                                        type: string
+                                    client_ca_file_reload:
+                                        type: bool
+                                    curve_preferences:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    include_insecure_cipher_suites:
+                                        type: bool
+                                    include_system_ca_certs_pool:
+                                        type: bool
+                                    key_file:
+                                        type: string
+                                    key_pem:
+                                        type: string
+                                    max_version:
+                                        type: string
+                                    min_version:
+                                        type: string
+                                    reload_interval:
+                                        type: duration
+                                    tpm:
+                                        fields:
+                                            auth:
+                                                type: string
+                                            enabled:
+                                                type: bool
+                                            owner_auth:
+                                                type: string
+                                            path:
+                                                type: string
+                                        type: object
+                                type: object
+                            transport:
+                                type: string
+                            write_timeout:
+                                type: duration
+                        type: object
+                    idle_timeout:
+                        type: duration
+                    include_metadata:
+                        type: bool
+                    keep_alives_enabled:
+                        type: bool
+                    max_request_body_size:
+                        type: int
+                    middlewares:
+                        elem:
+                            fields:
+                                id:
+                                    type: object
+                            type: object
+                        type: array
+                    path:
+                        type: string
+                    read_header_timeout:
+                        type: duration
+                    read_timeout:
+                        type: duration
+                    response_body:
+                        fields:
+                            healthy:
+                                type: string
+                            unhealthy:
+                                type: string
+                        type: object
+                    response_headers:
+                        elem:
+                            fields:
+                                name:
+                                    type: string
+                                value:
+                                    type: string
+                            type: object
+                        type: array
+                    tls:
+                        fields:
+                            ca_file:
+                                type: string
+                            ca_pem:
+                                type: string
+                            cert_file:
+                                type: string
+                            cert_pem:
+                                type: string
+                            cipher_suites:
+                                elem:
+                                    type: string
+                                type: array
+                            client_ca_file:
+                                type: string
+                            client_ca_file_reload:
+                                type: bool
+                            curve_preferences:
+                                elem:
+                                    type: string
+                                type: array
+                            include_insecure_cipher_suites:
+                                type: bool
+                            include_system_ca_certs_pool:
+                                type: bool
+                            key_file:
+                                type: string
+                            key_pem:
+                                type: string
+                            max_version:
+                                type: string
+                            min_version:
+                                type: string
+                            reload_interval:
+                                type: duration
+                            tpm:
+                                fields:
+                                    auth:
+                                        type: string
+                                    enabled:
+                                        type: bool
+                                    owner_auth:
+                                        type: string
+                                    path:
+                                        type: string
+                                type: object
+                        type: object
+                    transport:
+                        type: string
+                    use_v2:
+                        type: bool
+                    write_timeout:
+                        type: duration
+                type: object
+            host_observer:
+                fields:
+                    refresh_interval:
+                        type: duration
+                type: object
+            http_forwarder:
+                fields:
+                    egress:
+                        fields:
+                            auth:
+                                fields:
+                                    authenticator:
+                                        type: object
+                                type: object
+                            compression:
+                                type: string
+                            compression_params:
+                                fields:
+                                    level:
+                                        type: int
+                                type: object
+                            cookies:
+                                type: object
+                            disable_keep_alives:
+                                type: bool
+                            endpoint:
+                                type: string
+                            force_attempt_http2:
+                                type: bool
+                            headers:
+                                elem:
+                                    fields:
+                                        name:
+                                            type: string
+                                        value:
+                                            type: string
+                                    type: object
+                                type: array
+                            http2_ping_timeout:
+                                type: duration
+                            http2_read_idle_timeout:
+                                type: duration
+                            idle_conn_timeout:
+                                type: duration
+                            max_conns_per_host:
+                                type: int
+                            max_idle_conns:
+                                type: int
+                            max_idle_conns_per_host:
+                                type: int
+                            middlewares:
+                                elem:
+                                    fields:
+                                        id:
+                                            type: object
+                                    type: object
+                                type: array
+                            proxy_url:
+                                type: string
+                            read_buffer_size:
+                                type: int
+                            timeout:
+                                type: duration
+                            tls:
+                                fields:
+                                    ca_file:
+                                        type: string
+                                    ca_pem:
+                                        type: string
+                                    cert_file:
+                                        type: string
+                                    cert_pem:
+                                        type: string
+                                    cipher_suites:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    curve_preferences:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    include_insecure_cipher_suites:
+                                        type: bool
+                                    include_system_ca_certs_pool:
+                                        type: bool
+                                    insecure:
+                                        type: bool
+                                    insecure_skip_verify:
+                                        type: bool
+                                    key_file:
+                                        type: string
+                                    key_pem:
+                                        type: string
+                                    max_version:
+                                        type: string
+                                    min_version:
+                                        type: string
+                                    reload_interval:
+                                        type: duration
+                                    server_name_override:
+                                        type: string
+                                    tpm:
+                                        fields:
+                                            auth:
+                                                type: string
+                                            enabled:
+                                                type: bool
+                                            owner_auth:
+                                                type: string
+                                            path:
+                                                type: string
+                                        type: object
+                                type: object
+                            write_buffer_size:
+                                type: int
+                        type: object
+                    ingress:
+                        fields:
+                            auth:
+                                fields:
+                                    authenticator:
+                                        type: object
+                                    request_params:
+                                        elem:
+                                            type: string
+                                        type: array
+                                type: object
+                            compression_algorithms:
+                                elem:
+                                    type: string
+                                type: array
+                            cors:
+                                fields:
+                                    allowed_headers:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    allowed_origins:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    exposed_headers:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    max_age:
+                                        type: int
+                                type: object
+                            dialer:
+                                fields:
+                                    timeout:
+                                        type: duration
+                                type: object
+                            endpoint:
+                                type: string
+                            idle_timeout:
+                                type: duration
+                            include_metadata:
+                                type: bool
+                            keep_alives_enabled:
+                                type: bool
+                            max_request_body_size:
+                                type: int
+                            middlewares:
+                                elem:
+                                    fields:
+                                        id:
+                                            type: object
+                                    type: object
+                                type: array
+                            read_header_timeout:
+                                type: duration
+                            read_timeout:
+                                type: duration
+                            response_headers:
+                                elem:
+                                    fields:
+                                        name:
+                                            type: string
+                                        value:
+                                            type: string
+                                    type: object
+                                type: array
+                            tls:
+                                fields:
+                                    ca_file:
+                                        type: string
+                                    ca_pem:
+                                        type: string
+                                    cert_file:
+                                        type: string
+                                    cert_pem:
+                                        type: string
+                                    cipher_suites:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    client_ca_file:
+                                        type: string
+                                    client_ca_file_reload:
+                                        type: bool
+                                    curve_preferences:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    include_insecure_cipher_suites:
+                                        type: bool
+                                    include_system_ca_certs_pool:
+                                        type: bool
+                                    key_file:
+                                        type: string
+                                    key_pem:
+                                        type: string
+                                    max_version:
+                                        type: string
+                                    min_version:
+                                        type: string
+                                    reload_interval:
+                                        type: duration
+                                    tpm:
+                                        fields:
+                                            auth:
+                                                type: string
+                                            enabled:
+                                                type: bool
+                                            owner_auth:
+                                                type: string
+                                            path:
+                                                type: string
+                                        type: object
+                                type: object
+                            transport:
+                                type: string
+                            write_timeout:
+                                type: duration
+                        type: object
+                type: object
+            k8s_leader_elector:
+                fields:
+                    auth_type:
+                        type: string
+                    context:
+                        type: string
+                    kube_api_burst:
+                        type: int
+                    kube_api_qps:
+                        type: float
+                    lease_duration:
+                        type: duration
+                    lease_name:
+                        type: string
+                    lease_namespace:
+                        type: string
+                    renew_deadline:
+                        type: duration
+                    retry_period:
+                        type: duration
+                type: object
+            k8s_observer:
+                fields:
+                    auth_type:
+                        type: string
+                    context:
+                        type: string
+                    kube_api_burst:
+                        type: int
+                    kube_api_qps:
+                        type: float
+                    namespaces:
+                        elem:
+                            type: string
+                        type: array
+                    node:
+                        type: string
+                    observe_ingresses:
+                        type: bool
+                    observe_nodes:
+                        type: bool
+                    observe_pods:
+                        type: bool
+                    observe_services:
+                        type: bool
+                type: object
+            oauth2client:
+                fields:
+                    audience:
+                        type: string
+                    claims:
+                        elem:
+                            type: any
+                        type: map
+                    client_certificate_key:
+                        type: string
+                    client_certificate_key_file:
+                        type: string
+                    client_certificate_key_id:
+                        type: string
+                    client_id:
+                        type: string
+                    client_id_file:
+                        type: string
+                    client_secret:
+                        type: string
+                    client_secret_file:
+                        type: string
+                    endpoint_params:
+                        elem:
+                            elem:
+                                type: string
+                            type: array
+                        type: map
+                    expiry_buffer:
+                        type: duration
+                    grant_type:
+                        type: string
+                    iss:
+                        type: string
+                    scopes:
+                        elem:
+                            type: string
+                        type: array
+                    signature_algorithm:
+                        type: string
+                    timeout:
+                        type: duration
+                    tls:
+                        fields:
+                            ca_file:
+                                type: string
+                            ca_pem:
+                                type: string
+                            cert_file:
+                                type: string
+                            cert_pem:
+                                type: string
+                            cipher_suites:
+                                elem:
+                                    type: string
+                                type: array
+                            curve_preferences:
+                                elem:
+                                    type: string
+                                type: array
+                            include_insecure_cipher_suites:
+                                type: bool
+                            include_system_ca_certs_pool:
+                                type: bool
+                            insecure:
+                                type: bool
+                            insecure_skip_verify:
+                                type: bool
+                            key_file:
+                                type: string
+                            key_pem:
+                                type: string
+                            max_version:
+                                type: string
+                            min_version:
+                                type: string
+                            reload_interval:
+                                type: duration
+                            server_name_override:
+                                type: string
+                            tpm:
+                                fields:
+                                    auth:
+                                        type: string
+                                    enabled:
+                                        type: bool
+                                    owner_auth:
+                                        type: string
+                                    path:
+                                        type: string
+                                type: object
+                        type: object
+                    token_url:
+                        type: string
+                type: object
+            oidc:
+                fields:
+                    attribute:
+                        type: string
+                    audience:
+                        type: string
+                    groups_claim:
+                        type: string
+                    ignore_audience:
+                        type: bool
+                    issuer_ca_path:
+                        type: string
+                    issuer_url:
+                        type: string
+                    providers:
+                        elem:
+                            fields:
+                                audience:
+                                    type: string
+                                groups_claim:
+                                    type: string
+                                ignore_audience:
+                                    type: bool
+                                issuer_ca_path:
+                                    type: string
+                                issuer_url:
+                                    type: string
+                                public_keys_file:
+                                    type: string
+                                username_claim:
+                                    type: string
+                            type: object
+                        type: array
+                    username_claim:
+                        type: string
+                type: object
+            opamp:
+                fields:
+                    agent_description:
+                        fields:
+                            include_resource_attributes:
+                                type: bool
+                            non_identifying_attributes:
+                                elem:
+                                    type: string
+                                type: map
+                        type: object
+                    capabilities:
+                        fields:
+                            accepts_restart_command:
+                                type: bool
+                            reports_available_components:
+                                type: bool
+                            reports_effective_config:
+                                type: bool
+                            reports_health:
+                                type: bool
+                        type: object
+                    instance_uid:
+                        type: string
+                    ppid:
+                        type: int
+                    ppid_poll_interval:
+                        type: duration
+                    server:
+                        fields:
+                            http:
+                                fields:
+                                    polling_interval:
+                                        type: duration
+                                type: object
+                            ws:
+                                fields:
+                                    auth:
+                                        type: object
+                                    endpoint:
+                                        type: string
+                                    headers:
+                                        elem:
+                                            type: string
+                                        type: map
+                                    tls:
+                                        fields:
+                                            ca_file:
+                                                type: string
+                                            ca_pem:
+                                                type: string
+                                            cert_file:
+                                                type: string
+                                            cert_pem:
+                                                type: string
+                                            cipher_suites:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            curve_preferences:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            include_insecure_cipher_suites:
+                                                type: bool
+                                            include_system_ca_certs_pool:
+                                                type: bool
+                                            insecure:
+                                                type: bool
+                                            insecure_skip_verify:
+                                                type: bool
+                                            key_file:
+                                                type: string
+                                            key_pem:
+                                                type: string
+                                            max_version:
+                                                type: string
+                                            min_version:
+                                                type: string
+                                            reload_interval:
+                                                type: duration
+                                            server_name_override:
+                                                type: string
+                                            tpm:
+                                                fields:
+                                                    auth:
+                                                        type: string
+                                                    enabled:
+                                                        type: bool
+                                                    owner_auth:
+                                                        type: string
+                                                    path:
+                                                        type: string
+                                                type: object
+                                        type: object
+                                type: object
+                        type: object
+                type: object
+            pprof:
+                fields:
+                    block_profile_fraction:
+                        type: int
+                    dialer:
+                        fields:
+                            timeout:
+                                type: duration
+                        type: object
+                    endpoint:
+                        type: string
+                    mutex_profile_fraction:
+                        type: int
+                    save_to_file:
+                        type: string
+                type: object
+            zpages:
+                fields:
+                    auth:
+                        fields:
+                            authenticator:
+                                type: object
+                            request_params:
+                                elem:
+                                    type: string
+                                type: array
+                        type: object
+                    compression_algorithms:
+                        elem:
+                            type: string
+                        type: array
+                    cors:
+                        fields:
+                            allowed_headers:
+                                elem:
+                                    type: string
+                                type: array
+                            allowed_origins:
+                                elem:
+                                    type: string
+                                type: array
+                            exposed_headers:
+                                elem:
+                                    type: string
+                                type: array
+                            max_age:
+                                type: int
+                        type: object
+                    dialer:
+                        fields:
+                            timeout:
+                                type: duration
+                        type: object
+                    endpoint:
+                        type: string
+                    expvar:
+                        fields:
+                            enabled:
+                                type: bool
+                        type: object
+                    idle_timeout:
+                        type: duration
+                    include_metadata:
+                        type: bool
+                    keep_alives_enabled:
+                        type: bool
+                    max_request_body_size:
+                        type: int
+                    middlewares:
+                        elem:
+                            fields:
+                                id:
+                                    type: object
+                            type: object
+                        type: array
+                    read_header_timeout:
+                        type: duration
+                    read_timeout:
+                        type: duration
+                    response_headers:
+                        elem:
+                            fields:
+                                name:
+                                    type: string
+                                value:
+                                    type: string
+                            type: object
+                        type: array
+                    tls:
+                        fields:
+                            ca_file:
+                                type: string
+                            ca_pem:
+                                type: string
+                            cert_file:
+                                type: string
+                            cert_pem:
+                                type: string
+                            cipher_suites:
+                                elem:
+                                    type: string
+                                type: array
+                            client_ca_file:
+                                type: string
+                            client_ca_file_reload:
+                                type: bool
+                            curve_preferences:
+                                elem:
+                                    type: string
+                                type: array
+                            include_insecure_cipher_suites:
+                                type: bool
+                            include_system_ca_certs_pool:
+                                type: bool
+                            key_file:
+                                type: string
+                            key_pem:
+                                type: string
+                            max_version:
+                                type: string
+                            min_version:
+                                type: string
+                            reload_interval:
+                                type: duration
+                            tpm:
+                                fields:
+                                    auth:
+                                        type: string
+                                    enabled:
+                                        type: bool
+                                    owner_auth:
+                                        type: string
+                                    path:
+                                        type: string
+                                type: object
+                        type: object
+                    transport:
+                        type: string
+                    write_timeout:
+                        type: duration
+                type: object
+        processors:
+            attributes:
+                fields:
+                    actions:
+                        elem:
+                            fields:
+                                action:
+                                    type: string
+                                converted_type:
+                                    type: string
+                                default_value:
+                                    type: any
+                                from_attribute:
+                                    type: string
+                                from_context:
+                                    type: string
+                                key:
+                                    type: string
+                                pattern:
+                                    type: string
+                                value:
+                                    type: any
+                            type: object
+                        type: array
+                    exclude:
+                        fields:
+                            attributes:
+                                elem:
+                                    fields:
+                                        key:
+                                            type: string
+                                        value:
+                                            type: any
+                                    type: object
+                                type: array
+                            libraries:
+                                elem:
+                                    fields:
+                                        name:
+                                            type: string
+                                        version:
+                                            type: string
+                                    type: object
+                                type: array
+                            log_bodies:
+                                elem:
+                                    type: string
+                                type: array
+                            log_severity_number:
+                                fields:
+                                    match_undefined:
+                                        type: bool
+                                    min:
+                                        type: int
+                                type: object
+                            log_severity_texts:
+                                elem:
+                                    type: string
+                                type: array
+                            match_type:
+                                type: string
+                            metric_names:
+                                elem:
+                                    type: string
+                                type: array
+                            regexp:
+                                fields:
+                                    cacheenabled:
+                                        type: bool
+                                    cachemaxnumentries:
+                                        type: int
+                                type: object
+                            resources:
+                                elem:
+                                    fields:
+                                        key:
+                                            type: string
+                                        value:
+                                            type: any
+                                    type: object
+                                type: array
+                            services:
+                                elem:
+                                    type: string
+                                type: array
+                            span_kinds:
+                                elem:
+                                    type: string
+                                type: array
+                            span_names:
+                                elem:
+                                    type: string
+                                type: array
+                        type: object
+                    include:
+                        fields:
+                            attributes:
+                                elem:
+                                    fields:
+                                        key:
+                                            type: string
+                                        value:
+                                            type: any
+                                    type: object
+                                type: array
+                            libraries:
+                                elem:
+                                    fields:
+                                        name:
+                                            type: string
+                                        version:
+                                            type: string
+                                    type: object
+                                type: array
+                            log_bodies:
+                                elem:
+                                    type: string
+                                type: array
+                            log_severity_number:
+                                fields:
+                                    match_undefined:
+                                        type: bool
+                                    min:
+                                        type: int
+                                type: object
+                            log_severity_texts:
+                                elem:
+                                    type: string
+                                type: array
+                            match_type:
+                                type: string
+                            metric_names:
+                                elem:
+                                    type: string
+                                type: array
+                            regexp:
+                                fields:
+                                    cacheenabled:
+                                        type: bool
+                                    cachemaxnumentries:
+                                        type: int
+                                type: object
+                            resources:
+                                elem:
+                                    fields:
+                                        key:
+                                            type: string
+                                        value:
+                                            type: any
+                                    type: object
+                                type: array
+                            services:
+                                elem:
+                                    type: string
+                                type: array
+                            span_kinds:
+                                elem:
+                                    type: string
+                                type: array
+                            span_names:
+                                elem:
+                                    type: string
+                                type: array
+                        type: object
+                type: object
+            batch:
+                fields:
+                    metadata_cardinality_limit:
+                        type: int
+                    metadata_keys:
+                        elem:
+                            type: string
+                        type: array
+                    send_batch_max_size:
+                        type: int
+                    send_batch_size:
+                        type: int
+                    timeout:
+                        type: duration
+                type: object
+            cumulativetodelta:
+                fields:
+                    exclude:
+                        fields:
+                            match_type:
+                                type: string
+                            metric_types:
+                                elem:
+                                    type: string
+                                type: array
+                            metrics:
+                                elem:
+                                    type: string
+                                type: array
+                            regexp:
+                                fields:
+                                    cacheenabled:
+                                        type: bool
+                                    cachemaxnumentries:
+                                        type: int
+                                type: object
+                        type: object
+                    include:
+                        fields:
+                            match_type:
+                                type: string
+                            metric_types:
+                                elem:
+                                    type: string
+                                type: array
+                            metrics:
+                                elem:
+                                    type: string
+                                type: array
+                            regexp:
+                                fields:
+                                    cacheenabled:
+                                        type: bool
+                                    cachemaxnumentries:
+                                        type: int
+                                type: object
+                        type: object
+                    initial_value:
+                        type: int
+                    max_staleness:
+                        type: duration
+                type: object
+            deltatocumulative:
+                fields:
+                    max_stale:
+                        type: duration
+                    max_streams:
+                        type: int
+                type: object
+            deltatorate:
+                fields:
+                    metrics:
+                        elem:
+                            type: string
+                        type: array
+                type: object
+            drain:
+                fields:
+                    body_field:
+                        type: string
+                    extra_delimiters:
+                        elem:
+                            type: string
+                        type: array
+                    max_clusters:
+                        type: int
+                    max_node_children:
+                        type: int
+                    merge_threshold:
+                        type: float
+                    save_interval:
+                        type: duration
+                    seed_logs:
+                        elem:
+                            type: string
+                        type: array
+                    seed_templates:
+                        elem:
+                            type: string
+                        type: array
+                    storage:
+                        type: object
+                    template_attribute:
+                        type: string
+                    tree_depth:
+                        type: int
+                    warmup_min_clusters:
+                        type: int
+                type: object
+            filter:
+                fields:
+                    error_mode:
+                        type: string
+                    log_conditions:
+                        elem:
+                            fields:
+                                conditions:
+                                    elem:
+                                        type: string
+                                    type: array
+                                context:
+                                    type: string
+                                error_mode:
+                                    type: string
+                            type: object
+                        type: array
+                    logs:
+                        fields:
+                            exclude:
+                                fields:
+                                    bodies:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    match_type:
+                                        type: string
+                                    record_attributes:
+                                        elem:
+                                            fields:
+                                                key:
+                                                    type: string
+                                                value:
+                                                    type: any
+                                            type: object
+                                        type: array
+                                    resource_attributes:
+                                        elem:
+                                            fields:
+                                                key:
+                                                    type: string
+                                                value:
+                                                    type: any
+                                            type: object
+                                        type: array
+                                    severity_number:
+                                        fields:
+                                            match_undefined:
+                                                type: bool
+                                            min:
+                                                type: string
+                                        type: object
+                                    severity_texts:
+                                        elem:
+                                            type: string
+                                        type: array
+                                type: object
+                            include:
+                                fields:
+                                    bodies:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    match_type:
+                                        type: string
+                                    record_attributes:
+                                        elem:
+                                            fields:
+                                                key:
+                                                    type: string
+                                                value:
+                                                    type: any
+                                            type: object
+                                        type: array
+                                    resource_attributes:
+                                        elem:
+                                            fields:
+                                                key:
+                                                    type: string
+                                                value:
+                                                    type: any
+                                            type: object
+                                        type: array
+                                    severity_number:
+                                        fields:
+                                            match_undefined:
+                                                type: bool
+                                            min:
+                                                type: string
+                                        type: object
+                                    severity_texts:
+                                        elem:
+                                            type: string
+                                        type: array
+                                type: object
+                            log_record:
+                                elem:
+                                    type: string
+                                type: array
+                            resource:
+                                elem:
+                                    type: string
+                                type: array
+                        type: object
+                    metric_conditions:
+                        elem:
+                            fields:
+                                conditions:
+                                    elem:
+                                        type: string
+                                    type: array
+                                context:
+                                    type: string
+                                error_mode:
+                                    type: string
+                            type: object
+                        type: array
+                    metrics:
+                        fields:
+                            datapoint:
+                                elem:
+                                    type: string
+                                type: array
+                            exclude:
+                                fields:
+                                    expressions:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    match_type:
+                                        type: string
+                                    metric_names:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    regexp:
+                                        fields:
+                                            cacheenabled:
+                                                type: bool
+                                            cachemaxnumentries:
+                                                type: int
+                                        type: object
+                                    resource_attributes:
+                                        elem:
+                                            fields:
+                                                key:
+                                                    type: string
+                                                value:
+                                                    type: any
+                                            type: object
+                                        type: array
+                                type: object
+                            include:
+                                fields:
+                                    expressions:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    match_type:
+                                        type: string
+                                    metric_names:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    regexp:
+                                        fields:
+                                            cacheenabled:
+                                                type: bool
+                                            cachemaxnumentries:
+                                                type: int
+                                        type: object
+                                    resource_attributes:
+                                        elem:
+                                            fields:
+                                                key:
+                                                    type: string
+                                                value:
+                                                    type: any
+                                            type: object
+                                        type: array
+                                type: object
+                            metric:
+                                elem:
+                                    type: string
+                                type: array
+                            regexp:
+                                fields:
+                                    cacheenabled:
+                                        type: bool
+                                    cachemaxnumentries:
+                                        type: int
+                                type: object
+                            resource:
+                                elem:
+                                    type: string
+                                type: array
+                        type: object
+                    profile_conditions:
+                        elem:
+                            fields:
+                                conditions:
+                                    elem:
+                                        type: string
+                                    type: array
+                                context:
+                                    type: string
+                                error_mode:
+                                    type: string
+                            type: object
+                        type: array
+                    profiles:
+                        fields:
+                            profile:
+                                elem:
+                                    type: string
+                                type: array
+                            resource:
+                                elem:
+                                    type: string
+                                type: array
+                        type: object
+                    spans:
+                        fields:
+                            exclude:
+                                fields:
+                                    attributes:
+                                        elem:
+                                            fields:
+                                                key:
+                                                    type: string
+                                                value:
+                                                    type: any
+                                            type: object
+                                        type: array
+                                    libraries:
+                                        elem:
+                                            fields:
+                                                name:
+                                                    type: string
+                                                version:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    log_bodies:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    log_severity_number:
+                                        fields:
+                                            match_undefined:
+                                                type: bool
+                                            min:
+                                                type: int
+                                        type: object
+                                    log_severity_texts:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    match_type:
+                                        type: string
+                                    metric_names:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    regexp:
+                                        fields:
+                                            cacheenabled:
+                                                type: bool
+                                            cachemaxnumentries:
+                                                type: int
+                                        type: object
+                                    resources:
+                                        elem:
+                                            fields:
+                                                key:
+                                                    type: string
+                                                value:
+                                                    type: any
+                                            type: object
+                                        type: array
+                                    services:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    span_kinds:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    span_names:
+                                        elem:
+                                            type: string
+                                        type: array
+                                type: object
+                            include:
+                                fields:
+                                    attributes:
+                                        elem:
+                                            fields:
+                                                key:
+                                                    type: string
+                                                value:
+                                                    type: any
+                                            type: object
+                                        type: array
+                                    libraries:
+                                        elem:
+                                            fields:
+                                                name:
+                                                    type: string
+                                                version:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    log_bodies:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    log_severity_number:
+                                        fields:
+                                            match_undefined:
+                                                type: bool
+                                            min:
+                                                type: int
+                                        type: object
+                                    log_severity_texts:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    match_type:
+                                        type: string
+                                    metric_names:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    regexp:
+                                        fields:
+                                            cacheenabled:
+                                                type: bool
+                                            cachemaxnumentries:
+                                                type: int
+                                        type: object
+                                    resources:
+                                        elem:
+                                            fields:
+                                                key:
+                                                    type: string
+                                                value:
+                                                    type: any
+                                            type: object
+                                        type: array
+                                    services:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    span_kinds:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    span_names:
+                                        elem:
+                                            type: string
+                                        type: array
+                                type: object
+                        type: object
+                    trace_conditions:
+                        elem:
+                            fields:
+                                conditions:
+                                    elem:
+                                        type: string
+                                    type: array
+                                context:
+                                    type: string
+                                error_mode:
+                                    type: string
+                            type: object
+                        type: array
+                    traces:
+                        fields:
+                            resource:
+                                elem:
+                                    type: string
+                                type: array
+                            span:
+                                elem:
+                                    type: string
+                                type: array
+                            spanevent:
+                                elem:
+                                    type: string
+                                type: array
+                        type: object
+                type: object
+            groupbyattrs:
+                fields:
+                    keys:
+                        elem:
+                            type: string
+                        type: array
+                type: object
+            groupbytrace:
+                fields:
+                    discard_orphans:
+                        type: bool
+                    num_traces:
+                        type: int
+                    num_workers:
+                        type: int
+                    store_on_disk:
+                        type: bool
+                    wait_duration:
+                        type: duration
+                type: object
+            interval:
+                fields:
+                    interval:
+                        type: duration
+                    pass_through:
+                        fields:
+                            gauge:
+                                type: bool
+                            summary:
+                                type: bool
+                        type: object
+                type: object
+            k8s_attributes:
+                fields:
+                    auth_type:
+                        type: string
+                    context:
+                        type: string
+                    exclude:
+                        fields:
+                            pods:
+                                elem:
+                                    fields:
+                                        name:
+                                            type: string
+                                    type: object
+                                type: array
+                        type: object
+                    extract:
+                        fields:
+                            annotations:
+                                elem:
+                                    fields:
+                                        from:
+                                            type: string
+                                        key:
+                                            type: string
+                                        key_regex:
+                                            type: string
+                                        tag_name:
+                                            type: string
+                                    type: object
+                                type: array
+                            deployment_name_from_replicaset:
+                                type: bool
+                            labels:
+                                elem:
+                                    fields:
+                                        from:
+                                            type: string
+                                        key:
+                                            type: string
+                                        key_regex:
+                                            type: string
+                                        tag_name:
+                                            type: string
+                                    type: object
+                                type: array
+                            metadata:
+                                elem:
+                                    type: string
+                                type: array
+                            otel_annotations:
+                                type: bool
+                        type: object
+                    filter:
+                        fields:
+                            fields:
+                                elem:
+                                    fields:
+                                        key:
+                                            type: string
+                                        op:
+                                            type: string
+                                        value:
+                                            type: string
+                                    type: object
+                                type: array
+                            labels:
+                                elem:
+                                    fields:
+                                        key:
+                                            type: string
+                                        op:
+                                            type: string
+                                        value:
+                                            type: string
+                                    type: object
+                                type: array
+                            namespace:
+                                type: string
+                            node:
+                                type: string
+                            node_from_env_var:
+                                type: string
+                        type: object
+                    kube_api_burst:
+                        type: int
+                    kube_api_qps:
+                        type: float
+                    passthrough:
+                        type: bool
+                    pod_association:
+                        elem:
+                            fields:
+                                sources:
+                                    elem:
+                                        fields:
+                                            from:
+                                                type: string
+                                            name:
+                                                type: string
+                                        type: object
+                                    type: array
+                            type: object
+                        type: array
+                    pod_delete_grace_period:
+                        type: duration
+                    wait_for_metadata:
+                        type: bool
+                    wait_for_metadata_timeout:
+                        type: duration
+                    watch_sync_period:
+                        type: duration
+                type: object
+            log_dedup:
+                fields:
+                    conditions:
+                        elem:
+                            type: string
+                        type: array
+                    exclude_fields:
+                        elem:
+                            type: string
+                        type: array
+                    include_fields:
+                        elem:
+                            type: string
+                        type: array
+                    interval:
+                        type: duration
+                    log_count_attribute:
+                        type: string
+                    metadata_cardinality_limit:
+                        type: int
+                    metadata_keys:
+                        elem:
+                            type: string
+                        type: array
+                    timezone:
+                        type: string
+                type: object
+            memory_limiter:
+                fields:
+                    check_interval:
+                        type: duration
+                    limit_mib:
+                        type: int
+                    limit_percentage:
+                        type: int
+                    max_gc_interval_when_hard_limited:
+                        type: duration
+                    max_gc_interval_when_soft_limited:
+                        type: duration
+                    min_gc_interval_when_hard_limited:
+                        type: duration
+                    min_gc_interval_when_soft_limited:
+                        type: duration
+                    spike_limit_mib:
+                        type: int
+                    spike_limit_percentage:
+                        type: int
+                type: object
+            metrics_transform:
+                fields:
+                    transforms:
+                        elem:
+                            fields:
+                                action:
+                                    type: string
+                                aggregation_type:
+                                    type: string
+                                experimental_match_labels:
+                                    elem:
+                                        type: string
+                                    type: map
+                                group_resource_labels:
+                                    elem:
+                                        type: string
+                                    type: map
+                                include:
+                                    type: string
+                                match_type:
+                                    type: string
+                                new_name:
+                                    type: string
+                                operations:
+                                    elem:
+                                        fields:
+                                            action:
+                                                type: string
+                                            aggregated_values:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            aggregation_type:
+                                                type: string
+                                            experimental_scale:
+                                                type: float
+                                            label:
+                                                type: string
+                                            label_set:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            label_value:
+                                                type: string
+                                            new_label:
+                                                type: string
+                                            new_value:
+                                                type: string
+                                            value_actions:
+                                                elem:
+                                                    fields:
+                                                        new_value:
+                                                            type: string
+                                                        value:
+                                                            type: string
+                                                    type: object
+                                                type: array
+                                        type: object
+                                    type: array
+                                submatch_case:
+                                    type: string
+                            type: object
+                        type: array
+                type: object
+            metricsgeneration:
+                fields:
+                    rules:
+                        elem:
+                            fields:
+                                metric1:
+                                    type: string
+                                metric2:
+                                    type: string
+                                name:
+                                    type: string
+                                operation:
+                                    type: string
+                                scale_by:
+                                    type: float
+                                type:
+                                    type: string
+                                unit:
+                                    type: string
+                            type: object
+                        type: array
+                type: object
+            probabilistic_sampler:
+                fields:
+                    attribute_source:
+                        type: string
+                    fail_closed:
+                        type: bool
+                    from_attribute:
+                        type: string
+                    hash_seed:
+                        type: int
+                    mode:
+                        type: string
+                    sampling_percentage:
+                        type: float
+                    sampling_precision:
+                        type: int
+                    sampling_priority:
+                        type: string
+                type: object
+            redaction:
+                fields:
+                    allow_all_keys:
+                        type: bool
+                    allowed_keys:
+                        elem:
+                            type: string
+                        type: array
+                    allowed_values:
+                        elem:
+                            type: string
+                        type: array
+                    blocked_key_patterns:
+                        elem:
+                            type: string
+                        type: array
+                    blocked_values:
+                        elem:
+                            type: string
+                        type: array
+                    db_sanitizer:
+                        fields:
+                            es:
+                                fields:
+                                    attributes:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    enabled:
+                                        type: bool
+                                type: object
+                            memcached:
+                                fields:
+                                    attributes:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    enabled:
+                                        type: bool
+                                type: object
+                            mongo:
+                                fields:
+                                    attributes:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    enabled:
+                                        type: bool
+                                type: object
+                            opensearch:
+                                fields:
+                                    attributes:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    enabled:
+                                        type: bool
+                                type: object
+                            redis:
+                                fields:
+                                    attributes:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    enabled:
+                                        type: bool
+                                type: object
+                            sanitize_span_name:
+                                type: bool
+                            sql:
+                                fields:
+                                    attributes:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    enabled:
+                                        type: bool
+                                type: object
+                            valkey:
+                                fields:
+                                    attributes:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    enabled:
+                                        type: bool
+                                type: object
+                        type: object
+                    hash_function:
+                        type: string
+                    hmac_key:
+                        type: string
+                    ignored_key_patterns:
+                        elem:
+                            type: string
+                        type: array
+                    ignored_keys:
+                        elem:
+                            type: string
+                        type: array
+                    redact_all_types:
+                        type: bool
+                    summary:
+                        type: string
+                    url_sanitizer:
+                        fields:
+                            attributes:
+                                elem:
+                                    type: string
+                                type: array
+                            enabled:
+                                type: bool
+                            sanitize_span_name:
+                                type: bool
+                        type: object
+                type: object
+            remotetap:
+                fields:
+                    auth:
+                        fields:
+                            authenticator:
+                                type: object
+                            request_params:
+                                elem:
+                                    type: string
+                                type: array
+                        type: object
+                    compression_algorithms:
+                        elem:
+                            type: string
+                        type: array
+                    cors:
+                        fields:
+                            allowed_headers:
+                                elem:
+                                    type: string
+                                type: array
+                            allowed_origins:
+                                elem:
+                                    type: string
+                                type: array
+                            exposed_headers:
+                                elem:
+                                    type: string
+                                type: array
+                            max_age:
+                                type: int
+                        type: object
+                    dialer:
+                        fields:
+                            timeout:
+                                type: duration
+                        type: object
+                    endpoint:
+                        type: string
+                    idle_timeout:
+                        type: duration
+                    include_metadata:
+                        type: bool
+                    keep_alives_enabled:
+                        type: bool
+                    limit:
+                        type: float
+                    max_request_body_size:
+                        type: int
+                    middlewares:
+                        elem:
+                            fields:
+                                id:
+                                    type: object
+                            type: object
+                        type: array
+                    read_header_timeout:
+                        type: duration
+                    read_timeout:
+                        type: duration
+                    response_headers:
+                        elem:
+                            fields:
+                                name:
+                                    type: string
+                                value:
+                                    type: string
+                            type: object
+                        type: array
+                    tls:
+                        fields:
+                            ca_file:
+                                type: string
+                            ca_pem:
+                                type: string
+                            cert_file:
+                                type: string
+                            cert_pem:
+                                type: string
+                            cipher_suites:
+                                elem:
+                                    type: string
+                                type: array
+                            client_ca_file:
+                                type: string
+                            client_ca_file_reload:
+                                type: bool
+                            curve_preferences:
+                                elem:
+                                    type: string
+                                type: array
+                            include_insecure_cipher_suites:
+                                type: bool
+                            include_system_ca_certs_pool:
+                                type: bool
+                            key_file:
+                                type: string
+                            key_pem:
+                                type: string
+                            max_version:
+                                type: string
+                            min_version:
+                                type: string
+                            reload_interval:
+                                type: duration
+                            tpm:
+                                fields:
+                                    auth:
+                                        type: string
+                                    enabled:
+                                        type: bool
+                                    owner_auth:
+                                        type: string
+                                    path:
+                                        type: string
+                                type: object
+                        type: object
+                    transport:
+                        type: string
+                    write_timeout:
+                        type: duration
+                type: object
+            resource:
+                fields:
+                    attributes:
+                        elem:
+                            fields:
+                                action:
+                                    type: string
+                                converted_type:
+                                    type: string
+                                default_value:
+                                    type: any
+                                from_attribute:
+                                    type: string
+                                from_context:
+                                    type: string
+                                key:
+                                    type: string
+                                pattern:
+                                    type: string
+                                value:
+                                    type: any
+                            type: object
+                        type: array
+                type: object
+            resource_detection:
+                fields:
+                    akamai:
+                        fields:
+                            resource_attributes:
+                                fields:
+                                    cloud.account.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.platform:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.provider:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.region:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.image.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.image.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.type:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                type: object
+                        type: object
+                    aks:
+                        fields:
+                            resource_attributes:
+                                fields:
+                                    cloud.platform:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.provider:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    k8s.cluster.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                type: object
+                        type: object
+                    alibaba_ecs:
+                        fields:
+                            fail_on_missing_metadata:
+                                type: bool
+                            resource_attributes:
+                                fields:
+                                    cloud.account.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.availability_zone:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.platform:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.provider:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.region:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.image.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.type:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                type: object
+                        type: object
+                    auth:
+                        fields:
+                            authenticator:
+                                type: object
+                        type: object
+                    azure:
+                        fields:
+                            resource_attributes:
+                                fields:
+                                    azure.resourcegroup.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    azure.vm.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    azure.vm.scaleset.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    azure.vm.size:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.account.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.availability_zone:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.platform:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.provider:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.region:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                type: object
+                            tags:
+                                elem:
+                                    type: string
+                                type: array
+                        type: object
+                    compression:
+                        type: string
+                    compression_params:
+                        fields:
+                            level:
+                                type: int
+                        type: object
+                    consul:
+                        fields:
+                            address:
+                                type: string
+                            datacenter:
+                                type: string
+                            meta:
+                                elem:
+                                    type: any
+                                type: map
+                            namespace:
+                                type: string
+                            resource_attributes:
+                                fields:
+                                    cloud.region:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                type: object
+                            token:
+                                type: string
+                            token_file:
+                                type: string
+                        type: object
+                    cookies:
+                        type: object
+                    detectors:
+                        elem:
+                            type: string
+                        type: array
+                    digitalocean:
+                        fields:
+                            resource_attributes:
+                                fields:
+                                    cloud.provider:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.region:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                type: object
+                        type: object
+                    disable_keep_alives:
+                        type: bool
+                    docker:
+                        fields:
+                            resource_attributes:
+                                fields:
+                                    container.image.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    container.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    os.type:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                type: object
+                        type: object
+                    ec2:
+                        fields:
+                            fail_on_missing_metadata:
+                                type: bool
+                            max_attempts:
+                                type: int
+                            max_backoff:
+                                type: duration
+                            resource_attributes:
+                                fields:
+                                    cloud.account.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.availability_zone:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.platform:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.provider:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.region:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.image.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.type:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                type: object
+                            tags:
+                                elem:
+                                    type: string
+                                type: array
+                            tags_from_imds:
+                                type: bool
+                        type: object
+                    ecs:
+                        fields:
+                            resource_attributes:
+                                fields:
+                                    aws.ecs.cluster.arn:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    aws.ecs.launchtype:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    aws.ecs.task.arn:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    aws.ecs.task.family:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    aws.ecs.task.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    aws.ecs.task.revision:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    aws.log.group.arns:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    aws.log.group.names:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    aws.log.stream.arns:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    aws.log.stream.names:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.account.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.availability_zone:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.platform:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.provider:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.region:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                type: object
+                        type: object
+                    eks:
+                        fields:
+                            node_from_env_var:
+                                type: string
+                            resource_attributes:
+                                fields:
+                                    cloud.account.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.availability_zone:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.platform:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.provider:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.region:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.image.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.type:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    k8s.cluster.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                type: object
+                        type: object
+                    elasticbeanstalk:
+                        fields:
+                            resource_attributes:
+                                fields:
+                                    cloud.platform:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.provider:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    deployment.environment:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    service.instance.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    service.version:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                type: object
+                        type: object
+                    endpoint:
+                        type: string
+                    force_attempt_http2:
+                        type: bool
+                    gcp:
+                        fields:
+                            labels:
+                                elem:
+                                    type: string
+                                type: array
+                            resource_attributes:
+                                fields:
+                                    cloud.account.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.availability_zone:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.platform:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.provider:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.region:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    faas.instance:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    faas.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    faas.version:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    gcp.cloud_run.job.execution:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    gcp.cloud_run.job.task_index:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    gcp.gce.instance.hostname:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    gcp.gce.instance.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    gcp.gce.instance_group_manager.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    gcp.gce.instance_group_manager.region:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    gcp.gce.instance_group_manager.zone:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.type:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    k8s.cluster.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                type: object
+                        type: object
+                    headers:
+                        elem:
+                            fields:
+                                name:
+                                    type: string
+                                value:
+                                    type: string
+                            type: object
+                        type: array
+                    heroku:
+                        fields:
+                            resource_attributes:
+                                fields:
+                                    cloud.provider:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    heroku.app.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    heroku.dyno.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    heroku.release.commit:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    heroku.release.creation_timestamp:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    service.instance.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    service.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    service.version:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                type: object
+                        type: object
+                    hetzner:
+                        fields:
+                            resource_attributes:
+                                fields:
+                                    cloud.availability_zone:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.platform:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.provider:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.region:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                type: object
+                        type: object
+                    http2_ping_timeout:
+                        type: duration
+                    http2_read_idle_timeout:
+                        type: duration
+                    ibmcloud_classic:
+                        fields:
+                            resource_attributes:
+                                fields:
+                                    cloud.account.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.availability_zone:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.platform:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.provider:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.resource_id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                type: object
+                        type: object
+                    ibmcloud_vpc:
+                        fields:
+                            protocol:
+                                type: string
+                            resource_attributes:
+                                fields:
+                                    cloud.account.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.availability_zone:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.platform:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.provider:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.region:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.resource_id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.image.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.image.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.type:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                type: object
+                        type: object
+                    idle_conn_timeout:
+                        type: duration
+                    k8s_api:
+                        fields:
+                            auth_type:
+                                type: string
+                            context:
+                                type: string
+                            kube_api_burst:
+                                type: int
+                            kube_api_qps:
+                                type: float
+                            node_from_env_var:
+                                type: string
+                            resource_attributes:
+                                fields:
+                                    k8s.cluster.uid:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    k8s.node.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    k8s.node.uid:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                type: object
+                        type: object
+                    k8snode:
+                        fields:
+                            auth_type:
+                                type: string
+                            context:
+                                type: string
+                            kube_api_burst:
+                                type: int
+                            kube_api_qps:
+                                type: float
+                            node_from_env_var:
+                                type: string
+                            resource_attributes:
+                                fields:
+                                    k8s.cluster.uid:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    k8s.node.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    k8s.node.uid:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                type: object
+                        type: object
+                    kubeadm:
+                        fields:
+                            auth_type:
+                                type: string
+                            context:
+                                type: string
+                            kube_api_burst:
+                                type: int
+                            kube_api_qps:
+                                type: float
+                            resource_attributes:
+                                fields:
+                                    k8s.cluster.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    k8s.cluster.uid:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                type: object
+                        type: object
+                    lambda:
+                        fields:
+                            resource_attributes:
+                                fields:
+                                    aws.log.group.names:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    aws.log.stream.names:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.platform:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.provider:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.region:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    faas.instance:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    faas.max_memory:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    faas.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    faas.version:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                type: object
+                        type: object
+                    max_conns_per_host:
+                        type: int
+                    max_idle_conns:
+                        type: int
+                    max_idle_conns_per_host:
+                        type: int
+                    middlewares:
+                        elem:
+                            fields:
+                                id:
+                                    type: object
+                            type: object
+                        type: array
+                    nova:
+                        fields:
+                            fail_on_missing_metadata:
+                                type: bool
+                            labels:
+                                elem:
+                                    type: string
+                                type: array
+                            resource_attributes:
+                                fields:
+                                    cloud.account.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.availability_zone:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.platform:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.provider:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.type:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                type: object
+                        type: object
+                    openshift:
+                        fields:
+                            address:
+                                type: string
+                            resource_attributes:
+                                fields:
+                                    cloud.platform:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.provider:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.region:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    k8s.cluster.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                type: object
+                            tls:
+                                fields:
+                                    ca_file:
+                                        type: string
+                                    ca_pem:
+                                        type: string
+                                    cert_file:
+                                        type: string
+                                    cert_pem:
+                                        type: string
+                                    cipher_suites:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    curve_preferences:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    include_insecure_cipher_suites:
+                                        type: bool
+                                    include_system_ca_certs_pool:
+                                        type: bool
+                                    insecure:
+                                        type: bool
+                                    insecure_skip_verify:
+                                        type: bool
+                                    key_file:
+                                        type: string
+                                    key_pem:
+                                        type: string
+                                    max_version:
+                                        type: string
+                                    min_version:
+                                        type: string
+                                    reload_interval:
+                                        type: duration
+                                    server_name_override:
+                                        type: string
+                                    tpm:
+                                        fields:
+                                            auth:
+                                                type: string
+                                            enabled:
+                                                type: bool
+                                            owner_auth:
+                                                type: string
+                                            path:
+                                                type: string
+                                        type: object
+                                type: object
+                            token:
+                                type: string
+                        type: object
+                    oraclecloud:
+                        fields:
+                            resource_attributes:
+                                fields:
+                                    cloud.availability_zone:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.platform:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.provider:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.region:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.type:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    k8s.cluster.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    oracle_cloud.realm:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                type: object
+                        type: object
+                    override:
+                        type: bool
+                    proxy_url:
+                        type: string
+                    read_buffer_size:
+                        type: int
+                    refresh_interval:
+                        type: duration
+                    scaleway:
+                        fields:
+                            resource_attributes:
+                                fields:
+                                    cloud.account.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.availability_zone:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.platform:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.provider:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.region:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.image.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.image.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.type:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                type: object
+                        type: object
+                    system:
+                        fields:
+                            hostname_sources:
+                                elem:
+                                    type: string
+                                type: array
+                            resource_attributes:
+                                fields:
+                                    host.arch:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.cpu.cache.l2.size:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.cpu.family:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.cpu.model.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.cpu.model.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.cpu.stepping:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.cpu.vendor.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.interface:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.ip:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.mac:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    os.build.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    os.description:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    os.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    os.type:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    os.version:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                type: object
+                        type: object
+                    tencent_cvm:
+                        fields:
+                            fail_on_missing_metadata:
+                                type: bool
+                            resource_attributes:
+                                fields:
+                                    cloud.account.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.availability_zone:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.platform:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.provider:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.region:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.image.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.type:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                type: object
+                        type: object
+                    timeout:
+                        type: duration
+                    tls:
+                        fields:
+                            ca_file:
+                                type: string
+                            ca_pem:
+                                type: string
+                            cert_file:
+                                type: string
+                            cert_pem:
+                                type: string
+                            cipher_suites:
+                                elem:
+                                    type: string
+                                type: array
+                            curve_preferences:
+                                elem:
+                                    type: string
+                                type: array
+                            include_insecure_cipher_suites:
+                                type: bool
+                            include_system_ca_certs_pool:
+                                type: bool
+                            insecure:
+                                type: bool
+                            insecure_skip_verify:
+                                type: bool
+                            key_file:
+                                type: string
+                            key_pem:
+                                type: string
+                            max_version:
+                                type: string
+                            min_version:
+                                type: string
+                            reload_interval:
+                                type: duration
+                            server_name_override:
+                                type: string
+                            tpm:
+                                fields:
+                                    auth:
+                                        type: string
+                                    enabled:
+                                        type: bool
+                                    owner_auth:
+                                        type: string
+                                    path:
+                                        type: string
+                                type: object
+                        type: object
+                    upcloud:
+                        fields:
+                            fail_on_missing_metadata:
+                                type: bool
+                            resource_attributes:
+                                fields:
+                                    cloud.provider:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.region:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                type: object
+                        type: object
+                    vultr:
+                        fields:
+                            fail_on_missing_metadata:
+                                type: bool
+                            resource_attributes:
+                                fields:
+                                    cloud.platform:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.provider:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    cloud.region:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.id:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                    host.name:
+                                        fields:
+                                            enabled:
+                                                type: bool
+                                        type: object
+                                type: object
+                        type: object
+                    write_buffer_size:
+                        type: int
+                type: object
+            tail_sampling:
+                fields:
+                    block_on_overflow:
+                        type: bool
+                    decision_cache:
+                        fields:
+                            non_sampled_cache_size:
+                                type: int
+                            sampled_cache_size:
+                                type: int
+                        type: object
+                    decision_wait:
+                        type: duration
+                    decision_wait_after_root_received:
+                        type: duration
+                    drop_pending_traces_on_shutdown:
+                        type: bool
+                    expected_new_traces_per_sec:
+                        type: int
+                    maximum_trace_size_bytes:
+                        type: int
+                    num_traces:
+                        type: int
+                    policies:
+                        elem:
+                            fields:
+                                and:
+                                    fields:
+                                        and_sub_policy:
+                                            elem:
+                                                fields:
+                                                    not:
+                                                        fields:
+                                                            not_sub_policy:
+                                                                type: object
+                                                        type: object
+                                                type: object
+                                            type: array
+                                    type: object
+                                composite:
+                                    fields:
+                                        composite_sub_policy:
+                                            elem:
+                                                fields:
+                                                    and:
+                                                        fields:
+                                                            and_sub_policy:
+                                                                elem:
+                                                                    fields:
+                                                                        not:
+                                                                            fields:
+                                                                                not_sub_policy:
+                                                                                    type: object
+                                                                            type: object
+                                                                    type: object
+                                                                type: array
+                                                        type: object
+                                                type: object
+                                            type: array
+                                        max_total_spans_per_second:
+                                            type: int
+                                        policy_order:
+                                            elem:
+                                                type: string
+                                            type: array
+                                        rate_allocation:
+                                            elem:
+                                                fields:
+                                                    percent:
+                                                        type: int
+                                                    policy:
+                                                        type: string
+                                                type: object
+                                            type: array
+                                    type: object
+                                drop:
+                                    fields:
+                                        drop_sub_policy:
+                                            elem:
+                                                fields:
+                                                    not:
+                                                        fields:
+                                                            not_sub_policy:
+                                                                type: object
+                                                        type: object
+                                                type: object
+                                            type: array
+                                    type: object
+                                not:
+                                    fields:
+                                        not_sub_policy:
+                                            type: object
+                                    type: object
+                            type: object
+                        type: array
+                    sample_on_first_match:
+                        type: bool
+                    sampling_strategy:
+                        type: string
+                    tail_storage:
+                        type: object
+                type: object
+            transform:
+                fields:
+                    error_mode:
+                        type: string
+                    flatten_data:
+                        type: bool
+                    log_statements:
+                        elem:
+                            fields:
+                                conditions:
+                                    elem:
+                                        type: string
+                                    type: array
+                                context:
+                                    type: string
+                                error_mode:
+                                    type: string
+                                statements:
+                                    elem:
+                                        type: string
+                                    type: array
+                            type: object
+                        type: array
+                    metric_statements:
+                        elem:
+                            fields:
+                                conditions:
+                                    elem:
+                                        type: string
+                                    type: array
+                                context:
+                                    type: string
+                                error_mode:
+                                    type: string
+                                statements:
+                                    elem:
+                                        type: string
+                                    type: array
+                            type: object
+                        type: array
+                    profile_statements:
+                        elem:
+                            fields:
+                                conditions:
+                                    elem:
+                                        type: string
+                                    type: array
+                                context:
+                                    type: string
+                                error_mode:
+                                    type: string
+                                statements:
+                                    elem:
+                                        type: string
+                                    type: array
+                            type: object
+                        type: array
+                    trace_statements:
+                        elem:
+                            fields:
+                                conditions:
+                                    elem:
+                                        type: string
+                                    type: array
+                                context:
+                                    type: string
+                                error_mode:
+                                    type: string
+                                statements:
+                                    elem:
+                                        type: string
+                                    type: array
+                            type: object
+                        type: array
+                type: object
+        receivers:
+            file_log:
+                fields:
+                    acquire_fs_lock:
+                        type: bool
+                    attributes:
+                        elem:
+                            type: string
+                        type: map
+                    compression:
+                        type: string
+                    delete_after_read:
+                        type: bool
+                    encoding:
+                        type: string
+                    exclude:
+                        elem:
+                            type: string
+                        type: array
+                    exclude_older_than:
+                        type: duration
+                    file_cache_advise:
+                        type: bool
+                    fingerprint_size:
+                        type: int
+                    force_flush_period:
+                        type: duration
+                    header:
+                        fields:
+                            metadata_operators:
+                                elem:
+                                    type: object
+                                type: array
+                            pattern:
+                                type: string
+                        type: object
+                    id:
+                        type: string
+                    include:
+                        elem:
+                            type: string
+                        type: array
+                    include_file_name:
+                        type: bool
+                    include_file_name_resolved:
+                        type: bool
+                    include_file_owner_group_name:
+                        type: bool
+                    include_file_owner_name:
+                        type: bool
+                    include_file_path:
+                        type: bool
+                    include_file_path_resolved:
+                        type: bool
+                    include_file_permissions:
+                        type: bool
+                    include_file_record_number:
+                        type: bool
+                    include_file_record_offset:
+                        type: bool
+                    initial_buffer_size:
+                        type: int
+                    max_batches:
+                        type: int
+                    max_concurrent_files:
+                        type: int
+                    max_log_size:
+                        type: int
+                    max_log_size_behavior:
+                        type: string
+                    multiline:
+                        fields:
+                            line_end_pattern:
+                                type: string
+                            line_start_pattern:
+                                type: string
+                            omit_pattern:
+                                type: bool
+                        type: object
+                    on_truncate:
+                        type: string
+                    operators:
+                        elem:
+                            type: object
+                        type: array
+                    ordering_criteria:
+                        fields:
+                            group_by:
+                                type: string
+                            regex:
+                                type: string
+                            sort_by:
+                                elem:
+                                    fields:
+                                        ascending:
+                                            type: bool
+                                        layout:
+                                            type: string
+                                        location:
+                                            type: string
+                                        regex_key:
+                                            type: string
+                                        sort_type:
+                                            type: string
+                                    type: object
+                                type: array
+                            top_n:
+                                type: int
+                        type: object
+                    output:
+                        elem:
+                            type: string
+                        type: array
+                    poll_interval:
+                        type: duration
+                    polls_to_archive:
+                        type: int
+                    preserve_leading_whitespaces:
+                        type: bool
+                    preserve_trailing_whitespaces:
+                        type: bool
+                    resource:
+                        elem:
+                            type: string
+                        type: map
+                    retry_on_failure:
+                        fields:
+                            enabled:
+                                type: bool
+                            initial_interval:
+                                type: duration
+                            max_elapsed_time:
+                                type: duration
+                            max_interval:
+                                type: duration
+                        type: object
+                    start_at:
+                        type: string
+                    storage:
+                        type: object
+                    type:
+                        type: string
+                type: object
+            fluent_forward:
+                fields:
+                    endpoint:
+                        type: string
+                type: object
+            host_metrics:
+                fields:
+                    collection_interval:
+                        type: duration
+                    initial_delay:
+                        type: duration
+                    metadata_collection_interval:
+                        type: duration
+                    root_path:
+                        type: string
+                    timeout:
+                        type: duration
+                type: object
+            http_check:
+                fields:
+                    collection_interval:
+                        type: duration
+                    initial_delay:
+                        type: duration
+                    metrics:
+                        fields:
+                            httpcheck.client.connection.duration:
+                                fields:
+                                    aggregation_strategy:
+                                        type: string
+                                    attributes:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    enabled:
+                                        type: bool
+                                type: object
+                            httpcheck.client.request.duration:
+                                fields:
+                                    aggregation_strategy:
+                                        type: string
+                                    attributes:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    enabled:
+                                        type: bool
+                                type: object
+                            httpcheck.dns.lookup.duration:
+                                fields:
+                                    aggregation_strategy:
+                                        type: string
+                                    attributes:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    enabled:
+                                        type: bool
+                                type: object
+                            httpcheck.duration:
+                                fields:
+                                    aggregation_strategy:
+                                        type: string
+                                    attributes:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    enabled:
+                                        type: bool
+                                type: object
+                            httpcheck.error:
+                                fields:
+                                    aggregation_strategy:
+                                        type: string
+                                    attributes:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    enabled:
+                                        type: bool
+                                type: object
+                            httpcheck.response.duration:
+                                fields:
+                                    aggregation_strategy:
+                                        type: string
+                                    attributes:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    enabled:
+                                        type: bool
+                                type: object
+                            httpcheck.response.size:
+                                fields:
+                                    aggregation_strategy:
+                                        type: string
+                                    attributes:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    enabled:
+                                        type: bool
+                                type: object
+                            httpcheck.status:
+                                fields:
+                                    aggregation_strategy:
+                                        type: string
+                                    attributes:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    enabled:
+                                        type: bool
+                                type: object
+                            httpcheck.tls.cert_remaining:
+                                fields:
+                                    aggregation_strategy:
+                                        type: string
+                                    attributes:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    enabled:
+                                        type: bool
+                                type: object
+                            httpcheck.tls.handshake.duration:
+                                fields:
+                                    aggregation_strategy:
+                                        type: string
+                                    attributes:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    enabled:
+                                        type: bool
+                                type: object
+                            httpcheck.validation.failed:
+                                fields:
+                                    aggregation_strategy:
+                                        type: string
+                                    attributes:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    enabled:
+                                        type: bool
+                                type: object
+                            httpcheck.validation.passed:
+                                fields:
+                                    aggregation_strategy:
+                                        type: string
+                                    attributes:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    enabled:
+                                        type: bool
+                                type: object
+                        type: object
+                    targets:
+                        elem:
+                            fields:
+                                auth:
+                                    fields:
+                                        authenticator:
+                                            type: object
+                                    type: object
+                                auto_content_type:
+                                    type: bool
+                                body:
+                                    type: string
+                                compression:
+                                    type: string
+                                compression_params:
+                                    fields:
+                                        level:
+                                            type: int
+                                    type: object
+                                cookies:
+                                    type: object
+                                disable_keep_alives:
+                                    type: bool
+                                endpoint:
+                                    type: string
+                                endpoints:
+                                    elem:
+                                        type: string
+                                    type: array
+                                force_attempt_http2:
+                                    type: bool
+                                headers:
+                                    elem:
+                                        fields:
+                                            name:
+                                                type: string
+                                            value:
+                                                type: string
+                                        type: object
+                                    type: array
+                                http2_ping_timeout:
+                                    type: duration
+                                http2_read_idle_timeout:
+                                    type: duration
+                                idle_conn_timeout:
+                                    type: duration
+                                max_conns_per_host:
+                                    type: int
+                                max_idle_conns:
+                                    type: int
+                                max_idle_conns_per_host:
+                                    type: int
+                                method:
+                                    type: string
+                                middlewares:
+                                    elem:
+                                        fields:
+                                            id:
+                                                type: object
+                                        type: object
+                                    type: array
+                                proxy_url:
+                                    type: string
+                                read_buffer_size:
+                                    type: int
+                                timeout:
+                                    type: duration
+                                tls:
+                                    fields:
+                                        ca_file:
+                                            type: string
+                                        ca_pem:
+                                            type: string
+                                        cert_file:
+                                            type: string
+                                        cert_pem:
+                                            type: string
+                                        cipher_suites:
+                                            elem:
+                                                type: string
+                                            type: array
+                                        curve_preferences:
+                                            elem:
+                                                type: string
+                                            type: array
+                                        include_insecure_cipher_suites:
+                                            type: bool
+                                        include_system_ca_certs_pool:
+                                            type: bool
+                                        insecure:
+                                            type: bool
+                                        insecure_skip_verify:
+                                            type: bool
+                                        key_file:
+                                            type: string
+                                        key_pem:
+                                            type: string
+                                        max_version:
+                                            type: string
+                                        min_version:
+                                            type: string
+                                        reload_interval:
+                                            type: duration
+                                        server_name_override:
+                                            type: string
+                                        tpm:
+                                            fields:
+                                                auth:
+                                                    type: string
+                                                enabled:
+                                                    type: bool
+                                                owner_auth:
+                                                    type: string
+                                                path:
+                                                    type: string
+                                            type: object
+                                    type: object
+                                validations:
+                                    elem:
+                                        fields:
+                                            contains:
+                                                type: string
+                                            equals:
+                                                type: string
+                                            json_path:
+                                                type: string
+                                            max_size:
+                                                type: int
+                                            min_size:
+                                                type: int
+                                            not_contains:
+                                                type: string
+                                            regex:
+                                                type: string
+                                        type: object
+                                    type: array
+                                write_buffer_size:
+                                    type: int
+                            type: object
+                        type: array
+                    timeout:
+                        type: duration
+                type: object
+            jaeger:
+                fields:
+                    protocols:
+                        fields:
+                            grpc:
+                                fields:
+                                    auth:
+                                        fields:
+                                            authenticator:
+                                                type: object
+                                        type: object
+                                    dialer:
+                                        fields:
+                                            timeout:
+                                                type: duration
+                                        type: object
+                                    endpoint:
+                                        type: string
+                                    include_metadata:
+                                        type: bool
+                                    keepalive:
+                                        fields:
+                                            enforcement_policy:
+                                                fields:
+                                                    min_time:
+                                                        type: duration
+                                                    permit_without_stream:
+                                                        type: bool
+                                                type: object
+                                            server_parameters:
+                                                fields:
+                                                    max_connection_age:
+                                                        type: duration
+                                                    max_connection_age_grace:
+                                                        type: duration
+                                                    max_connection_idle:
+                                                        type: duration
+                                                    time:
+                                                        type: duration
+                                                    timeout:
+                                                        type: duration
+                                                type: object
+                                        type: object
+                                    max_concurrent_streams:
+                                        type: int
+                                    max_recv_msg_size_mib:
+                                        type: int
+                                    middlewares:
+                                        elem:
+                                            fields:
+                                                id:
+                                                    type: object
+                                            type: object
+                                        type: array
+                                    read_buffer_size:
+                                        type: int
+                                    tls:
+                                        fields:
+                                            ca_file:
+                                                type: string
+                                            ca_pem:
+                                                type: string
+                                            cert_file:
+                                                type: string
+                                            cert_pem:
+                                                type: string
+                                            cipher_suites:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            client_ca_file:
+                                                type: string
+                                            client_ca_file_reload:
+                                                type: bool
+                                            curve_preferences:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            include_insecure_cipher_suites:
+                                                type: bool
+                                            include_system_ca_certs_pool:
+                                                type: bool
+                                            key_file:
+                                                type: string
+                                            key_pem:
+                                                type: string
+                                            max_version:
+                                                type: string
+                                            min_version:
+                                                type: string
+                                            reload_interval:
+                                                type: duration
+                                            tpm:
+                                                fields:
+                                                    auth:
+                                                        type: string
+                                                    enabled:
+                                                        type: bool
+                                                    owner_auth:
+                                                        type: string
+                                                    path:
+                                                        type: string
+                                                type: object
+                                        type: object
+                                    transport:
+                                        type: string
+                                    write_buffer_size:
+                                        type: int
+                                type: object
+                            thrift_binary:
+                                fields:
+                                    endpoint:
+                                        type: string
+                                    max_packet_size:
+                                        type: int
+                                    queue_size:
+                                        type: int
+                                    socket_buffer_size:
+                                        type: int
+                                    workers:
+                                        type: int
+                                type: object
+                            thrift_compact:
+                                fields:
+                                    endpoint:
+                                        type: string
+                                    max_packet_size:
+                                        type: int
+                                    queue_size:
+                                        type: int
+                                    socket_buffer_size:
+                                        type: int
+                                    workers:
+                                        type: int
+                                type: object
+                            thrift_http:
+                                fields:
+                                    auth:
+                                        fields:
+                                            authenticator:
+                                                type: object
+                                            request_params:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                        type: object
+                                    compression_algorithms:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    cors:
+                                        fields:
+                                            allowed_headers:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            allowed_origins:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            exposed_headers:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            max_age:
+                                                type: int
+                                        type: object
+                                    dialer:
+                                        fields:
+                                            timeout:
+                                                type: duration
+                                        type: object
+                                    endpoint:
+                                        type: string
+                                    idle_timeout:
+                                        type: duration
+                                    include_metadata:
+                                        type: bool
+                                    keep_alives_enabled:
+                                        type: bool
+                                    max_request_body_size:
+                                        type: int
+                                    middlewares:
+                                        elem:
+                                            fields:
+                                                id:
+                                                    type: object
+                                            type: object
+                                        type: array
+                                    read_header_timeout:
+                                        type: duration
+                                    read_timeout:
+                                        type: duration
+                                    response_headers:
+                                        elem:
+                                            fields:
+                                                name:
+                                                    type: string
+                                                value:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    tls:
+                                        fields:
+                                            ca_file:
+                                                type: string
+                                            ca_pem:
+                                                type: string
+                                            cert_file:
+                                                type: string
+                                            cert_pem:
+                                                type: string
+                                            cipher_suites:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            client_ca_file:
+                                                type: string
+                                            client_ca_file_reload:
+                                                type: bool
+                                            curve_preferences:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            include_insecure_cipher_suites:
+                                                type: bool
+                                            include_system_ca_certs_pool:
+                                                type: bool
+                                            key_file:
+                                                type: string
+                                            key_pem:
+                                                type: string
+                                            max_version:
+                                                type: string
+                                            min_version:
+                                                type: string
+                                            reload_interval:
+                                                type: duration
+                                            tpm:
+                                                fields:
+                                                    auth:
+                                                        type: string
+                                                    enabled:
+                                                        type: bool
+                                                    owner_auth:
+                                                        type: string
+                                                    path:
+                                                        type: string
+                                                type: object
+                                        type: object
+                                    transport:
+                                        type: string
+                                    write_timeout:
+                                        type: duration
+                                type: object
+                        type: object
+                    remote_sampling:
+                        fields:
+                            auth:
+                                fields:
+                                    authenticator:
+                                        type: object
+                                type: object
+                            authority:
+                                type: string
+                            balancer_name:
+                                type: string
+                            compression:
+                                type: string
+                            endpoint:
+                                type: string
+                            headers:
+                                elem:
+                                    fields:
+                                        name:
+                                            type: string
+                                        value:
+                                            type: string
+                                    type: object
+                                type: array
+                            host_endpoint:
+                                type: string
+                            keepalive:
+                                fields:
+                                    permit_without_stream:
+                                        type: bool
+                                    time:
+                                        type: duration
+                                    timeout:
+                                        type: duration
+                                type: object
+                            middlewares:
+                                elem:
+                                    fields:
+                                        id:
+                                            type: object
+                                    type: object
+                                type: array
+                            read_buffer_size:
+                                type: int
+                            strategy_file:
+                                type: string
+                            strategy_file_reload_interval:
+                                type: duration
+                            tls:
+                                fields:
+                                    ca_file:
+                                        type: string
+                                    ca_pem:
+                                        type: string
+                                    cert_file:
+                                        type: string
+                                    cert_pem:
+                                        type: string
+                                    cipher_suites:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    curve_preferences:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    include_insecure_cipher_suites:
+                                        type: bool
+                                    include_system_ca_certs_pool:
+                                        type: bool
+                                    insecure:
+                                        type: bool
+                                    insecure_skip_verify:
+                                        type: bool
+                                    key_file:
+                                        type: string
+                                    key_pem:
+                                        type: string
+                                    max_version:
+                                        type: string
+                                    min_version:
+                                        type: string
+                                    reload_interval:
+                                        type: duration
+                                    server_name_override:
+                                        type: string
+                                    tpm:
+                                        fields:
+                                            auth:
+                                                type: string
+                                            enabled:
+                                                type: bool
+                                            owner_auth:
+                                                type: string
+                                            path:
+                                                type: string
+                                        type: object
+                                type: object
+                            user_agent:
+                                type: string
+                            wait_for_ready:
+                                type: bool
+                            write_buffer_size:
+                                type: int
+                        type: object
+                type: object
+            journald:
+                fields:
+                    all:
+                        type: bool
+                    attributes:
+                        elem:
+                            type: string
+                        type: map
+                    convert_message_bytes:
+                        type: bool
+                    directory:
+                        type: string
+                    dmesg:
+                        type: bool
+                    files:
+                        elem:
+                            type: string
+                        type: array
+                    grep:
+                        type: string
+                    id:
+                        type: string
+                    identifiers:
+                        elem:
+                            type: string
+                        type: array
+                    journalctl_path:
+                        type: string
+                    matches:
+                        elem:
+                            elem:
+                                type: string
+                            type: map
+                        type: array
+                    merge:
+                        type: bool
+                    namespace:
+                        type: string
+                    operators:
+                        elem:
+                            type: object
+                        type: array
+                    output:
+                        elem:
+                            type: string
+                        type: array
+                    priority:
+                        type: string
+                    resource:
+                        elem:
+                            type: string
+                        type: map
+                    retry_on_failure:
+                        fields:
+                            enabled:
+                                type: bool
+                            initial_interval:
+                                type: duration
+                            max_elapsed_time:
+                                type: duration
+                            max_interval:
+                                type: duration
+                        type: object
+                    root_path:
+                        type: string
+                    start_at:
+                        type: string
+                    storage:
+                        type: object
+                    type:
+                        type: string
+                    units:
+                        elem:
+                            type: string
+                        type: array
+                type: object
+            k8s_cluster:
+                fields:
+                    allocatable_types_to_report:
+                        elem:
+                            type: string
+                        type: array
+                    auth_type:
+                        type: string
+                    collection_interval:
+                        type: duration
+                    context:
+                        type: string
+                    distribution:
+                        type: string
+                    k8s_leader_elector:
+                        type: object
+                    kube_api_burst:
+                        type: int
+                    kube_api_qps:
+                        type: float
+                    metadata_collection_interval:
+                        type: duration
+                    metadata_exporters:
+                        elem:
+                            type: string
+                        type: array
+                    metrics:
+                        fields:
+                            k8s.container.cpu_limit:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.container.cpu_request:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.container.ephemeralstorage_limit:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.container.ephemeralstorage_request:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.container.memory_limit:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.container.memory_request:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.container.ready:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.container.restarts:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.container.status.reason:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.container.status.state:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.container.storage_limit:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.container.storage_request:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.cronjob.active_jobs:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.daemonset.current_scheduled_nodes:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.daemonset.desired_scheduled_nodes:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.daemonset.misscheduled_nodes:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.daemonset.ready_nodes:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.deployment.available:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.deployment.desired:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.hpa.current_replicas:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.hpa.desired_replicas:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.hpa.max_replicas:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.hpa.min_replicas:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.job.active_pods:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.job.desired_successful_pods:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.job.failed_pods:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.job.max_parallel_pods:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.job.successful_pods:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.namespace.phase:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.node.condition:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.persistentvolume.status.phase:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.persistentvolume.storage.capacity:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.persistentvolumeclaim.status.phase:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.persistentvolumeclaim.storage.capacity:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.persistentvolumeclaim.storage.request:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.pod.phase:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.pod.status_reason:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.replicaset.available:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.replicaset.desired:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.replication_controller.available:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.replication_controller.desired:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.resource_quota.hard_limit:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.resource_quota.used:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.service.endpoint.count:
+                                fields:
+                                    aggregation_strategy:
+                                        type: string
+                                    attributes:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.service.load_balancer.ingress.count:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.statefulset.current_pods:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.statefulset.desired_pods:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.statefulset.ready_pods:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.statefulset.updated_pods:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            openshift.appliedclusterquota.limit:
+                                fields:
+                                    aggregation_strategy:
+                                        type: string
+                                    attributes:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    enabled:
+                                        type: bool
+                                type: object
+                            openshift.appliedclusterquota.used:
+                                fields:
+                                    aggregation_strategy:
+                                        type: string
+                                    attributes:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    enabled:
+                                        type: bool
+                                type: object
+                            openshift.clusterquota.limit:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            openshift.clusterquota.used:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                        type: object
+                    namespace:
+                        type: string
+                    namespaces:
+                        elem:
+                            type: string
+                        type: array
+                    node_conditions_to_report:
+                        elem:
+                            type: string
+                        type: array
+                    resource_attributes:
+                        fields:
+                            container.id:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            container.image.name:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            container.image.tag:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            container.runtime:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            container.runtime.version:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.container.name:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.container.status.last_terminated_reason:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.cronjob.name:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.cronjob.uid:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.daemonset.name:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.daemonset.uid:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.deployment.name:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.deployment.uid:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.hpa.name:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.hpa.scaletargetref.apiversion:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.hpa.scaletargetref.kind:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.hpa.scaletargetref.name:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.hpa.uid:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.job.name:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.job.uid:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.kubelet.version:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.namespace.name:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.namespace.uid:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.node.name:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.node.uid:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.persistentvolume.name:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.persistentvolume.reclaim_policy:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.persistentvolume.uid:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.persistentvolumeclaim.name:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.persistentvolumeclaim.uid:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.pod.name:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.pod.qos_class:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.pod.uid:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.replicaset.name:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.replicaset.uid:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.replicationcontroller.name:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.replicationcontroller.uid:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.resourcequota.name:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.resourcequota.uid:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.service.name:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.service.publish_not_ready_addresses:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.service.traffic_distribution:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.service.type:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.service.uid:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.statefulset.name:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.statefulset.uid:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.storageclass.name:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            openshift.clusterquota.name:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            openshift.clusterquota.uid:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            os.description:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            os.type:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                        type: object
+                type: object
+            k8s_events:
+                fields:
+                    auth_type:
+                        type: string
+                    context:
+                        type: string
+                    dedup_interval:
+                        type: duration
+                    k8s_leader_elector:
+                        type: object
+                    kube_api_burst:
+                        type: int
+                    kube_api_qps:
+                        type: float
+                    namespaces:
+                        elem:
+                            type: string
+                        type: array
+                    storage:
+                        type: object
+                type: object
+            k8s_objects:
+                fields:
+                    auth_type:
+                        type: string
+                    context:
+                        type: string
+                    error_mode:
+                        type: string
+                    include_initial_state:
+                        type: bool
+                    interval:
+                        type: duration
+                    k8s_leader_elector:
+                        type: object
+                    kube_api_burst:
+                        type: int
+                    kube_api_qps:
+                        type: float
+                    objects:
+                        elem:
+                            fields:
+                                exclude_namespaces:
+                                    elem:
+                                        fields:
+                                            regexp:
+                                                type: string
+                                            strict:
+                                                type: string
+                                        type: object
+                                    type: array
+                                exclude_watch_type:
+                                    elem:
+                                        type: string
+                                    type: array
+                                field_selector:
+                                    type: string
+                                group:
+                                    type: string
+                                initial_delay:
+                                    type: duration
+                                interval:
+                                    type: duration
+                                label_selector:
+                                    type: string
+                                mode:
+                                    type: string
+                                name:
+                                    type: string
+                                namespaces:
+                                    elem:
+                                        type: string
+                                    type: array
+                                resource_version:
+                                    type: string
+                            type: object
+                        type: array
+                    storage:
+                        type: object
+                type: object
+            kubelet_stats:
+                fields:
+                    auth_type:
+                        type: string
+                    ca_file:
+                        type: string
+                    ca_pem:
+                        type: string
+                    cert_file:
+                        type: string
+                    cert_pem:
+                        type: string
+                    cipher_suites:
+                        elem:
+                            type: string
+                        type: array
+                    collect_all_network_interfaces:
+                        fields:
+                            node:
+                                type: bool
+                            pod:
+                                type: bool
+                        type: object
+                    collection_interval:
+                        type: duration
+                    context:
+                        type: string
+                    curve_preferences:
+                        elem:
+                            type: string
+                        type: array
+                    dialer:
+                        fields:
+                            timeout:
+                                type: duration
+                        type: object
+                    endpoint:
+                        type: string
+                    extra_metadata_labels:
+                        elem:
+                            type: string
+                        type: array
+                    include_insecure_cipher_suites:
+                        type: bool
+                    include_system_ca_certs_pool:
+                        type: bool
+                    initial_delay:
+                        type: duration
+                    insecure_skip_verify:
+                        type: bool
+                    k8s_api_config:
+                        fields:
+                            auth_type:
+                                type: string
+                            context:
+                                type: string
+                            kube_api_burst:
+                                type: int
+                            kube_api_qps:
+                                type: float
+                        type: object
+                    key_file:
+                        type: string
+                    key_pem:
+                        type: string
+                    kube_api_burst:
+                        type: int
+                    kube_api_qps:
+                        type: float
+                    max_version:
+                        type: string
+                    metric_groups:
+                        elem:
+                            type: string
+                        type: array
+                    metrics:
+                        fields:
+                            container.cpu.time:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            container.cpu.usage:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            container.filesystem.available:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            container.filesystem.capacity:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            container.filesystem.usage:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            container.memory.available:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            container.memory.major_page_faults:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            container.memory.page_faults:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            container.memory.rss:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            container.memory.usage:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            container.memory.working_set:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            container.uptime:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.container.cpu.node.utilization:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.container.cpu_limit_utilization:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.container.cpu_request_utilization:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.container.ephemeral_storage.usage:
+                                fields:
+                                    aggregation_strategy:
+                                        type: string
+                                    attributes:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.container.memory.node.utilization:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.container.memory_limit_utilization:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.container.memory_request_utilization:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.node.cpu.time:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.node.cpu.usage:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.node.filesystem.available:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.node.filesystem.capacity:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.node.filesystem.usage:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.node.memory.available:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.node.memory.major_page_faults:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.node.memory.page_faults:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.node.memory.rss:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.node.memory.usage:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.node.memory.working_set:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.node.network.errors:
+                                fields:
+                                    aggregation_strategy:
+                                        type: string
+                                    attributes:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.node.network.io:
+                                fields:
+                                    aggregation_strategy:
+                                        type: string
+                                    attributes:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.node.system_container.cpu.time:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.node.system_container.cpu.usage:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.node.system_container.memory.usage:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.node.system_container.memory.working_set:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.node.uptime:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.pod.cpu.node.utilization:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.pod.cpu.time:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.pod.cpu.usage:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.pod.cpu_limit_utilization:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.pod.cpu_request_utilization:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.pod.filesystem.available:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.pod.filesystem.capacity:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.pod.filesystem.usage:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.pod.memory.available:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.pod.memory.major_page_faults:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.pod.memory.node.utilization:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.pod.memory.page_faults:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.pod.memory.rss:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.pod.memory.usage:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.pod.memory.working_set:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.pod.memory_limit_utilization:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.pod.memory_request_utilization:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.pod.network.errors:
+                                fields:
+                                    aggregation_strategy:
+                                        type: string
+                                    attributes:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.pod.network.io:
+                                fields:
+                                    aggregation_strategy:
+                                        type: string
+                                    attributes:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.pod.uptime:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.pod.volume.usage:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.volume.available:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.volume.capacity:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.volume.inodes:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.volume.inodes.free:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                            k8s.volume.inodes.used:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                type: object
+                        type: object
+                    min_version:
+                        type: string
+                    node:
+                        type: string
+                    reload_interval:
+                        type: duration
+                    resource_attributes:
+                        fields:
+                            aws.volume.id:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            container.id:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            fs.type:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            gce.pd.name:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            glusterfs.endpoints.name:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            glusterfs.path:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.container.name:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.namespace.name:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.node.name:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.node.system_container.name:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.persistentvolumeclaim.name:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.pod.name:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.pod.uid:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.volume.name:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            k8s.volume.type:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                            partition:
+                                fields:
+                                    enabled:
+                                        type: bool
+                                    metrics_exclude:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    metrics_include:
+                                        elem:
+                                            fields:
+                                                regexp:
+                                                    type: string
+                                                strict:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                type: object
+                        type: object
+                    timeout:
+                        type: duration
+                    tpm:
+                        fields:
+                            auth:
+                                type: string
+                            enabled:
+                                type: bool
+                            owner_auth:
+                                type: string
+                            path:
+                                type: string
+                        type: object
+                type: object
+            otelarrow:
+                fields:
+                    admission:
+                        fields:
+                            request_limit_mib:
+                                type: int
+                            waiting_limit_mib:
+                                type: int
+                        type: object
+                    protocols:
+                        fields:
+                            arrow:
+                                fields:
+                                    admission_limit_mib:
+                                        type: int
+                                    memory_limit_mib:
+                                        type: int
+                                    waiter_limit:
+                                        type: int
+                                    zstd:
+                                        fields:
+                                            concurrency:
+                                                type: int
+                                            max_window_size_mib:
+                                                type: int
+                                            memory_limit_mib:
+                                                type: int
+                                        type: object
+                                type: object
+                            grpc:
+                                fields:
+                                    auth:
+                                        fields:
+                                            authenticator:
+                                                type: object
+                                        type: object
+                                    dialer:
+                                        fields:
+                                            timeout:
+                                                type: duration
+                                        type: object
+                                    endpoint:
+                                        type: string
+                                    include_metadata:
+                                        type: bool
+                                    keepalive:
+                                        fields:
+                                            enforcement_policy:
+                                                fields:
+                                                    min_time:
+                                                        type: duration
+                                                    permit_without_stream:
+                                                        type: bool
+                                                type: object
+                                            server_parameters:
+                                                fields:
+                                                    max_connection_age:
+                                                        type: duration
+                                                    max_connection_age_grace:
+                                                        type: duration
+                                                    max_connection_idle:
+                                                        type: duration
+                                                    time:
+                                                        type: duration
+                                                    timeout:
+                                                        type: duration
+                                                type: object
+                                        type: object
+                                    max_concurrent_streams:
+                                        type: int
+                                    max_recv_msg_size_mib:
+                                        type: int
+                                    middlewares:
+                                        elem:
+                                            fields:
+                                                id:
+                                                    type: object
+                                            type: object
+                                        type: array
+                                    read_buffer_size:
+                                        type: int
+                                    tls:
+                                        fields:
+                                            ca_file:
+                                                type: string
+                                            ca_pem:
+                                                type: string
+                                            cert_file:
+                                                type: string
+                                            cert_pem:
+                                                type: string
+                                            cipher_suites:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            client_ca_file:
+                                                type: string
+                                            client_ca_file_reload:
+                                                type: bool
+                                            curve_preferences:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            include_insecure_cipher_suites:
+                                                type: bool
+                                            include_system_ca_certs_pool:
+                                                type: bool
+                                            key_file:
+                                                type: string
+                                            key_pem:
+                                                type: string
+                                            max_version:
+                                                type: string
+                                            min_version:
+                                                type: string
+                                            reload_interval:
+                                                type: duration
+                                            tpm:
+                                                fields:
+                                                    auth:
+                                                        type: string
+                                                    enabled:
+                                                        type: bool
+                                                    owner_auth:
+                                                        type: string
+                                                    path:
+                                                        type: string
+                                                type: object
+                                        type: object
+                                    transport:
+                                        type: string
+                                    write_buffer_size:
+                                        type: int
+                                type: object
+                        type: object
+                type: object
+            otlp:
+                fields:
+                    protocols:
+                        fields:
+                            grpc:
+                                fields:
+                                    auth:
+                                        fields:
+                                            authenticator:
+                                                type: object
+                                        type: object
+                                    dialer:
+                                        fields:
+                                            timeout:
+                                                type: duration
+                                        type: object
+                                    endpoint:
+                                        type: string
+                                    include_metadata:
+                                        type: bool
+                                    keepalive:
+                                        fields:
+                                            enforcement_policy:
+                                                fields:
+                                                    min_time:
+                                                        type: duration
+                                                    permit_without_stream:
+                                                        type: bool
+                                                type: object
+                                            server_parameters:
+                                                fields:
+                                                    max_connection_age:
+                                                        type: duration
+                                                    max_connection_age_grace:
+                                                        type: duration
+                                                    max_connection_idle:
+                                                        type: duration
+                                                    time:
+                                                        type: duration
+                                                    timeout:
+                                                        type: duration
+                                                type: object
+                                        type: object
+                                    max_concurrent_streams:
+                                        type: int
+                                    max_recv_msg_size_mib:
+                                        type: int
+                                    middlewares:
+                                        elem:
+                                            fields:
+                                                id:
+                                                    type: object
+                                            type: object
+                                        type: array
+                                    read_buffer_size:
+                                        type: int
+                                    tls:
+                                        fields:
+                                            ca_file:
+                                                type: string
+                                            ca_pem:
+                                                type: string
+                                            cert_file:
+                                                type: string
+                                            cert_pem:
+                                                type: string
+                                            cipher_suites:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            client_ca_file:
+                                                type: string
+                                            client_ca_file_reload:
+                                                type: bool
+                                            curve_preferences:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            include_insecure_cipher_suites:
+                                                type: bool
+                                            include_system_ca_certs_pool:
+                                                type: bool
+                                            key_file:
+                                                type: string
+                                            key_pem:
+                                                type: string
+                                            max_version:
+                                                type: string
+                                            min_version:
+                                                type: string
+                                            reload_interval:
+                                                type: duration
+                                            tpm:
+                                                fields:
+                                                    auth:
+                                                        type: string
+                                                    enabled:
+                                                        type: bool
+                                                    owner_auth:
+                                                        type: string
+                                                    path:
+                                                        type: string
+                                                type: object
+                                        type: object
+                                    transport:
+                                        type: string
+                                    write_buffer_size:
+                                        type: int
+                                type: object
+                            http:
+                                fields:
+                                    auth:
+                                        fields:
+                                            authenticator:
+                                                type: object
+                                            request_params:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                        type: object
+                                    compression_algorithms:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    cors:
+                                        fields:
+                                            allowed_headers:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            allowed_origins:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            exposed_headers:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            max_age:
+                                                type: int
+                                        type: object
+                                    dialer:
+                                        fields:
+                                            timeout:
+                                                type: duration
+                                        type: object
+                                    endpoint:
+                                        type: string
+                                    idle_timeout:
+                                        type: duration
+                                    include_metadata:
+                                        type: bool
+                                    keep_alives_enabled:
+                                        type: bool
+                                    logs_url_path:
+                                        type: string
+                                    max_request_body_size:
+                                        type: int
+                                    metrics_url_path:
+                                        type: string
+                                    middlewares:
+                                        elem:
+                                            fields:
+                                                id:
+                                                    type: object
+                                            type: object
+                                        type: array
+                                    read_header_timeout:
+                                        type: duration
+                                    read_timeout:
+                                        type: duration
+                                    response_headers:
+                                        elem:
+                                            fields:
+                                                name:
+                                                    type: string
+                                                value:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    tls:
+                                        fields:
+                                            ca_file:
+                                                type: string
+                                            ca_pem:
+                                                type: string
+                                            cert_file:
+                                                type: string
+                                            cert_pem:
+                                                type: string
+                                            cipher_suites:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            client_ca_file:
+                                                type: string
+                                            client_ca_file_reload:
+                                                type: bool
+                                            curve_preferences:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            include_insecure_cipher_suites:
+                                                type: bool
+                                            include_system_ca_certs_pool:
+                                                type: bool
+                                            key_file:
+                                                type: string
+                                            key_pem:
+                                                type: string
+                                            max_version:
+                                                type: string
+                                            min_version:
+                                                type: string
+                                            reload_interval:
+                                                type: duration
+                                            tpm:
+                                                fields:
+                                                    auth:
+                                                        type: string
+                                                    enabled:
+                                                        type: bool
+                                                    owner_auth:
+                                                        type: string
+                                                    path:
+                                                        type: string
+                                                type: object
+                                        type: object
+                                    traces_url_path:
+                                        type: string
+                                    transport:
+                                        type: string
+                                    write_timeout:
+                                        type: duration
+                                type: object
+                        type: object
+                type: object
+            prometheus:
+                fields:
+                    api_server:
+                        fields:
+                            enabled:
+                                type: bool
+                            max_connections:
+                                type: int
+                            server_config:
+                                fields:
+                                    auth:
+                                        fields:
+                                            authenticator:
+                                                type: object
+                                            request_params:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                        type: object
+                                    compression_algorithms:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    cors:
+                                        fields:
+                                            allowed_headers:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            allowed_origins:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            exposed_headers:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            max_age:
+                                                type: int
+                                        type: object
+                                    dialer:
+                                        fields:
+                                            timeout:
+                                                type: duration
+                                        type: object
+                                    endpoint:
+                                        type: string
+                                    idle_timeout:
+                                        type: duration
+                                    include_metadata:
+                                        type: bool
+                                    keep_alives_enabled:
+                                        type: bool
+                                    max_request_body_size:
+                                        type: int
+                                    middlewares:
+                                        elem:
+                                            fields:
+                                                id:
+                                                    type: object
+                                            type: object
+                                        type: array
+                                    read_header_timeout:
+                                        type: duration
+                                    read_timeout:
+                                        type: duration
+                                    response_headers:
+                                        elem:
+                                            fields:
+                                                name:
+                                                    type: string
+                                                value:
+                                                    type: string
+                                            type: object
+                                        type: array
+                                    tls:
+                                        fields:
+                                            ca_file:
+                                                type: string
+                                            ca_pem:
+                                                type: string
+                                            cert_file:
+                                                type: string
+                                            cert_pem:
+                                                type: string
+                                            cipher_suites:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            client_ca_file:
+                                                type: string
+                                            client_ca_file_reload:
+                                                type: bool
+                                            curve_preferences:
+                                                elem:
+                                                    type: string
+                                                type: array
+                                            include_insecure_cipher_suites:
+                                                type: bool
+                                            include_system_ca_certs_pool:
+                                                type: bool
+                                            key_file:
+                                                type: string
+                                            key_pem:
+                                                type: string
+                                            max_version:
+                                                type: string
+                                            min_version:
+                                                type: string
+                                            reload_interval:
+                                                type: duration
+                                            tpm:
+                                                fields:
+                                                    auth:
+                                                        type: string
+                                                    enabled:
+                                                        type: bool
+                                                    owner_auth:
+                                                        type: string
+                                                    path:
+                                                        type: string
+                                                type: object
+                                        type: object
+                                    transport:
+                                        type: string
+                                    write_timeout:
+                                        type: duration
+                                type: object
+                        type: object
+                    config:
+                        type: object
+                    discovery_reload_on_startup:
+                        type: bool
+                    initial_scrape_offset:
+                        type: duration
+                    scrape_on_shutdown:
+                        type: bool
+                    target_allocator:
+                        fields:
+                            auth:
+                                fields:
+                                    authenticator:
+                                        type: object
+                                type: object
+                            collector_id:
+                                type: string
+                            compression:
+                                type: string
+                            compression_params:
+                                fields:
+                                    level:
+                                        type: int
+                                type: object
+                            cookies:
+                                type: object
+                            disable_keep_alives:
+                                type: bool
+                            endpoint:
+                                type: string
+                            force_attempt_http2:
+                                type: bool
+                            headers:
+                                elem:
+                                    fields:
+                                        name:
+                                            type: string
+                                        value:
+                                            type: string
+                                    type: object
+                                type: array
+                            http_scrape_config:
+                                type: object
+                            http_sd_config:
+                                type: object
+                            http2_ping_timeout:
+                                type: duration
+                            http2_read_idle_timeout:
+                                type: duration
+                            idle_conn_timeout:
+                                type: duration
+                            interval:
+                                type: duration
+                            max_conns_per_host:
+                                type: int
+                            max_idle_conns:
+                                type: int
+                            max_idle_conns_per_host:
+                                type: int
+                            middlewares:
+                                elem:
+                                    fields:
+                                        id:
+                                            type: object
+                                    type: object
+                                type: array
+                            proxy_url:
+                                type: string
+                            read_buffer_size:
+                                type: int
+                            timeout:
+                                type: duration
+                            tls:
+                                fields:
+                                    ca_file:
+                                        type: string
+                                    ca_pem:
+                                        type: string
+                                    cert_file:
+                                        type: string
+                                    cert_pem:
+                                        type: string
+                                    cipher_suites:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    curve_preferences:
+                                        elem:
+                                            type: string
+                                        type: array
+                                    include_insecure_cipher_suites:
+                                        type: bool
+                                    include_system_ca_certs_pool:
+                                        type: bool
+                                    insecure:
+                                        type: bool
+                                    insecure_skip_verify:
+                                        type: bool
+                                    key_file:
+                                        type: string
+                                    key_pem:
+                                        type: string
+                                    max_version:
+                                        type: string
+                                    min_version:
+                                        type: string
+                                    reload_interval:
+                                        type: duration
+                                    server_name_override:
+                                        type: string
+                                    tpm:
+                                        fields:
+                                            auth:
+                                                type: string
+                                            enabled:
+                                                type: bool
+                                            owner_auth:
+                                                type: string
+                                            path:
+                                                type: string
+                                        type: object
+                                type: object
+                            write_buffer_size:
+                                type: int
+                        type: object
+                    trim_metric_suffixes:
+                        type: bool
+                type: object
+            receiver_creator:
+                fields:
+                    discovery:
+                        fields:
+                            default_annotations:
+                                elem:
+                                    type: string
+                                type: map
+                            default_file_log_config:
+                                elem:
+                                    type: any
+                                type: map
+                            enabled:
+                                type: bool
+                            ignore_receivers:
+                                elem:
+                                    type: string
+                                type: array
+                        type: object
+                    resource_attributes:
+                        elem:
+                            elem:
+                                type: string
+                            type: map
+                        type: map
+                    watch_observers:
+                        elem:
+                            type: object
+                        type: array
+                type: object
+            zipkin:
+                fields:
+                    auth:
+                        fields:
+                            authenticator:
+                                type: object
+                            request_params:
+                                elem:
+                                    type: string
+                                type: array
+                        type: object
+                    compression_algorithms:
+                        elem:
+                            type: string
+                        type: array
+                    cors:
+                        fields:
+                            allowed_headers:
+                                elem:
+                                    type: string
+                                type: array
+                            allowed_origins:
+                                elem:
+                                    type: string
+                                type: array
+                            exposed_headers:
+                                elem:
+                                    type: string
+                                type: array
+                            max_age:
+                                type: int
+                        type: object
+                    dialer:
+                        fields:
+                            timeout:
+                                type: duration
+                        type: object
+                    endpoint:
+                        type: string
+                    idle_timeout:
+                        type: duration
+                    include_metadata:
+                        type: bool
+                    keep_alives_enabled:
+                        type: bool
+                    max_request_body_size:
+                        type: int
+                    middlewares:
+                        elem:
+                            fields:
+                                id:
+                                    type: object
+                            type: object
+                        type: array
+                    parse_string_tags:
+                        type: bool
+                    read_header_timeout:
+                        type: duration
+                    read_timeout:
+                        type: duration
+                    response_headers:
+                        elem:
+                            fields:
+                                name:
+                                    type: string
+                                value:
+                                    type: string
+                            type: object
+                        type: array
+                    tls:
+                        fields:
+                            ca_file:
+                                type: string
+                            ca_pem:
+                                type: string
+                            cert_file:
+                                type: string
+                            cert_pem:
+                                type: string
+                            cipher_suites:
+                                elem:
+                                    type: string
+                                type: array
+                            client_ca_file:
+                                type: string
+                            client_ca_file_reload:
+                                type: bool
+                            curve_preferences:
+                                elem:
+                                    type: string
+                                type: array
+                            include_insecure_cipher_suites:
+                                type: bool
+                            include_system_ca_certs_pool:
+                                type: bool
+                            key_file:
+                                type: string
+                            key_pem:
+                                type: string
+                            max_version:
+                                type: string
+                            min_version:
+                                type: string
+                            reload_interval:
+                                type: duration
+                            tpm:
+                                fields:
+                                    auth:
+                                        type: string
+                                    enabled:
+                                        type: bool
+                                    owner_auth:
+                                        type: string
+                                    path:
+                                        type: string
+                                type: object
+                        type: object
+                    transport:
+                        type: string
+                    write_timeout:
+                        type: duration
+                type: object
     components:
         connectors:
             - count
@@ -46,7 +9398,7 @@ spec:
         processors:
             - attributes
             - batch
-            - cumulative_to_delta
+            - cumulativetodelta
             - deltatocumulative
             - deltatorate
             - drain


### PR DESCRIPTION
Backfill `spec.componentConfigs` (per-component config field schemas) for **v0.156.0**: `otelcol` and `otelcol-k8s` (no `otelcol-contrib` build exists at this version).

Part of the per-version config-schema backfill (newest→oldest), stacked on #577. Generated with `hack/gen-component-configs.sh` + `CONFIGS_DIR` merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)